### PR TITLE
feat(quantization): ADC, DAC, dither, noise shaping, SQNR — closes #3

### DIFF
--- a/include/sw/dsp/quantization/adc.hpp
+++ b/include/sw/dsp/quantization/adc.hpp
@@ -1,0 +1,39 @@
+#pragma once
+// adc.hpp: analog-to-digital conversion model
+//
+// Models quantization from a high-precision input type to a
+// lower-precision output type. The ADC maps a continuous-valued
+// input in [-1, 1] to discrete output levels.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+// ADC: convert from InputT (high precision) to OutputT (lower precision).
+// Simply performs static_cast, which triggers the target type's quantization.
+// For Universal types, this naturally rounds/truncates per the type's rules.
+template <DspField InputT, DspField OutputT>
+class ADC {
+public:
+	// Convert a single sample
+	OutputT convert(InputT sample) const {
+		return static_cast<OutputT>(sample);
+	}
+
+	// Convert a vector of samples
+	mtl::vec::dense_vector<OutputT> convert(const mtl::vec::dense_vector<InputT>& input) const {
+		mtl::vec::dense_vector<OutputT> output(input.size());
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			output[i] = static_cast<OutputT>(input[i]);
+		}
+		return output;
+	}
+};
+
+} // namespace sw::dsp

--- a/include/sw/dsp/quantization/dac.hpp
+++ b/include/sw/dsp/quantization/dac.hpp
@@ -1,0 +1,33 @@
+#pragma once
+// dac.hpp: digital-to-analog reconstruction model
+//
+// Models reconstruction from a quantized type back to a
+// high-precision type. Inverse of ADC.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+// DAC: convert from InputT (quantized) to OutputT (high precision).
+template <DspField InputT, DspField OutputT>
+class DAC {
+public:
+	OutputT convert(InputT sample) const {
+		return static_cast<OutputT>(sample);
+	}
+
+	mtl::vec::dense_vector<OutputT> convert(const mtl::vec::dense_vector<InputT>& input) const {
+		mtl::vec::dense_vector<OutputT> output(input.size());
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			output[i] = static_cast<OutputT>(input[i]);
+		}
+		return output;
+	}
+};
+
+} // namespace sw::dsp

--- a/include/sw/dsp/quantization/dither.hpp
+++ b/include/sw/dsp/quantization/dither.hpp
@@ -1,0 +1,74 @@
+#pragma once
+// dither.hpp: dithering for quantization noise shaping
+//
+// TPDF (triangular probability density function) and RPDF (rectangular)
+// dithering add small noise before quantization to decorrelate
+// quantization error from the signal, converting distortion into
+// flat noise floor.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <random>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+// RPDF dither: uniform noise in [-amplitude, +amplitude]
+template <DspField T>
+class RPDFDither {
+public:
+	explicit RPDFDither(T amplitude, unsigned seed = 0)
+		: amplitude_(amplitude)
+		, gen_(seed == 0 ? std::random_device{}() : seed)
+		, dist_(-1.0, 1.0) {}
+
+	T operator()() {
+		return amplitude_ * static_cast<T>(dist_(gen_));
+	}
+
+	// Apply dither to a vector in-place
+	void apply(mtl::vec::dense_vector<T>& signal) {
+		for (std::size_t i = 0; i < signal.size(); ++i) {
+			signal[i] = signal[i] + (*this)();
+		}
+	}
+
+private:
+	T amplitude_;
+	std::mt19937 gen_;
+	std::uniform_real_distribution<double> dist_;
+};
+
+// TPDF dither: triangular noise (sum of two uniform)
+// TPDF eliminates the noise modulation artifact that RPDF leaves.
+template <DspField T>
+class TPDFDither {
+public:
+	explicit TPDFDither(T amplitude, unsigned seed = 0)
+		: amplitude_(amplitude)
+		, gen_(seed == 0 ? std::random_device{}() : seed)
+		, dist_(-1.0, 1.0) {}
+
+	T operator()() {
+		// Sum of two uniform gives triangular distribution
+		double u1 = dist_(gen_);
+		double u2 = dist_(gen_);
+		return amplitude_ * static_cast<T>((u1 + u2) * 0.5);
+	}
+
+	void apply(mtl::vec::dense_vector<T>& signal) {
+		for (std::size_t i = 0; i < signal.size(); ++i) {
+			signal[i] = signal[i] + (*this)();
+		}
+	}
+
+private:
+	T amplitude_;
+	std::mt19937 gen_;
+	std::uniform_real_distribution<double> dist_;
+};
+
+} // namespace sw::dsp

--- a/include/sw/dsp/quantization/noise_shaping.hpp
+++ b/include/sw/dsp/quantization/noise_shaping.hpp
@@ -1,0 +1,53 @@
+#pragma once
+// noise_shaping.hpp: error-feedback noise shaping
+//
+// Feeds the quantization error back through a filter to reshape
+// the noise spectrum, pushing noise energy out of the band of
+// interest. First-order noise shaping is the simplest form.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+// First-order error-feedback noise shaper.
+//
+// For each sample:
+//   shaped = input + error_feedback
+//   quantized = quantize(shaped)    // conversion to OutputT
+//   error = shaped - quantized      // quantization error
+//   error_feedback = -error         // feed back for next sample
+//
+// This pushes noise energy to higher frequencies (first-order
+// high-pass shaping of the noise floor).
+template <DspField HighPrecT, DspField LowPrecT>
+class FirstOrderNoiseShaper {
+public:
+	LowPrecT process(HighPrecT input) {
+		HighPrecT shaped = input + error_feedback_;
+		LowPrecT quantized = static_cast<LowPrecT>(shaped);
+		HighPrecT reconstructed = static_cast<HighPrecT>(quantized);
+		HighPrecT error = shaped - reconstructed;
+		error_feedback_ = HighPrecT{} - error;  // negative feedback
+		return quantized;
+	}
+
+	mtl::vec::dense_vector<LowPrecT> process(const mtl::vec::dense_vector<HighPrecT>& input) {
+		mtl::vec::dense_vector<LowPrecT> output(input.size());
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			output[i] = process(input[i]);
+		}
+		return output;
+	}
+
+	void reset() { error_feedback_ = HighPrecT{}; }
+
+private:
+	HighPrecT error_feedback_{};
+};
+
+} // namespace sw::dsp

--- a/include/sw/dsp/quantization/quantization.hpp
+++ b/include/sw/dsp/quantization/quantization.hpp
@@ -1,0 +1,11 @@
+#pragma once
+// quantization.hpp: umbrella header for quantization analysis tools
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/quantization/adc.hpp>
+#include <sw/dsp/quantization/dac.hpp>
+#include <sw/dsp/quantization/dither.hpp>
+#include <sw/dsp/quantization/noise_shaping.hpp>
+#include <sw/dsp/quantization/sqnr.hpp>

--- a/include/sw/dsp/quantization/sqnr.hpp
+++ b/include/sw/dsp/quantization/sqnr.hpp
@@ -1,0 +1,92 @@
+#pragma once
+// sqnr.hpp: signal-to-quantization-noise ratio analysis
+//
+// Compares a reference signal against a quantized version to
+// measure the signal-to-quantization-noise ratio in dB.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+// Compute SQNR in dB between a reference signal and a quantized version.
+// SQNR = 10 * log10(signal_power / noise_power)
+// where noise = reference - quantized.
+//
+// Both vectors must be the same length.
+// Returns SQNR in dB. Higher = better.
+template <DspField RefT, DspField QuantT>
+double sqnr_db(const mtl::vec::dense_vector<RefT>& reference,
+               const mtl::vec::dense_vector<QuantT>& quantized) {
+	if (reference.size() != quantized.size())
+		throw std::invalid_argument("sqnr_db: vectors must have equal length");
+	if (reference.size() == 0)
+		throw std::invalid_argument("sqnr_db: vectors must not be empty");
+
+	double signal_power = 0.0;
+	double noise_power = 0.0;
+
+	for (std::size_t i = 0; i < reference.size(); ++i) {
+		double ref = static_cast<double>(reference[i]);
+		double quant = static_cast<double>(quantized[i]);
+		double noise = ref - quant;
+		signal_power += ref * ref;
+		noise_power += noise * noise;
+	}
+
+	if (noise_power == 0.0) return std::numeric_limits<double>::infinity();
+	if (signal_power == 0.0) return 0.0;
+
+	return 10.0 * std::log10(signal_power / noise_power);
+}
+
+// Convenience: quantize a reference signal to type QuantT and compute SQNR.
+template <DspField RefT, DspField QuantT>
+double measure_sqnr_db(const mtl::vec::dense_vector<RefT>& reference) {
+	mtl::vec::dense_vector<QuantT> quantized(reference.size());
+	for (std::size_t i = 0; i < reference.size(); ++i) {
+		quantized[i] = static_cast<QuantT>(reference[i]);
+	}
+	return sqnr_db(reference, quantized);
+}
+
+// Compute max absolute error between reference and quantized signals.
+template <DspField RefT, DspField QuantT>
+double max_absolute_error(const mtl::vec::dense_vector<RefT>& reference,
+                           const mtl::vec::dense_vector<QuantT>& quantized) {
+	if (reference.size() != quantized.size())
+		throw std::invalid_argument("max_absolute_error: vectors must have equal length");
+
+	double max_err = 0.0;
+	for (std::size_t i = 0; i < reference.size(); ++i) {
+		double err = std::abs(static_cast<double>(reference[i]) - static_cast<double>(quantized[i]));
+		if (err > max_err) max_err = err;
+	}
+	return max_err;
+}
+
+// Compute max relative error between reference and quantized signals.
+template <DspField RefT, DspField QuantT>
+double max_relative_error(const mtl::vec::dense_vector<RefT>& reference,
+                           const mtl::vec::dense_vector<QuantT>& quantized) {
+	if (reference.size() != quantized.size())
+		throw std::invalid_argument("max_relative_error: vectors must have equal length");
+
+	double max_ref = 0.0;
+	double max_err = 0.0;
+	for (std::size_t i = 0; i < reference.size(); ++i) {
+		double ref = std::abs(static_cast<double>(reference[i]));
+		double err = std::abs(static_cast<double>(reference[i]) - static_cast<double>(quantized[i]));
+		if (ref > max_ref) max_ref = ref;
+		if (err > max_err) max_err = err;
+	}
+	return (max_ref > 0.0) ? max_err / max_ref : 0.0;
+}
+
+} // namespace sw::dsp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,3 +33,6 @@ dsp_add_test(test_elliptic)
 
 # Windows + Signal + Sampling (Issue #3)
 dsp_add_test(test_windows)
+
+# Quantization (Issue #3)
+dsp_add_test(test_quantization)

--- a/tests/test_quantization.cpp
+++ b/tests/test_quantization.cpp
@@ -1,0 +1,227 @@
+// test_quantization.cpp: test ADC, DAC, dither, noise shaping, and SQNR
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/quantization/quantization.hpp>
+#include <sw/dsp/signals/generators.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+
+using namespace sw::dsp;
+
+bool near(double a, double b, double eps = 1e-4) {
+	return std::abs(a - b) < eps;
+}
+
+void test_adc_dac_roundtrip() {
+	// double -> float -> double should lose precision but be close
+	ADC<double, float> adc;
+	DAC<float, double> dac;
+
+	double input = 0.123456789012345;
+	float quantized = adc.convert(input);
+	double reconstructed = dac.convert(quantized);
+
+	// float has ~7 decimal digits
+	if (!(std::abs(reconstructed - input) < 1e-6))
+		throw std::runtime_error("test failed: ADC/DAC roundtrip precision");
+	if (!(reconstructed != input))
+		throw std::runtime_error("test failed: ADC/DAC should lose some precision");
+
+	std::cout << "  adc_dac_roundtrip: passed (error=" << std::abs(reconstructed - input) << ")\n";
+}
+
+void test_adc_vector() {
+	auto sig = sine<double>(100, 1.0, 100.0);
+	ADC<double, float> adc;
+	auto quantized = adc.convert(sig);
+	if (!(quantized.size() == sig.size()))
+		throw std::runtime_error("test failed: ADC vector size");
+	// Quantized values should be close but not identical
+	double max_err = 0;
+	for (std::size_t i = 0; i < sig.size(); ++i) {
+		double err = std::abs(static_cast<double>(sig[i]) - static_cast<double>(quantized[i]));
+		if (err > max_err) max_err = err;
+	}
+	if (!(max_err < 1e-6))
+		throw std::runtime_error("test failed: ADC vector precision");
+
+	std::cout << "  adc_vector: passed (max_err=" << max_err << ")\n";
+}
+
+void test_rpdf_dither() {
+	RPDFDither<double> dither(0.01, 42);
+
+	// Generate some dither values
+	double sum = 0;
+	constexpr int N = 10000;
+	for (int i = 0; i < N; ++i) {
+		double d = dither();
+		if (!(std::abs(d) <= 0.01 + 1e-10))
+			throw std::runtime_error("test failed: RPDF dither out of range");
+		sum += d;
+	}
+	// Mean should be near zero
+	double mean = sum / N;
+	if (!(std::abs(mean) < 0.001))
+		throw std::runtime_error("test failed: RPDF dither mean");
+
+	std::cout << "  rpdf_dither: passed (mean=" << mean << ")\n";
+}
+
+void test_tpdf_dither() {
+	TPDFDither<double> dither(0.01, 42);
+
+	double sum = 0;
+	double sum_sq = 0;
+	constexpr int N = 10000;
+	for (int i = 0; i < N; ++i) {
+		double d = dither();
+		sum += d;
+		sum_sq += d * d;
+	}
+	double mean = sum / N;
+	// TPDF mean should be near zero
+	if (!(std::abs(mean) < 0.001))
+		throw std::runtime_error("test failed: TPDF dither mean");
+	// TPDF should have lower variance than RPDF (triangular is narrower)
+	double variance = sum_sq / N - mean * mean;
+	if (!(variance < 0.01 * 0.01))
+		throw std::runtime_error("test failed: TPDF dither variance");
+
+	std::cout << "  tpdf_dither: passed (mean=" << mean << ", var=" << variance << ")\n";
+}
+
+void test_dither_apply() {
+	auto sig = sine<double>(100, 1.0, 100.0);
+	mtl::vec::dense_vector<double> sig_copy(sig.size());
+	for (std::size_t i = 0; i < sig.size(); ++i) sig_copy[i] = sig[i];
+
+	RPDFDither<double> dither(0.001, 42);
+	dither.apply(sig_copy);
+
+	// Signal should be slightly different after dithering
+	double diff = 0;
+	for (std::size_t i = 0; i < sig.size(); ++i) {
+		diff += std::abs(static_cast<double>(sig[i]) - sig_copy[i]);
+	}
+	if (!(diff > 0))
+		throw std::runtime_error("test failed: dither should modify signal");
+
+	std::cout << "  dither_apply: passed\n";
+}
+
+void test_noise_shaping() {
+	// First-order noise shaping: double -> float
+	FirstOrderNoiseShaper<double, float> shaper;
+
+	auto sig = sine<double>(1000, 100.0, 44100.0);
+
+	// Process with noise shaping
+	auto shaped = shaper.process(sig);
+	if (!(shaped.size() == sig.size()))
+		throw std::runtime_error("test failed: noise shaping size");
+
+	// Compare SQNR: shaped vs plain quantization
+	ADC<double, float> adc;
+	auto plain = adc.convert(sig);
+
+	double sqnr_plain = sqnr_db(sig, plain);
+	double sqnr_shaped = sqnr_db(sig, shaped);
+
+	// Noise shaping should not make things dramatically worse
+	// (for first-order with float, the improvement may be subtle)
+	if (!(std::isfinite(sqnr_plain)))
+		throw std::runtime_error("test failed: plain SQNR not finite");
+	if (!(std::isfinite(sqnr_shaped)))
+		throw std::runtime_error("test failed: shaped SQNR not finite");
+
+	std::cout << "  noise_shaping: passed (plain=" << sqnr_plain
+	          << " dB, shaped=" << sqnr_shaped << " dB)\n";
+}
+
+void test_sqnr_identical() {
+	// Identical signals should give infinite SQNR
+	auto sig = sine<double>(100, 1.0, 100.0);
+	double sqnr = sqnr_db(sig, sig);
+	if (!(sqnr == std::numeric_limits<double>::infinity()))
+		throw std::runtime_error("test failed: SQNR of identical signals should be inf");
+
+	std::cout << "  sqnr_identical: passed\n";
+}
+
+void test_sqnr_float() {
+	// SQNR of double -> float quantization of a sine wave
+	// Theoretical: ~150 dB (float has 24-bit mantissa, ~7 decimal digits)
+	auto sig = sine<double>(10000, 440.0, 44100.0);
+	double sqnr = measure_sqnr_db<double, float>(sig);
+
+	if (!(sqnr > 100.0))
+		throw std::runtime_error("test failed: float SQNR too low");
+	if (!(sqnr < 200.0))
+		throw std::runtime_error("test failed: float SQNR unreasonably high");
+
+	std::cout << "  sqnr_float: passed (" << sqnr << " dB)\n";
+}
+
+void test_max_errors() {
+	auto sig = sine<double>(1000, 440.0, 44100.0);
+	ADC<double, float> adc;
+	auto quantized = adc.convert(sig);
+
+	double abs_err = max_absolute_error(sig, quantized);
+	double rel_err = max_relative_error(sig, quantized);
+
+	if (!(abs_err > 0.0))
+		throw std::runtime_error("test failed: max_absolute_error should be > 0");
+	if (!(abs_err < 1e-6))
+		throw std::runtime_error("test failed: float max_absolute_error too large");
+	if (!(rel_err > 0.0))
+		throw std::runtime_error("test failed: max_relative_error should be > 0");
+	if (!(rel_err < 1e-6))
+		throw std::runtime_error("test failed: float max_relative_error too large");
+
+	std::cout << "  max_errors: passed (abs=" << abs_err << ", rel=" << rel_err << ")\n";
+}
+
+void test_sqnr_validation() {
+	// Empty vectors should throw
+	mtl::vec::dense_vector<double> empty;
+	mtl::vec::dense_vector<double> nonempty(10, 1.0);
+	bool caught = false;
+	try { sqnr_db(empty, empty); } catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: sqnr_db should reject empty vectors");
+
+	// Mismatched sizes should throw
+	caught = false;
+	try { sqnr_db(nonempty, empty); } catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: sqnr_db should reject mismatched sizes");
+
+	std::cout << "  sqnr_validation: passed\n";
+}
+
+int main() {
+	try {
+		std::cout << "Quantization Tests\n";
+
+		test_adc_dac_roundtrip();
+		test_adc_vector();
+		test_rpdf_dither();
+		test_tpdf_dither();
+		test_dither_apply();
+		test_noise_shaping();
+		test_sqnr_identical();
+		test_sqnr_float();
+		test_max_errors();
+		test_sqnr_validation();
+
+		std::cout << "All quantization tests passed.\n";
+		return 0;
+	} catch (const std::exception& e) {
+		std::cerr << "FAILED: " << e.what() << '\n';
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary
Completes Issue #3 with the quantization analysis toolbox.

## Changes (6 headers + test)
- `quantization/adc.hpp` — ADC<InputT, OutputT> type-conversion model
- `quantization/dac.hpp` — DAC<InputT, OutputT> reconstruction model
- `quantization/dither.hpp` — RPDFDither and TPDFDither with apply()
- `quantization/noise_shaping.hpp` — FirstOrderNoiseShaper<HighPrecT, LowPrecT>
- `quantization/sqnr.hpp` — sqnr_db(), measure_sqnr_db(), max_absolute_error(), max_relative_error()
- `quantization/quantization.hpp` — umbrella
- `tests/test_quantization.cpp` — 10 tests

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| all tests | OK | 10/10 PASS | OK | 10/10 PASS |

## Test plan
- [x] Local gcc + clang
- [x] CI passes (all 5 platforms)

Resolves #3

Generated with [Claude Code](https://claude.com/claude-code)