### PR TITLE
feat(estimation): Linear Kalman, LMS, NLMS, RLS

### DIFF
--- a/include/sw/dsp/estimation/estimation.hpp
+++ b/include/sw/dsp/estimation/estimation.hpp
@@ -1,0 +1,10 @@
+#pragma once
+// estimation.hpp: umbrella header for state estimation and adaptive filtering
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/estimation/kalman.hpp>
+#include <sw/dsp/estimation/lms.hpp>
+#include <sw/dsp/estimation/rls.hpp>
+// Future: ekf.hpp, ukf.hpp

--- a/include/sw/dsp/estimation/kalman.hpp
+++ b/include/sw/dsp/estimation/kalman.hpp
@@ -1,0 +1,152 @@
+#pragma once
+// kalman.hpp: linear Kalman filter
+//
+// State estimation via predict/update cycle. The user provides
+// system matrices F, H, Q, R (and optionally B for control input).
+//
+// Predict:
+//   x_pred = F * x + B * u
+//   P_pred = F * P * F^T + Q
+//
+// Update:
+//   y = z - H * x_pred           (innovation)
+//   S = H * P_pred * H^T + R     (innovation covariance)
+//   K = P_pred * H^T * S^-1      (Kalman gain)
+//   x = x_pred + K * y
+//   P = (I - K * H) * P_pred
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <stdexcept>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/mat/operators.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/vec/operators.hpp>
+#include <mtl/operation/trans.hpp>
+#include <mtl/operation/inv.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+// Linear Kalman filter.
+//
+// Template parameters:
+//   T:        scalar type (DspField)
+//
+// State dimension, measurement dimension, and control dimension are
+// runtime parameters set via setup().
+template <DspField T>
+class KalmanFilter {
+public:
+	using matrix_t = mtl::mat::dense2D<T>;
+	using vector_t = mtl::vec::dense_vector<T>;
+
+	// Initialize with state dimension and measurement dimension.
+	// Control dimension defaults to 0 (no control input).
+	KalmanFilter(std::size_t state_dim, std::size_t meas_dim, std::size_t ctrl_dim = 0)
+		: state_dim_(state_dim), meas_dim_(meas_dim), ctrl_dim_(ctrl_dim),
+		  x_(state_dim, T{}),
+		  P_(state_dim, state_dim),
+		  F_(state_dim, state_dim),
+		  H_(meas_dim, state_dim),
+		  Q_(state_dim, state_dim),
+		  R_(meas_dim, meas_dim),
+		  B_(state_dim, ctrl_dim > 0 ? ctrl_dim : 1)
+	{
+		if (state_dim == 0) throw std::invalid_argument("KalmanFilter: state_dim must be > 0");
+		if (meas_dim == 0) throw std::invalid_argument("KalmanFilter: meas_dim must be > 0");
+		// Initialize P, F, Q to identity by default
+		identity_matrix(P_);
+		identity_matrix(F_);
+		identity_matrix(Q_);
+		identity_matrix(R_);
+	}
+
+	// System matrix accessors
+	matrix_t& F() { return F_; }
+	matrix_t& H() { return H_; }
+	matrix_t& Q() { return Q_; }
+	matrix_t& R() { return R_; }
+	matrix_t& B() { return B_; }
+	matrix_t& P() { return P_; }
+	vector_t& state() { return x_; }
+
+	const matrix_t& F() const { return F_; }
+	const matrix_t& H() const { return H_; }
+	const matrix_t& Q() const { return Q_; }
+	const matrix_t& R() const { return R_; }
+	const matrix_t& P() const { return P_; }
+	const vector_t& state() const { return x_; }
+
+	// Predict step (no control input)
+	void predict() {
+		using mtl::trans;
+		// x = F * x
+		x_ = F_ * x_;
+		// P = F * P * F^T + Q
+		P_ = F_ * P_ * trans(F_) + Q_;
+	}
+
+	// Predict step with control input
+	void predict(const vector_t& u) {
+		using mtl::trans;
+		if (u.size() != ctrl_dim_)
+			throw std::invalid_argument("KalmanFilter::predict: control vector size mismatch");
+		x_ = F_ * x_ + B_ * u;
+		P_ = F_ * P_ * trans(F_) + Q_;
+	}
+
+	// Update step with measurement z
+	void update(const vector_t& z) {
+		using mtl::trans;
+		using mtl::inv;
+		if (z.size() != meas_dim_)
+			throw std::invalid_argument("KalmanFilter::update: measurement size mismatch");
+
+		// Innovation: y = z - H * x
+		vector_t y = z - H_ * x_;
+
+		// Innovation covariance: S = H * P * H^T + R
+		matrix_t S = H_ * P_ * trans(H_) + R_;
+
+		// Kalman gain: K = P * H^T * S^-1
+		matrix_t K = P_ * trans(H_) * inv(S);
+
+		// Update state: x = x + K * y
+		x_ = x_ + K * y;
+
+		// Update covariance: P = (I - K * H) * P
+		matrix_t I_n(state_dim_, state_dim_);
+		identity_matrix(I_n);
+		P_ = (I_n - K * H_) * P_;
+	}
+
+	std::size_t state_dim() const { return state_dim_; }
+	std::size_t meas_dim() const { return meas_dim_; }
+	std::size_t ctrl_dim() const { return ctrl_dim_; }
+
+private:
+	static void identity_matrix(matrix_t& m) {
+		std::size_t n = m.num_rows();
+		for (std::size_t i = 0; i < n; ++i) {
+			for (std::size_t j = 0; j < m.num_cols(); ++j) {
+				m(i, j) = (i == j) ? T{1} : T{};
+			}
+		}
+	}
+
+	std::size_t state_dim_;
+	std::size_t meas_dim_;
+	std::size_t ctrl_dim_;
+	vector_t x_;     // state estimate
+	matrix_t P_;     // error covariance
+	matrix_t F_;     // state transition
+	matrix_t H_;     // observation
+	matrix_t Q_;     // process noise covariance
+	matrix_t R_;     // measurement noise covariance
+	matrix_t B_;     // control input matrix
+};
+
+} // namespace sw::dsp

--- a/include/sw/dsp/estimation/lms.hpp
+++ b/include/sw/dsp/estimation/lms.hpp
@@ -1,0 +1,183 @@
+#pragma once
+// lms.hpp: Least Mean Squares adaptive filter
+//
+// Online adaptation of FIR tap weights to minimize the mean
+// squared error between a desired signal and the filter output.
+//
+// Update rule:
+//   error = desired - output
+//   w[k] = w[k] + mu * error * x[k]    for each tap k
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <stdexcept>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+// LMS adaptive filter.
+//
+// Template parameters:
+//   T:  scalar type
+//
+// Usage:
+//   LMSFilter<double> lms(num_taps, step_size);
+//   double y = lms.process(input, desired);
+template <DspField T>
+class LMSFilter {
+public:
+	LMSFilter(std::size_t num_taps, T step_size)
+		: weights_(num_taps, T{}),
+		  delay_(num_taps, T{}),
+		  step_size_(step_size),
+		  num_taps_(num_taps),
+		  write_pos_(0)
+	{
+		if (num_taps == 0)
+			throw std::invalid_argument("LMSFilter: num_taps must be > 0");
+	}
+
+	// Process one sample with adaptation.
+	// input:   the reference input signal x[n]
+	// desired: the desired signal d[n]
+	// Returns: the filter output y[n]
+	// After processing, the error e[n] = d[n] - y[n] is available.
+	T process(T input, T desired) {
+		// Insert input into circular delay line
+		delay_[write_pos_] = input;
+
+		// Compute output: y = sum(w[k] * x[n-k])
+		T output{};
+		std::size_t idx = write_pos_;
+		for (std::size_t k = 0; k < num_taps_; ++k) {
+			output = output + weights_[k] * delay_[idx];
+			idx = (idx == 0) ? num_taps_ - 1 : idx - 1;
+		}
+
+		// Compute error
+		T error = desired - output;
+		last_error_ = error;
+
+		// Update weights: w[k] += mu * e * x[n-k]
+		idx = write_pos_;
+		for (std::size_t k = 0; k < num_taps_; ++k) {
+			weights_[k] = weights_[k] + step_size_ * error * delay_[idx];
+			idx = (idx == 0) ? num_taps_ - 1 : idx - 1;
+		}
+
+		// Advance write position
+		write_pos_ = (write_pos_ + 1) % num_taps_;
+
+		return output;
+	}
+
+	// Process without adapting (use frozen weights)
+	T predict(T input) {
+		delay_[write_pos_] = input;
+		T output{};
+		std::size_t idx = write_pos_;
+		for (std::size_t k = 0; k < num_taps_; ++k) {
+			output = output + weights_[k] * delay_[idx];
+			idx = (idx == 0) ? num_taps_ - 1 : idx - 1;
+		}
+		write_pos_ = (write_pos_ + 1) % num_taps_;
+		return output;
+	}
+
+	// Reset weights and delay line to zero
+	void reset() {
+		for (std::size_t i = 0; i < num_taps_; ++i) {
+			weights_[i] = T{};
+			delay_[i] = T{};
+		}
+		write_pos_ = 0;
+		last_error_ = T{};
+	}
+
+	// Access
+	const mtl::vec::dense_vector<T>& weights() const { return weights_; }
+	mtl::vec::dense_vector<T>& weights() { return weights_; }
+	std::size_t num_taps() const { return num_taps_; }
+	T step_size() const { return step_size_; }
+	T last_error() const { return last_error_; }
+
+	void set_step_size(T mu) { step_size_ = mu; }
+
+private:
+	mtl::vec::dense_vector<T> weights_;
+	mtl::vec::dense_vector<T> delay_;
+	T step_size_;
+	std::size_t num_taps_;
+	std::size_t write_pos_;
+	T last_error_{};
+};
+
+// Normalized LMS variant: scales step size by input power.
+// Provides better stability across varying input levels.
+template <DspField T>
+class NLMSFilter {
+public:
+	NLMSFilter(std::size_t num_taps, T step_size, T epsilon = T{1e-6})
+		: weights_(num_taps, T{}),
+		  delay_(num_taps, T{}),
+		  step_size_(step_size),
+		  epsilon_(epsilon),
+		  num_taps_(num_taps),
+		  write_pos_(0)
+	{
+		if (num_taps == 0)
+			throw std::invalid_argument("NLMSFilter: num_taps must be > 0");
+	}
+
+	T process(T input, T desired) {
+		delay_[write_pos_] = input;
+
+		T output{};
+		T power{};
+		std::size_t idx = write_pos_;
+		for (std::size_t k = 0; k < num_taps_; ++k) {
+			output = output + weights_[k] * delay_[idx];
+			power = power + delay_[idx] * delay_[idx];
+			idx = (idx == 0) ? num_taps_ - 1 : idx - 1;
+		}
+
+		T error = desired - output;
+		last_error_ = error;
+
+		// Normalized step: mu / (epsilon + power)
+		T norm_mu = step_size_ / (epsilon_ + power);
+
+		idx = write_pos_;
+		for (std::size_t k = 0; k < num_taps_; ++k) {
+			weights_[k] = weights_[k] + norm_mu * error * delay_[idx];
+			idx = (idx == 0) ? num_taps_ - 1 : idx - 1;
+		}
+
+		write_pos_ = (write_pos_ + 1) % num_taps_;
+		return output;
+	}
+
+	void reset() {
+		for (std::size_t i = 0; i < num_taps_; ++i) { weights_[i] = T{}; delay_[i] = T{}; }
+		write_pos_ = 0;
+		last_error_ = T{};
+	}
+
+	const mtl::vec::dense_vector<T>& weights() const { return weights_; }
+	std::size_t num_taps() const { return num_taps_; }
+	T last_error() const { return last_error_; }
+
+private:
+	mtl::vec::dense_vector<T> weights_;
+	mtl::vec::dense_vector<T> delay_;
+	T step_size_;
+	T epsilon_;
+	std::size_t num_taps_;
+	std::size_t write_pos_;
+	T last_error_{};
+};
+
+} // namespace sw::dsp

--- a/include/sw/dsp/estimation/rls.hpp
+++ b/include/sw/dsp/estimation/rls.hpp
@@ -1,0 +1,144 @@
+#pragma once
+// rls.hpp: Recursive Least Squares adaptive filter
+//
+// Faster convergence than LMS at the cost of higher computational
+// complexity (O(N^2) vs O(N) per sample). Uses an exponentially
+// weighted forgetting factor to track non-stationary signals.
+//
+// Update rule (matrix form):
+//   k = (P * x) / (lambda + x^T * P * x)    (gain vector)
+//   error = desired - w^T * x
+//   w = w + k * error
+//   P = (P - k * x^T * P) / lambda
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <stdexcept>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+// RLS adaptive filter.
+//
+// Template parameters:
+//   T: scalar type
+//
+// Constructor parameters:
+//   num_taps:  filter length
+//   lambda:    forgetting factor in (0, 1], typically 0.99
+//   delta:     initial value for P diagonal (large for fast convergence)
+template <DspField T>
+class RLSFilter {
+public:
+	using matrix_t = mtl::mat::dense2D<T>;
+	using vector_t = mtl::vec::dense_vector<T>;
+
+	RLSFilter(std::size_t num_taps, T lambda = T{0.99}, T delta = T{1000})
+		: weights_(num_taps, T{}),
+		  delay_(num_taps, T{}),
+		  P_(num_taps, num_taps),
+		  num_taps_(num_taps),
+		  lambda_(lambda)
+	{
+		if (num_taps == 0)
+			throw std::invalid_argument("RLSFilter: num_taps must be > 0");
+		if (!(lambda > T{} && lambda <= T{1}))
+			throw std::invalid_argument("RLSFilter: lambda must be in (0, 1]");
+
+		// P = delta * I
+		for (std::size_t i = 0; i < num_taps; ++i) {
+			for (std::size_t j = 0; j < num_taps; ++j) {
+				P_(i, j) = (i == j) ? delta : T{};
+			}
+		}
+	}
+
+	// Process one sample with adaptation.
+	T process(T input, T desired) {
+		// Shift delay line: x[k] = x[k-1] for k = num_taps-1 .. 1; x[0] = input
+		for (std::size_t k = num_taps_ - 1; k > 0; --k) {
+			delay_[k] = delay_[k - 1];
+		}
+		delay_[0] = input;
+
+		// Compute output: y = w^T * x
+		T output{};
+		for (std::size_t k = 0; k < num_taps_; ++k) {
+			output = output + weights_[k] * delay_[k];
+		}
+
+		// Error
+		T error = desired - output;
+		last_error_ = error;
+
+		// pi = P * x
+		vector_t pi(num_taps_, T{});
+		for (std::size_t i = 0; i < num_taps_; ++i) {
+			T sum{};
+			for (std::size_t j = 0; j < num_taps_; ++j) {
+				sum = sum + P_(i, j) * delay_[j];
+			}
+			pi[i] = sum;
+		}
+
+		// gamma = lambda + x^T * pi
+		T gamma = lambda_;
+		for (std::size_t i = 0; i < num_taps_; ++i) {
+			gamma = gamma + delay_[i] * pi[i];
+		}
+
+		// gain k = pi / gamma
+		vector_t gain(num_taps_, T{});
+		for (std::size_t i = 0; i < num_taps_; ++i) {
+			gain[i] = pi[i] / gamma;
+		}
+
+		// Update weights: w = w + k * error
+		for (std::size_t i = 0; i < num_taps_; ++i) {
+			weights_[i] = weights_[i] + gain[i] * error;
+		}
+
+		// Update P: P = (P - k * pi^T) / lambda
+		// Note: pi = P * x, so k * pi^T = (P*x*x^T*P) / (lambda + x^T*P*x)
+		T inv_lambda = T{1} / lambda_;
+		for (std::size_t i = 0; i < num_taps_; ++i) {
+			for (std::size_t j = 0; j < num_taps_; ++j) {
+				P_(i, j) = (P_(i, j) - gain[i] * pi[j]) * inv_lambda;
+			}
+		}
+
+		return output;
+	}
+
+	// Reset weights and P
+	void reset(T delta = T{1000}) {
+		for (std::size_t i = 0; i < num_taps_; ++i) {
+			weights_[i] = T{};
+			delay_[i] = T{};
+			for (std::size_t j = 0; j < num_taps_; ++j) {
+				P_(i, j) = (i == j) ? delta : T{};
+			}
+		}
+		last_error_ = T{};
+	}
+
+	// Access
+	const vector_t& weights() const { return weights_; }
+	std::size_t num_taps() const { return num_taps_; }
+	T last_error() const { return last_error_; }
+	T lambda() const { return lambda_; }
+
+private:
+	vector_t weights_;
+	vector_t delay_;
+	matrix_t P_;
+	std::size_t num_taps_;
+	T lambda_;
+	T last_error_{};
+};
+
+} // namespace sw::dsp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,3 +48,6 @@ dsp_add_test(test_spectral)
 
 # Signal conditioning (Issue #6)
 dsp_add_test(test_conditioning)
+
+# Estimation: Kalman, LMS, RLS (Issue #7)
+dsp_add_test(test_kalman)

--- a/tests/test_kalman.cpp
+++ b/tests/test_kalman.cpp
@@ -1,0 +1,233 @@
+// test_kalman.cpp: test Kalman filter, LMS, and RLS adaptive filters
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/estimation/estimation.hpp>
+#include <sw/dsp/signals/generators.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <stdexcept>
+
+using namespace sw::dsp;
+
+bool near(double a, double b, double eps = 1e-3) {
+	return std::abs(a - b) < eps;
+}
+
+// ========== Kalman Filter Tests ==========
+
+void test_kalman_construction() {
+	KalmanFilter<double> kf(2, 1);
+	if (!(kf.state_dim() == 2)) throw std::runtime_error("test failed: kalman state_dim");
+	if (!(kf.meas_dim() == 1)) throw std::runtime_error("test failed: kalman meas_dim");
+	if (!(kf.state().size() == 2)) throw std::runtime_error("test failed: kalman state size");
+
+	std::cout << "  kalman_construction: passed\n";
+}
+
+void test_kalman_constant_velocity() {
+	// 1D constant-velocity tracking:
+	// State = [position, velocity], dt = 1
+	// F = [[1, 1], [0, 1]]  (position += velocity * dt)
+	// H = [[1, 0]]          (we only measure position)
+	// Q = small process noise
+	// R = measurement noise variance
+
+	KalmanFilter<double> kf(2, 1);
+
+	// State transition: position += velocity (dt=1)
+	kf.F()(0, 0) = 1.0; kf.F()(0, 1) = 1.0;
+	kf.F()(1, 0) = 0.0; kf.F()(1, 1) = 1.0;
+
+	// Observation: measure position only
+	kf.H()(0, 0) = 1.0; kf.H()(0, 1) = 0.0;
+
+	// Process noise (small)
+	kf.Q()(0, 0) = 0.001; kf.Q()(0, 1) = 0.0;
+	kf.Q()(1, 0) = 0.0;   kf.Q()(1, 1) = 0.001;
+
+	// Measurement noise
+	kf.R()(0, 0) = 0.5;
+
+	// Initial state covariance (uncertain)
+	kf.P()(0, 0) = 100.0; kf.P()(0, 1) = 0.0;
+	kf.P()(1, 0) = 0.0;   kf.P()(1, 1) = 100.0;
+
+	// True trajectory: position starts at 0, velocity = 1
+	// Generate noisy measurements
+	std::mt19937 gen(42);
+	std::normal_distribution<double> noise(0.0, 0.5);
+
+	mtl::vec::dense_vector<double> z(1);
+	for (int t = 0; t < 50; ++t) {
+		double true_pos = static_cast<double>(t);
+		z[0] = true_pos + noise(gen);
+
+		kf.predict();
+		kf.update(z);
+	}
+
+	// After 50 steps, estimated position and velocity should be close to truth
+	double est_pos = kf.state()[0];
+	double est_vel = kf.state()[1];
+
+	if (!(near(est_pos, 49.0, 2.0)))
+		throw std::runtime_error("test failed: kalman position estimate");
+	if (!(near(est_vel, 1.0, 0.3)))
+		throw std::runtime_error("test failed: kalman velocity estimate");
+
+	std::cout << "  kalman_constant_velocity: passed (pos=" << est_pos
+	          << ", vel=" << est_vel << ")\n";
+}
+
+void test_kalman_validation() {
+	bool caught = false;
+	try { KalmanFilter<double> kf(0, 1); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: kalman should reject state_dim=0");
+
+	caught = false;
+	try { KalmanFilter<double> kf(2, 0); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: kalman should reject meas_dim=0");
+
+	std::cout << "  kalman_validation: passed\n";
+}
+
+// ========== LMS Tests ==========
+
+void test_lms_converges_to_known_filter() {
+	// Setup: an "unknown" filter that we'll try to learn via LMS.
+	// Unknown impulse response: [0.5, -0.3, 0.2]
+	mtl::vec::dense_vector<double> unknown({0.5, -0.3, 0.2});
+
+	LMSFilter<double> lms(3, 0.1);
+
+	// Generate training data: random input, desired = unknown filter applied
+	std::mt19937 gen(42);
+	std::uniform_real_distribution<double> dist(-1.0, 1.0);
+
+	mtl::vec::dense_vector<double> delay(3, 0.0);
+	for (int n = 0; n < 5000; ++n) {
+		double x = dist(gen);
+		// Compute desired output from unknown filter
+		delay[2] = delay[1]; delay[1] = delay[0]; delay[0] = x;
+		double d = unknown[0] * delay[0] + unknown[1] * delay[1] + unknown[2] * delay[2];
+		lms.process(x, d);
+	}
+
+	// Weights should converge close to the unknown filter
+	const auto& w = lms.weights();
+	if (!(near(w[0], 0.5, 0.05))) throw std::runtime_error("test failed: LMS w[0]");
+	if (!(near(w[1], -0.3, 0.05))) throw std::runtime_error("test failed: LMS w[1]");
+	if (!(near(w[2], 0.2, 0.05))) throw std::runtime_error("test failed: LMS w[2]");
+
+	std::cout << "  lms_converges: passed (w=[" << w[0] << ", " << w[1] << ", " << w[2] << "])\n";
+}
+
+void test_lms_reset() {
+	LMSFilter<double> lms(4, 0.1);
+	for (int i = 0; i < 100; ++i) lms.process(0.5, 1.0);
+	if (!(lms.weights()[0] != 0.0))
+		throw std::runtime_error("test failed: LMS weights should be non-zero after training");
+	lms.reset();
+	if (!(lms.weights()[0] == 0.0))
+		throw std::runtime_error("test failed: LMS reset weights to zero");
+
+	std::cout << "  lms_reset: passed\n";
+}
+
+void test_nlms() {
+	NLMSFilter<double> nlms(3, 0.5, 1e-6);
+
+	mtl::vec::dense_vector<double> unknown({0.5, -0.3, 0.2});
+	std::mt19937 gen(42);
+	std::uniform_real_distribution<double> dist(-1.0, 1.0);
+
+	mtl::vec::dense_vector<double> delay(3, 0.0);
+	for (int n = 0; n < 2000; ++n) {
+		double x = dist(gen);
+		delay[2] = delay[1]; delay[1] = delay[0]; delay[0] = x;
+		double d = unknown[0] * delay[0] + unknown[1] * delay[1] + unknown[2] * delay[2];
+		nlms.process(x, d);
+	}
+
+	// NLMS should converge faster than LMS
+	const auto& w = nlms.weights();
+	if (!(near(w[0], 0.5, 0.05))) throw std::runtime_error("test failed: NLMS w[0]");
+	if (!(near(w[1], -0.3, 0.05))) throw std::runtime_error("test failed: NLMS w[1]");
+	if (!(near(w[2], 0.2, 0.05))) throw std::runtime_error("test failed: NLMS w[2]");
+
+	std::cout << "  nlms: passed\n";
+}
+
+// ========== RLS Tests ==========
+
+void test_rls_converges_fast() {
+	// RLS should converge much faster than LMS for the same problem
+	mtl::vec::dense_vector<double> unknown({0.5, -0.3, 0.2});
+
+	RLSFilter<double> rls(3, 0.99, 1000.0);
+
+	std::mt19937 gen(42);
+	std::uniform_real_distribution<double> dist(-1.0, 1.0);
+
+	mtl::vec::dense_vector<double> delay(3, 0.0);
+	for (int n = 0; n < 100; ++n) {  // RLS needs far fewer samples than LMS
+		double x = dist(gen);
+		delay[2] = delay[1]; delay[1] = delay[0]; delay[0] = x;
+		double d = unknown[0] * delay[0] + unknown[1] * delay[1] + unknown[2] * delay[2];
+		rls.process(x, d);
+	}
+
+	const auto& w = rls.weights();
+	if (!(near(w[0], 0.5, 0.01))) throw std::runtime_error("test failed: RLS w[0]");
+	if (!(near(w[1], -0.3, 0.01))) throw std::runtime_error("test failed: RLS w[1]");
+	if (!(near(w[2], 0.2, 0.01))) throw std::runtime_error("test failed: RLS w[2]");
+
+	std::cout << "  rls_converges_fast: passed (100 samples, w=[" << w[0] << ", "
+	          << w[1] << ", " << w[2] << "])\n";
+}
+
+void test_rls_validation() {
+	bool caught = false;
+	try { RLSFilter<double> rls(0, 0.99); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: RLS should reject num_taps=0");
+
+	caught = false;
+	try { RLSFilter<double> rls(4, 1.5); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: RLS should reject lambda > 1");
+
+	caught = false;
+	try { RLSFilter<double> rls(4, 0.0); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: RLS should reject lambda = 0");
+
+	std::cout << "  rls_validation: passed\n";
+}
+
+int main() {
+	try {
+		std::cout << "Estimation Tests\n";
+
+		test_kalman_construction();
+		test_kalman_constant_velocity();
+		test_kalman_validation();
+		test_lms_converges_to_known_filter();
+		test_lms_reset();
+		test_nlms();
+		test_rls_converges_fast();
+		test_rls_validation();
+
+		std::cout << "All estimation tests passed.\n";
+		return 0;
+	} catch (const std::exception& e) {
+		std::cerr << "FAILED: " << e.what() << '\n';
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary
State estimation and adaptive filtering: Linear Kalman filter, LMS/NLMS/RLS adaptive filters.

## Changes
- `estimation/kalman.hpp` — KalmanFilter<T> with mtl::dense2D system matrices
- `estimation/lms.hpp` — LMSFilter<T>, NLMSFilter<T> with circular delay line
- `estimation/rls.hpp` — RLSFilter<T> with forgetting factor and P matrix update
- `estimation/estimation.hpp` — umbrella
- `tests/test_kalman.cpp` — 8 tests

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| all tests | OK | 15/15 PASS | OK | 15/15 PASS |

## Notes
- EKF (Extended Kalman) and UKF (Unscented Kalman) deferred — they need user-provided Jacobian functions and sigma point generation respectively, and warrant their own follow-up work.

Resolves #7

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Kalman Filter for linear state estimation with configurable system matrices and noise parameters
  * Introduced LMS adaptive filter for real-time FIR coefficient learning
  * Introduced NLMS adaptive filter with normalized step-size adaptation
  * Introduced RLS adaptive filter with forgetting factor support for accelerated convergence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->