### PR TITLE
fix: ADL math calls for Universal type compatibility

### DIFF
--- a/include/sw/dsp/concepts/scalar.hpp
+++ b/include/sw/dsp/concepts/scalar.hpp
@@ -54,12 +54,18 @@ struct is_complex<std::complex<T>> : std::true_type {};
 template <typename T>
 constexpr bool is_complex_v = is_complex<T>::value;
 
+namespace detail {
+	// ADL-friendly conj for concept checking
+	using std::conj;
+	template <typename T>
+	concept has_conj = requires(T z) { { conj(z) } -> std::convertible_to<T>; };
+}
+
 template <typename T>
 concept ComplexType = requires(T z) {
 	{ z.real() };
 	{ z.imag() };
-	{ std::conj(z) } -> std::convertible_to<T>;
-};
+} && detail::has_conj<T>;
 
 // Trait to extract the real scalar type from a potentially complex type
 template <typename T>

--- a/include/sw/dsp/filter/biquad/biquad.hpp
+++ b/include/sw/dsp/filter/biquad/biquad.hpp
@@ -22,6 +22,8 @@ struct BiquadPoleState : PoleZeroPair<T> {
 	// Construct from biquad coefficients by extracting poles and zeros
 	explicit BiquadPoleState(const BiquadCoefficients<T>& c) {
 		using complex_t = complex_for_t<T>;
+		using std::sqrt;
+		using std::conj;
 
 		// Extract zeros from numerator: b0 + b1*z^-1 + b2*z^-2
 		// Roots of b0*z^2 + b1*z + b2 = 0
@@ -34,14 +36,14 @@ struct BiquadPoleState : PoleZeroPair<T> {
 		} else {
 			T disc_z = c.b1 * c.b1 - T{4} * c.b0 * c.b2;
 			if (disc_z >= T{}) {
-				T sq = std::sqrt(disc_z);
+				T sq = sqrt(disc_z);
 				this->zeros.first = complex_t((T{-1} * c.b1 + sq) / (T{2} * c.b0));
 				this->zeros.second = complex_t((T{-1} * c.b1 - sq) / (T{2} * c.b0));
 			} else {
-				T sq = std::sqrt(T{-1} * disc_z);
+				T sq = sqrt(T{-1} * disc_z);
 				this->zeros.first = complex_t(T{-1} * c.b1 / (T{2} * c.b0),
 				                              sq / (T{2} * c.b0));
-				this->zeros.second = std::conj(this->zeros.first);
+				this->zeros.second = conj(this->zeros.first);
 			}
 		}
 
@@ -53,13 +55,13 @@ struct BiquadPoleState : PoleZeroPair<T> {
 		} else {
 			T disc_p = c.a1 * c.a1 - T{4} * c.a2;
 			if (disc_p >= T{}) {
-				T sq = std::sqrt(disc_p);
+				T sq = sqrt(disc_p);
 				this->poles.first = complex_t((T{-1} * c.a1 + sq) / T{2});
 				this->poles.second = complex_t((T{-1} * c.a1 - sq) / T{2});
 			} else {
-				T sq = std::sqrt(T{-1} * disc_p);
+				T sq = sqrt(T{-1} * disc_p);
 				this->poles.first = complex_t(T{-1} * c.a1 / T{2}, sq / T{2});
-				this->poles.second = std::conj(this->poles.first);
+				this->poles.second = conj(this->poles.first);
 			}
 		}
 

--- a/include/sw/dsp/filter/biquad/cascade.hpp
+++ b/include/sw/dsp/filter/biquad/cascade.hpp
@@ -113,7 +113,8 @@ private:
 		double f = w / (2.0 * pi);  // convert angular freq to normalized freq
 
 		auto current_response = response(f);
-		double mag = std::abs(current_response);
+		using std::abs;  // ADL for Universal complex types
+		double mag = static_cast<double>(abs(current_response));
 
 		if (mag < 1e-30) {
 			return CoeffScalar{1};  // avoid division by zero

--- a/include/sw/dsp/filter/iir/butterworth.hpp
+++ b/include/sw/dsp/filter/iir/butterworth.hpp
@@ -62,8 +62,9 @@ public:
 		layout.reset();
 		layout.set_normal(pi_v<T>, T{1});
 
+		using std::pow;
 		const T n2 = static_cast<T>(num_poles) * T{2};
-		const T g = std::pow(std::pow(T{10}, gain_db / T{20}), T{1} / n2);
+		const T g = pow(pow(T{10}, gain_db / T{20}), T{1} / n2);
 		const T gp = T{-1} / g;
 		const T gz = T{-1} * g;
 

--- a/include/sw/dsp/filter/iir/chebyshev1.hpp
+++ b/include/sw/dsp/filter/iir/chebyshev1.hpp
@@ -28,7 +28,9 @@ public:
 	void design(int num_poles, T ripple_db, PoleZeroLayout<T, MaxOrder>& layout) {
 		layout.reset();
 
-		const T eps = std::sqrt(T{1} / std::exp(T{-1} * ripple_db * T{0.1} * ln10_v<T>) - T{1});
+		using std::sqrt;
+		using std::exp;
+		const T eps = sqrt(T{1} / exp(T{-1} * ripple_db * T{0.1} * ln10_v<T>) - T{1});
 		const T v0 = static_cast<T>(std::asinh(static_cast<double>(T{1} / eps))) / static_cast<T>(num_poles);
 		const T sinh_v0 = T{-1} * static_cast<T>(std::sinh(static_cast<double>(v0)));
 		const T cosh_v0 = static_cast<T>(std::cosh(static_cast<double>(v0)));

--- a/include/sw/dsp/filter/iir/chebyshev2.hpp
+++ b/include/sw/dsp/filter/iir/chebyshev2.hpp
@@ -30,7 +30,9 @@ public:
 		layout.reset();
 		layout.set_normal(T{}, T{1});
 
-		const T eps = std::sqrt(T{1} / (std::exp(stopband_db * T{0.1} * ln10_v<T>) - T{1}));
+		using std::sqrt;
+		using std::exp;
+		const T eps = sqrt(T{1} / (exp(stopband_db * T{0.1} * ln10_v<T>) - T{1}));
 		const T v0 = static_cast<T>(std::asinh(static_cast<double>(T{1} / eps))) / static_cast<T>(num_poles);
 		const T sinh_v0 = T{-1} * static_cast<T>(std::sinh(static_cast<double>(v0)));
 		const T cosh_v0 = static_cast<T>(std::cosh(static_cast<double>(v0)));

--- a/include/sw/dsp/filter/transform/bilinear.hpp
+++ b/include/sw/dsp/filter/transform/bilinear.hpp
@@ -32,10 +32,11 @@ public:
 	LowPassTransform(T fc,
 	                  PoleZeroLayout<T, MaxDigital>& digital,
 	                  const PoleZeroLayout<T, MaxAnalog>& analog) {
+		using std::tan;
 		digital.reset();
 
 		// Prewarp
-		f_ = std::tan(pi_v<T> * fc);
+		f_ = tan(pi_v<T> * fc);
 
 		const int num_poles = analog.num_poles();
 		const int pairs = num_poles / 2;
@@ -80,10 +81,11 @@ public:
 	HighPassTransform(T fc,
 	                  PoleZeroLayout<T, MaxDigital>& digital,
 	                  const PoleZeroLayout<T, MaxAnalog>& analog) {
+		using std::tan;
 		digital.reset();
 
 		// Prewarp (reciprocal for highpass)
-		f_ = T{1} / std::tan(pi_v<T> * fc);
+		f_ = T{1} / tan(pi_v<T> * fc);
 
 		const int num_poles = analog.num_poles();
 		const int pairs = num_poles / 2;

--- a/include/sw/dsp/filter/transform/constantinides.hpp
+++ b/include/sw/dsp/filter/transform/constantinides.hpp
@@ -50,12 +50,16 @@ public:
 		wc_ = wc2_ + ww;
 
 		// Clamp to valid range
+		using std::cos;
+		using std::tan;
+		using std::atan;
+		using std::sqrt;
 		const T eps = T{1e-8};
 		if (wc2_ < eps) wc2_ = eps;
 		if (wc_ > pi_v<T> - eps) wc_ = pi_v<T> - eps;
 
-		a_ = std::cos((wc_ + wc2_) * T{0.5}) / std::cos((wc_ - wc2_) * T{0.5});
-		b_ = T{1} / std::tan((wc_ - wc2_) * T{0.5});
+		a_ = cos((wc_ + wc2_) * T{0.5}) / cos((wc_ - wc2_) * T{0.5});
+		b_ = T{1} / tan((wc_ - wc2_) * T{0.5});
 		a2_ = a_ * a_;
 		b2_ = b_ * b_;
 		ab_ = a_ * b_;
@@ -81,8 +85,8 @@ public:
 
 		T wn = analog.normal_w();
 		digital.set_normal(
-			T{2} * std::atan(std::sqrt(
-				std::tan((wc_ + wn) * T{0.5}) * std::tan((wc2_ + wn) * T{0.5}))),
+			T{2} * atan(sqrt(
+				tan((wc_ + wn) * T{0.5}) * tan((wc2_ + wn) * T{0.5}))),
 			analog.normal_gain());
 	}
 
@@ -100,7 +104,8 @@ private:
 		v = v + complex_t(T{8} * (b2_ * (a2_ - T{1}) - T{1}));
 		v = v * c;
 		v = v + complex_t(T{4} * (b2_ * (a2_ - T{1}) + T{1}));
-		v = std::sqrt(v);
+		using std::sqrt;
+		v = sqrt(v);
 
 		complex_t u = T{-1} * v;
 		u = detail::addmul(u, ab_2_, c);
@@ -135,12 +140,15 @@ public:
 		wc2_ = two_pi_v<T> * fc - ww / T{2};
 		wc_ = wc2_ + ww;
 
+		using std::cos;
+		using std::tan;
+		using std::conj;
 		const T eps = T{1e-8};
 		if (wc2_ < eps) wc2_ = eps;
 		if (wc_ > pi_v<T> - eps) wc_ = pi_v<T> - eps;
 
-		a_ = std::cos((wc_ + wc2_) * T{0.5}) / std::cos((wc_ - wc2_) * T{0.5});
-		b_ = std::tan((wc_ - wc2_) * T{0.5});
+		a_ = cos((wc_ + wc2_) * T{0.5}) / cos((wc_ - wc2_) * T{0.5});
+		b_ = tan((wc_ - wc2_) * T{0.5});
 		a2_ = a_ * a_;
 		b2_ = b_ * b_;
 
@@ -154,7 +162,7 @@ public:
 
 			// Ensure conjugate symmetry
 			if (z.second == z.first) {
-				z.second = std::conj(z.first);
+				z.second = conj(z.first);
 			}
 
 			digital.add_conjugate_pairs(p.first, z.first);
@@ -189,7 +197,8 @@ private:
 		u = u + complex_t(T{8} * (b2_ - a2_ + T{1}));
 		u = u * c;
 		u = u + complex_t(T{4} * (a2_ + b2_ - T{1}));
-		u = std::sqrt(u);
+		using std::sqrt;
+		u = sqrt(u);
 
 		complex_t v = u * T{-0.5};
 		v = v + complex_t(a_);

--- a/include/sw/dsp/math/quadratic.hpp
+++ b/include/sw/dsp/math/quadratic.hpp
@@ -14,14 +14,16 @@ namespace sw::dsp {
 template <DspField T>
 complex_for_t<T> solve_quadratic_1(T a, T b, T c) {
 	using complex_t = complex_for_t<T>;
-	return (complex_t(-b) + std::sqrt(complex_t(b * b - T{4} * a * c))) / (T{2} * a);
+	using std::sqrt;
+	return (complex_t(-b) + sqrt(complex_t(b * b - T{4} * a * c))) / (T{2} * a);
 }
 
 // Solve ax^2 + bx + c = 0, returning the root with the negative discriminant sign.
 template <DspField T>
 complex_for_t<T> solve_quadratic_2(T a, T b, T c) {
 	using complex_t = complex_for_t<T>;
-	return (complex_t(-b) - std::sqrt(complex_t(b * b - T{4} * a * c))) / (T{2} * a);
+	using std::sqrt;
+	return (complex_t(-b) - sqrt(complex_t(b * b - T{4} * a * c))) / (T{2} * a);
 }
 
 // Return both roots of ax^2 + bx + c = 0

--- a/include/sw/dsp/math/root_finder.hpp
+++ b/include/sw/dsp/math/root_finder.hpp
@@ -62,6 +62,7 @@ public:
 		if (degree < 1 || degree > MaxDegree)
 			throw std::out_of_range("RootFinder::solve degree out of range");
 
+		using std::abs;
 		const T snap_eps = std::numeric_limits<T>::epsilon() * T{32};
 
 		// Copy coefficients for deflation
@@ -76,7 +77,7 @@ public:
 			laguerre(j + 1, deflated_.data(), x, its);
 
 			// Snap near-real roots to real axis
-			if (std::abs(x.imag()) <= T{2} * snap_eps * std::max(T{1}, std::abs(x.real()))) {
+			if (abs(x.imag()) <= T{2} * snap_eps * std::max(T{1}, abs(x.real()))) {
 				x = complex_t(x.real(), T{});
 			}
 
@@ -127,6 +128,9 @@ private:
 		constexpr int MT = 10;
 		constexpr int MAXIT = MT * MR;
 		const T EPS = std::numeric_limits<T>::epsilon();
+		using std::abs;
+		using std::sqrt;
+		using std::polar;
 
 		static const double frac[MR + 1] = {
 			0.0, 0.5, 0.25, 0.75, 0.13, 0.38, 0.62, 0.88, 1.0
@@ -136,38 +140,38 @@ private:
 		for (int iter = 1; iter <= MAXIT; ++iter) {
 			its = iter;
 			complex_t b = a[m];
-			T err = std::abs(b);
+			T err = abs(b);
 			complex_t d(T{}), f(T{});
-			T abx = std::abs(x);
+			T abx = abs(x);
 
 			for (int j = m - 1; j >= 0; --j) {
 				f = x * f + d;
 				d = x * d + b;
 				b = x * b + a[j];
-				err = std::abs(b) + abx * err;
+				err = abs(b) + abx * err;
 			}
 			err *= EPS;
 
-			if (std::abs(b) <= err) return;
+			if (abs(b) <= err) return;
 
 			complex_t g = d / b;
 			complex_t g2 = g * g;
 			complex_t h = g2 - complex_t(T{2}) * f / b;
 
-			complex_t sq = std::sqrt(
+			complex_t sq = sqrt(
 				complex_t(static_cast<T>(m - 1)) * (complex_t(static_cast<T>(m)) * h - g2));
 			complex_t gp = g + sq;
 			complex_t gm = g - sq;
 
-			T abp = std::abs(gp);
-			T abm = std::abs(gm);
+			T abp = abs(gp);
+			T abm = abs(gm);
 			if (abp < abm) gp = gm;
 
 			complex_t dx;
 			if (std::max(abp, abm) > T{}) {
 				dx = complex_t(static_cast<T>(m)) / gp;
 			} else {
-				dx = std::polar(static_cast<double>(T{1} + abx), static_cast<double>(iter));
+				dx = polar(static_cast<double>(T{1} + abx), static_cast<double>(iter));
 			}
 
 			complex_t x1 = x - dx;

--- a/include/sw/dsp/types/complex_pair.hpp
+++ b/include/sw/dsp/types/complex_pair.hpp
@@ -30,7 +30,8 @@ struct ComplexPair {
 		: first(c1), second(c2) {}
 
 	constexpr bool is_conjugate() const {
-		return second == std::conj(first);
+		using std::conj;
+		return second == conj(first);
 	}
 
 	constexpr bool is_real() const {
@@ -40,8 +41,9 @@ struct ComplexPair {
 	// Returns true if this is either a conjugate pair,
 	// or a pair of reals where neither is zero.
 	constexpr bool is_matched_pair() const {
+		using std::conj;
 		if (first.imag() != T{}) {
-			return second == std::conj(first);
+			return second == conj(first);
 		}
 		return second.imag() == T{} &&
 		       second.real() != T{} &&
@@ -49,8 +51,9 @@ struct ComplexPair {
 	}
 
 	constexpr bool is_nan() const {
-		return std::isnan(first.real()) || std::isnan(first.imag()) ||
-		       std::isnan(second.real()) || std::isnan(second.imag());
+		using std::isnan;
+		return isnan(first.real()) || isnan(first.imag()) ||
+		       isnan(second.real()) || isnan(second.imag());
 	}
 };
 


### PR DESCRIPTION
## Summary
Replace all `std::` qualified math function calls on template type `T` with
ADL-friendly `using std::func; func(expr);` pattern across 11 library headers.
This enables the library to compile when `CoeffScalar` is a Universal number type.

## Changes (11 files, ~50 call sites)
- `concepts/scalar.hpp` — ADL-friendly `ComplexType` concept via detail namespace
- `types/complex_pair.hpp` — `conj()`, `isnan()` via ADL
- `filter/biquad/biquad.hpp` — `sqrt()`, `conj()` via ADL
- `filter/biquad/cascade.hpp` — `abs()` via ADL
- `math/quadratic.hpp` — `sqrt()` via ADL
- `math/root_finder.hpp` — `abs()`, `sqrt()`, `polar()` via ADL
- `filter/transform/bilinear.hpp` — `tan()` via ADL
- `filter/transform/constantinides.hpp` — `cos()`, `tan()`, `atan()`, `sqrt()`, `conj()` via ADL
- `filter/iir/butterworth.hpp` — `pow()` via ADL
- `filter/iir/chebyshev1.hpp` — `sqrt()`, `exp()` via ADL
- `filter/iir/chebyshev2.hpp` — `sqrt()`, `exp()` via ADL

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| all tests | OK | 7/7 PASS | OK | 7/7 PASS |

## Test plan
- [x] Local gcc + clang
- [x] CI passes (all 5 platforms)

Resolves #19

Generated with [Claude Code](https://claude.com/claude-code)