### PR TITLE
feat(image): planar image processing with convolution, morphology, edge detection

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -19,7 +19,7 @@ add_subdirectory(iir_demo)
 # add_subdirectory(estimation_demo)
 
 # Phase 10: Image processing
-# add_subdirectory(image_demo)
+add_subdirectory(image_demo)
 
 # Phase 8: Signal conditioning
 # add_subdirectory(conditioning_demo)

--- a/applications/image_demo/CMakeLists.txt
+++ b/applications/image_demo/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(edge_detection edge_detection.cpp)
+target_link_libraries(edge_detection PRIVATE sw::dsp)

--- a/applications/image_demo/edge_detection.cpp
+++ b/applications/image_demo/edge_detection.cpp
@@ -1,0 +1,167 @@
+// edge_detection.cpp: edge detection demonstration
+//
+// Demonstrates Sobel and Canny edge detection on synthetic test images,
+// showing the planar Image<T,C> container, border handling, and
+// morphological operations.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/image/image.hpp>
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+using namespace sw::dsp;
+
+void print_separator(const std::string& title) {
+	std::cout << "\n" << std::string(60, '=') << "\n";
+	std::cout << "  " << title << "\n";
+	std::cout << std::string(60, '=') << "\n\n";
+}
+
+// Print a dense2D matrix as a text-art visualization
+template <typename T>
+void print_image(const mtl::mat::dense2D<T>& img, const std::string& label,
+                 int width = 6, int precision = 2) {
+	std::cout << label << " (" << img.num_rows() << "x" << img.num_cols() << "):\n";
+	for (std::size_t r = 0; r < img.num_rows(); ++r) {
+		std::cout << "  ";
+		for (std::size_t c = 0; c < img.num_cols(); ++c) {
+			std::cout << std::setw(width) << std::fixed
+			          << std::setprecision(precision)
+			          << static_cast<double>(img(r, c));
+		}
+		std::cout << "\n";
+	}
+	std::cout << "\n";
+}
+
+// Print a binary edge map as ASCII art
+template <typename T>
+void print_edge_map(const mtl::mat::dense2D<T>& edges, const std::string& label) {
+	std::cout << label << " (" << edges.num_rows() << "x" << edges.num_cols() << "):\n";
+	for (std::size_t r = 0; r < edges.num_rows(); ++r) {
+		std::cout << "  ";
+		for (std::size_t c = 0; c < edges.num_cols(); ++c) {
+			std::cout << (static_cast<double>(edges(r, c)) > 0.5 ? "#" : ".");
+		}
+		std::cout << "\n";
+	}
+	std::cout << "\n";
+}
+
+int main() {
+	print_separator("Edge Detection Demo");
+	std::cout << "Planar image processing with sw::dsp\n\n";
+
+	// --- Step Edge ---
+	print_separator("1. Step Edge: Sobel Gradient");
+
+	std::size_t rows = 12, cols = 16;
+	mtl::mat::dense2D<double> step(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			step(r, c) = (c >= cols / 2) ? 1.0 : 0.0;
+
+	print_image(step, "Input: step edge");
+
+	auto gx = sobel_x(step);
+	auto gy = sobel_y(step);
+	auto mag = gradient_magnitude(gx, gy);
+
+	print_image(gx, "Sobel X (horizontal gradient)");
+	print_image(mag, "Gradient magnitude");
+
+	// --- Canny on Step Edge ---
+	print_separator("2. Canny Edge Detection");
+
+	auto edges = canny(step, 0.5, 1.5, 0.8);
+	print_edge_map(edges, "Canny edges");
+
+	// --- Checkerboard Pattern ---
+	print_separator("3. Checkerboard: Morphological Gradient");
+
+	std::size_t brows = 8, bcols = 8;
+	mtl::mat::dense2D<double> checker(brows, bcols);
+	for (std::size_t r = 0; r < brows; ++r)
+		for (std::size_t c = 0; c < bcols; ++c)
+			checker(r, c) = ((r / 2 + c / 2) % 2 == 0) ? 1.0 : 0.0;
+
+	print_image(checker, "Input: checkerboard");
+
+	auto elem = make_rect_element(3, 3);
+	auto morph_grad = morphological_gradient(checker, elem);
+	print_image(morph_grad, "Morphological gradient");
+
+	// --- Gaussian Blur ---
+	print_separator("4. Gaussian Blur");
+
+	mtl::mat::dense2D<double> impulse(7, 7);
+	for (std::size_t r = 0; r < 7; ++r)
+		for (std::size_t c = 0; c < 7; ++c)
+			impulse(r, c) = 0.0;
+	impulse(3, 3) = 1.0;
+
+	print_image(impulse, "Input: impulse");
+	auto blurred = gaussian_blur(impulse, 1.0);
+	print_image(blurred, "Gaussian blur (sigma=1.0)", 8, 4);
+
+	// --- RGB Multi-channel Processing ---
+	print_separator("5. Multi-Channel Processing");
+
+	RGBImage<double> rgb(6, 6);
+	for (std::size_t r = 0; r < 6; ++r) {
+		for (std::size_t c = 0; c < 6; ++c) {
+			rgb[0](r, c) = (c >= 3) ? 1.0 : 0.0;  // R: step at col 3
+			rgb[1](r, c) = (r >= 3) ? 1.0 : 0.0;  // G: step at row 3
+			rgb[2](r, c) = 0.5;                     // B: constant
+		}
+	}
+
+	std::cout << "RGB image (6x6): R=horizontal step, G=vertical step, B=constant\n\n";
+
+	auto gray = rgb_to_gray(rgb);
+	print_image(gray, "Grayscale (BT.601 luminance)");
+
+	auto gray_edges = canny(gray, 0.1, 0.3, 0.8);
+	print_edge_map(gray_edges, "Canny edges on grayscale");
+
+	// Per-channel Sobel
+	auto rgb_gx = apply_per_channel(rgb, [](const mtl::mat::dense2D<double>& plane) {
+		return sobel_x(plane);
+	});
+
+	std::cout << "Per-channel Sobel X:\n";
+	print_image(rgb_gx[0], "  R channel Sobel X");
+	print_image(rgb_gx[1], "  G channel Sobel X");
+	print_image(rgb_gx[2], "  B channel Sobel X");
+
+	// --- Border Mode Comparison ---
+	print_separator("6. Border Mode Comparison");
+
+	mtl::mat::dense2D<double> small(1, 5);
+	small(0, 0) = 10; small(0, 1) = 20; small(0, 2) = 30;
+	small(0, 3) = 40; small(0, 4) = 50;
+
+	std::cout << "Input: [10, 20, 30, 40, 50]\n\n";
+	std::cout << "Pixel at index -1 by border mode:\n";
+	std::cout << "  Zero:        " << fetch_pixel(small, 0, -1, BorderMode::zero) << "\n";
+	std::cout << "  Replicate:   " << fetch_pixel(small, 0, -1, BorderMode::replicate) << "\n";
+	std::cout << "  Reflect:     " << fetch_pixel(small, 0, -1, BorderMode::reflect) << "\n";
+	std::cout << "  Reflect_101: " << fetch_pixel(small, 0, -1, BorderMode::reflect_101) << "\n";
+	std::cout << "  Wrap:        " << fetch_pixel(small, 0, -1, BorderMode::wrap) << "\n";
+
+	std::cout << "\nPixel at index 5 by border mode:\n";
+	std::cout << "  Zero:        " << fetch_pixel(small, 0, 5, BorderMode::zero) << "\n";
+	std::cout << "  Replicate:   " << fetch_pixel(small, 0, 5, BorderMode::replicate) << "\n";
+	std::cout << "  Reflect:     " << fetch_pixel(small, 0, 5, BorderMode::reflect) << "\n";
+	std::cout << "  Reflect_101: " << fetch_pixel(small, 0, 5, BorderMode::reflect_101) << "\n";
+	std::cout << "  Wrap:        " << fetch_pixel(small, 0, 5, BorderMode::wrap) << "\n";
+
+	print_separator("Done");
+
+	return 0;
+}

--- a/docs/assessments/image-api-opencv-comparison.md
+++ b/docs/assessments/image-api-opencv-comparison.md
@@ -1,0 +1,253 @@
+# Image Processing API: OpenCV Comparison and Design Decisions
+
+**Date:** 2026-04-12
+**Context:** Design assessment for `sw::dsp` image processing module (Issue #8)
+
+---
+
+## 1. OpenCV's Image Processing API
+
+### 1.1 Image Container: `cv::Mat`
+
+OpenCV's core container is `cv::Mat` — a reference-counted N-dimensional dense array.
+
+**Key characteristics:**
+- **Interleaved memory layout** — channels are packed per pixel: `B0 G0 R0 B1 G1 R1 ...`
+- **BGR channel order** — historical artifact from early camera driver conventions
+- **Runtime type encoding** — `CV_MAKETYPE(depth, channels)` produces an integer type code (e.g., `CV_8UC3` = 3-channel 8-bit unsigned). No compile-time type safety on depth or channel count.
+- **Row-major with optional padding** — `step[0]` may exceed `cols * elemSize` for alignment
+- **Up to 512 channels** supported (`CV_CN_MAX`)
+
+**Channel decomposition:**
+```cpp
+// Split interleaved BGR into 3 separate single-channel Mats (full copy)
+std::vector<cv::Mat> planes;
+cv::split(bgr_image, planes);   // planes[0]=B, planes[1]=G, planes[2]=R
+
+// Merge back (full copy)
+cv::Mat merged;
+cv::merge(planes, merged);
+```
+
+`split()` and `merge()` perform full memory copies. This is the canonical path whenever a single-channel algorithm (e.g., Canny) must be applied to a color image.
+
+### 1.2 2D Convolution
+
+```cpp
+void cv::filter2D(InputArray src, OutputArray dst, int ddepth,
+                  InputArray kernel, Point anchor = Point(-1,-1),
+                  double delta = 0, int borderType = BORDER_DEFAULT);
+```
+
+- The same kernel is applied to every channel independently (no cross-channel coupling).
+- `ddepth` controls output precision at runtime (e.g., `CV_16S` for derivative filters on `CV_8U` input).
+- Internally switches to DFT-based convolution for large kernels.
+
+**Separable variant:**
+```cpp
+void cv::sepFilter2D(InputArray src, OutputArray dst, int ddepth,
+                     InputArray kernelX, InputArray kernelY,
+                     Point anchor = Point(-1,-1), double delta = 0,
+                     int borderType = BORDER_DEFAULT);
+```
+
+Applies row filter then column filter — O(k) per pixel instead of O(k²).
+
+### 1.3 Morphological Operations
+
+```cpp
+void cv::erode(InputArray src, OutputArray dst, InputArray kernel, ...);
+void cv::dilate(InputArray src, OutputArray dst, InputArray kernel, ...);
+void cv::morphologyEx(InputArray src, OutputArray dst, int op, InputArray kernel, ...);
+```
+
+- Structuring elements created via `cv::getStructuringElement(shape, ksize)` with `MORPH_RECT`, `MORPH_CROSS`, `MORPH_ELLIPSE`.
+- `morphologyEx` provides compound operations: `MORPH_OPEN`, `MORPH_CLOSE`, `MORPH_GRADIENT`, `MORPH_TOPHAT`, `MORPH_BLACKHAT`, `MORPH_HITMISS`.
+- Multi-channel: operates per channel independently. `MORPH_HITMISS` requires single-channel.
+
+### 1.4 Edge Detection
+
+```cpp
+void cv::Sobel(InputArray src, OutputArray dst, int ddepth,
+               int dx, int dy, int ksize = 3, ...);
+
+void cv::Canny(InputArray image, OutputArray edges,
+               double threshold1, double threshold2,
+               int apertureSize = 3, bool L2gradient = false);
+```
+
+- Sobel works on multi-channel images (per channel independently).
+- **Canny requires single-channel input** — users must convert to grayscale or `split()` first.
+- A second Canny overload accepts pre-computed gradient images `(dx, dy)`.
+
+### 1.5 Border Handling
+
+| Mode | Behavior | Default for |
+|------|----------|-------------|
+| `BORDER_CONSTANT` | Pad with fixed value | Morphology (max for erode, 0 for dilate) |
+| `BORDER_REPLICATE` | Clamp to edge pixel | — |
+| `BORDER_REFLECT` | Mirror including edge | — |
+| `BORDER_REFLECT_101` | Mirror excluding edge | Convolution (`BORDER_DEFAULT`) |
+| `BORDER_WRAP` | Periodic tiling | — |
+| `BORDER_TRANSPARENT` | Leave dst unchanged at borders | — |
+
+### 1.6 Design Philosophy Summary
+
+1. **Interleaved, not planar** — channels packed per pixel; decomposition is explicit via `split()`
+2. **Per-channel independence** — convolution and morphology apply the same kernel to each channel
+3. **Output depth is explicit** — `ddepth` parameter for precision control
+4. **In-place allowed** — `src` and `dst` can alias; temp allocated internally
+5. **Separability is first-class** — `sepFilter2D` and Sobel's internal use
+6. **Runtime type system** — integer-encoded depth+channels, no compile-time safety
+7. **Standardized border handling** — single enum across all spatial filters
+
+---
+
+## 2. Our Planned API (`sw::dsp`)
+
+### 2.1 Image Container: Planar `Image<T, Channels>`
+
+We use `mtl::mat::dense2D<T>` as the single-channel image primitive, wrapped in a thin multi-channel container:
+
+```cpp
+template <DspField T, std::size_t Channels = 1>
+struct Image {
+    std::array<mtl::mat::dense2D<T>, Channels> planes;
+
+    std::size_t rows() const { return planes[0].num_rows(); }
+    std::size_t cols() const { return planes[0].num_cols(); }
+
+    dense2D<T>&       operator[](std::size_t c)       { return planes[c]; }
+    const dense2D<T>& operator[](std::size_t c) const { return planes[c]; }
+};
+
+// Convenience aliases
+template <typename T> using GrayImage = Image<T, 1>;
+template <typename T> using RGBImage  = Image<T, 3>;
+template <typename T> using RGBAImage = Image<T, 4>;
+```
+
+**Rationale for planar layout:**
+- Consistent with MTL5 — `dense2D<T>` is our container; no new 3D tensor needed
+- Consistent with our audio pattern — stereo WAV already uses separate `dense_vector<T>` per channel
+- All single-channel algorithms work directly — `convolve2d(img[0], kernel)` with no adaptation
+- No split/merge copy cost — channels are already separate planes
+- Cache-friendly for DSP — filtering processes one channel at a time; each plane is contiguous
+- Mixed precision per channel — `Image<posit<16,1>, 3>` for color, `Image<uint8_t, 1>` for alpha
+
+### 2.2 Core Functions Operate on Single Planes
+
+All core algorithms accept `dense2D<T>` (single channel):
+
+```cpp
+// 2D convolution
+template <DspField T, DspField K>
+dense2D<T> convolve2d(const dense2D<T>& image, const dense2D<K>& kernel,
+                      BorderMode border = BorderMode::reflect_101);
+
+// Separable filter
+template <DspField T, DspField K>
+dense2D<T> separable_filter(const dense2D<T>& image,
+                            const dense_vector<K>& row_kernel,
+                            const dense_vector<K>& col_kernel,
+                            BorderMode border = BorderMode::reflect_101);
+
+// Morphology
+template <DspOrderedField T>
+dense2D<T> erode(const dense2D<T>& image, const dense2D<bool>& element);
+
+template <DspOrderedField T>
+dense2D<T> dilate(const dense2D<T>& image, const dense2D<bool>& element);
+
+// Edge detection
+template <DspField T, DspField K = double>
+dense2D<T> sobel_x(const dense2D<T>& image, int ksize = 3);
+
+template <DspField T>
+dense2D<bool> canny(const dense2D<T>& image,
+                    double low_threshold, double high_threshold,
+                    int aperture = 3);
+```
+
+A convenience helper applies any function across all channels:
+
+```cpp
+template <DspField T, std::size_t C, typename Func>
+Image<T, C> apply_per_channel(const Image<T, C>& img, Func&& func) {
+    Image<T, C> result;
+    for (std::size_t i = 0; i < C; ++i)
+        result[i] = func(img[i]);
+    return result;
+}
+```
+
+### 2.3 Border Handling
+
+```cpp
+enum class BorderMode {
+    zero,          // pad with T{0}
+    constant,      // pad with user-specified value
+    replicate,     // clamp to edge
+    reflect,       // mirror including edge pixel
+    reflect_101,   // mirror excluding edge pixel (default)
+    wrap           // periodic
+};
+```
+
+### 2.4 RGBA Channel Handling
+
+Alpha is fundamentally different from color channels — it is a mask/weight, not a signal. Planar layout makes this distinction natural:
+
+- **Filter RGB, preserve alpha:** process only `img[0..2]`, leave `img[3]` untouched
+- **Filter alpha separately:** apply different parameters (e.g., binary morphology on alpha mask)
+- **Alpha blending:** per-pixel operation across planes, straightforward with planar access
+- **Mixed types:** color channels as `posit<16,1>`, alpha as `uint8_t` — possible with separate `Image` instances
+
+---
+
+## 3. Comparison Matrix
+
+| Aspect | OpenCV | `sw::dsp` | Advantage |
+|--------|--------|-----------|-----------|
+| **Type safety** | Runtime integers (`CV_8UC3`) | Compile-time templates (`Image<T, C>`) | `sw::dsp` — type errors caught at compile time |
+| **Memory layout** | Interleaved (pixel-packed) | Planar (channel-separated) | `sw::dsp` — no split/merge cost for per-channel DSP |
+| **Mixed precision** | Runtime `ddepth` parameter | Template parameters `T`, `K` | `sw::dsp` — kernel, image, and output types independent at compile time |
+| **Channel handling** | Implicit (same kernel per channel) | Explicit (operate on planes) | Trade-off: OpenCV is more concise for simple cases; ours is more flexible |
+| **Border modes** | 7 modes including `TRANSPARENT` | 6 modes (no transparent/isolated) | OpenCV — more modes, but ours covers all DSP-relevant cases |
+| **Separability** | `sepFilter2D` | `separable_filter` | Equivalent |
+| **Canny input** | Single-channel only | Single-channel only | Equivalent — but our planar layout means no `split()` needed |
+| **In-place operation** | Supported (internal temp) | Not planned (functional style) | OpenCV — saves allocation for large images |
+| **Arithmetic types** | `float`, `double`, `uint8_t`, etc. | Any `DspField` including Universal types | `sw::dsp` — posit, cfloat, fixpnt, half, etc. |
+| **BGR convention** | Yes (historical) | No — RGB by convention | `sw::dsp` — no legacy baggage |
+| **Dependencies** | Large runtime library | Header-only, MTL5 only | `sw::dsp` — embeddable, no link-time cost |
+
+---
+
+## 4. What We Should Add (Improvements Over Current Issue #8)
+
+1. **`Image<T, Channels>` thin wrapper** in `image.hpp` — not a heavy class, just `std::array<dense2D<T>, C>` with accessors
+2. **`BorderMode::replicate` and `BorderMode::reflect_101`** — OpenCV's default and most useful mode; our original issue only had zero-pad, reflect, wrap
+3. **`apply_per_channel()` helper** — convenience for bulk per-plane operations
+4. **Color space utilities** — `rgb_to_gray<T>()` (weighted sum: 0.299R + 0.587G + 0.114B)
+5. **Structuring element factory** — `make_rect_element(rows, cols)`, `make_cross_element(size)`, `make_ellipse_element(size)`
+6. **Compound morphology** — `open()`, `close()`, `gradient()`, `tophat()`, `blackhat()` built from `erode()`/`dilate()`
+
+### What We Intentionally Omit
+
+- **In-place operation** — functional style (return new matrix) is safer and easier to reason about; the allocation cost is acceptable for our use cases
+- **DFT-accelerated large-kernel convolution** — can be added later; spatial-domain convolution covers typical kernel sizes (3×3 to 15×15)
+- **`BORDER_TRANSPARENT`** — niche; not needed for standard DSP workflows
+- **Runtime type dispatch** — we use templates; no need for OpenCV's `switch(depth)` pattern
+
+---
+
+## 5. Conclusion
+
+Our planar `Image<T, Channels>` design is a better fit than OpenCV's interleaved `cv::Mat` for a DSP-focused library because:
+
+1. **Per-channel processing is the dominant pattern** in image filtering — planar layout avoids the split/merge overhead that OpenCV pays
+2. **Mixed-precision parameterization** is our core value proposition — template-based typing is superior to runtime `ddepth` for this purpose
+3. **Consistency with MTL5 and our audio API** — the same container philosophy (`dense2D`, `dense_vector`) across all domains
+4. **Alpha channel is naturally decoupled** — treated as a separate plane rather than forced into the same interleaved structure
+
+The main trade-off is that per-pixel operations (color space conversion, alpha blending) require iterating across planes rather than reading contiguous pixel structs. This is acceptable because these operations are memory-bound and the stride cost is negligible compared to the flexibility gained.

--- a/docs/assessments/image-api-opencv-comparison.md
+++ b/docs/assessments/image-api-opencv-comparison.md
@@ -164,9 +164,10 @@ template <DspField T, DspField K = double>
 dense2D<T> sobel_x(const dense2D<T>& image, int ksize = 3);
 
 template <DspField T>
-dense2D<bool> canny(const dense2D<T>& image,
-                    double low_threshold, double high_threshold,
-                    int aperture = 3);
+    requires ConvertibleToDouble<T>
+dense2D<T> canny(const dense2D<T>& image,
+                 double low_threshold, double high_threshold,
+                 double sigma = 1.0);
 ```
 
 A convenience helper applies any function across all channels:

--- a/include/sw/dsp/image/convolve2d.hpp
+++ b/include/sw/dsp/image/convolve2d.hpp
@@ -1,34 +1,41 @@
 #pragma once
-// convolve2d.hpp: 2D spatial convolution
+// convolve2d.hpp: 2D spatial convolution (correlation)
 //
 // Applies a 2D kernel to a single-channel image with configurable
 // border handling. The kernel type K can differ from the image type T
 // to support mixed-precision convolution.
 //
+// Note: this implements correlation (no kernel flip), which is the
+// standard convention for image processing. All common kernels
+// (Gaussian, Sobel, box) are symmetric or designed for correlation.
+// For true convolution, pre-flip the kernel before calling.
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
 #include <cstddef>
+#include <type_traits>
 #include <mtl/mat/dense2D.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
 #include <sw/dsp/image/image.hpp>
 
 namespace sw::dsp {
 
-// 2D spatial convolution.
+// 2D spatial correlation with mixed-precision accumulation.
 //
-// Convolves image with kernel using the specified border mode.
-// The kernel is applied in correlation order (no flip); pass a
-// pre-flipped kernel if true convolution is needed.
+// Accumulates in std::common_type_t<T, K> to preserve kernel precision,
+// then casts to T when writing the output pixel.
 //
 // Template parameters:
-//   T: image pixel type
+//   T: image pixel type (output type)
 //   K: kernel coefficient type (may differ for mixed precision)
 template <DspField T, DspField K>
 mtl::mat::dense2D<T> convolve2d(const mtl::mat::dense2D<T>& image,
                                 const mtl::mat::dense2D<K>& kernel,
                                 BorderMode border = BorderMode::reflect_101,
                                 T pad = T{}) {
+	using acc_t = std::common_type_t<T, K>;
+
 	std::size_t rows = image.num_rows();
 	std::size_t cols = image.num_cols();
 	std::size_t krows = kernel.num_rows();
@@ -40,16 +47,17 @@ mtl::mat::dense2D<T> convolve2d(const mtl::mat::dense2D<T>& image,
 
 	for (std::size_t r = 0; r < rows; ++r) {
 		for (std::size_t c = 0; c < cols; ++c) {
-			T sum{};
+			acc_t sum{};
 			for (std::size_t ki = 0; ki < krows; ++ki) {
 				for (std::size_t kj = 0; kj < kcols; ++kj) {
 					int ir = static_cast<int>(r) + static_cast<int>(ki) - kr;
 					int ic = static_cast<int>(c) + static_cast<int>(kj) - kc;
-					T pixel = fetch_pixel(image, ir, ic, border, pad);
-					sum = sum + static_cast<T>(kernel(ki, kj)) * pixel;
+					acc_t pixel = static_cast<acc_t>(
+						fetch_pixel(image, ir, ic, border, pad));
+					sum = sum + static_cast<acc_t>(kernel(ki, kj)) * pixel;
 				}
 			}
-			result(r, c) = sum;
+			result(r, c) = static_cast<T>(sum);
 		}
 	}
 	return result;

--- a/include/sw/dsp/image/convolve2d.hpp
+++ b/include/sw/dsp/image/convolve2d.hpp
@@ -1,0 +1,69 @@
+#pragma once
+// convolve2d.hpp: 2D spatial convolution
+//
+// Applies a 2D kernel to a single-channel image with configurable
+// border handling. The kernel type K can differ from the image type T
+// to support mixed-precision convolution.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <mtl/mat/dense2D.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/image/image.hpp>
+
+namespace sw::dsp {
+
+// 2D spatial convolution.
+//
+// Convolves image with kernel using the specified border mode.
+// The kernel is applied in correlation order (no flip); pass a
+// pre-flipped kernel if true convolution is needed.
+//
+// Template parameters:
+//   T: image pixel type
+//   K: kernel coefficient type (may differ for mixed precision)
+template <DspField T, DspField K>
+mtl::mat::dense2D<T> convolve2d(const mtl::mat::dense2D<T>& image,
+                                const mtl::mat::dense2D<K>& kernel,
+                                BorderMode border = BorderMode::reflect_101,
+                                T pad = T{}) {
+	std::size_t rows = image.num_rows();
+	std::size_t cols = image.num_cols();
+	std::size_t krows = kernel.num_rows();
+	std::size_t kcols = kernel.num_cols();
+	int kr = static_cast<int>(krows / 2);
+	int kc = static_cast<int>(kcols / 2);
+
+	mtl::mat::dense2D<T> result(rows, cols);
+
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			T sum{};
+			for (std::size_t ki = 0; ki < krows; ++ki) {
+				for (std::size_t kj = 0; kj < kcols; ++kj) {
+					int ir = static_cast<int>(r) + static_cast<int>(ki) - kr;
+					int ic = static_cast<int>(c) + static_cast<int>(kj) - kc;
+					T pixel = fetch_pixel(image, ir, ic, border, pad);
+					sum = sum + static_cast<T>(kernel(ki, kj)) * pixel;
+				}
+			}
+			result(r, c) = sum;
+		}
+	}
+	return result;
+}
+
+// Convenience: convolve all channels of a multi-channel image.
+template <DspField T, std::size_t C, DspField K>
+Image<T, C> convolve2d(const Image<T, C>& img,
+                       const mtl::mat::dense2D<K>& kernel,
+                       BorderMode border = BorderMode::reflect_101,
+                       T pad = T{}) {
+	return apply_per_channel(img, [&](const mtl::mat::dense2D<T>& plane) {
+		return convolve2d(plane, kernel, border, pad);
+	});
+}
+
+} // namespace sw::dsp

--- a/include/sw/dsp/image/edge.hpp
+++ b/include/sw/dsp/image/edge.hpp
@@ -1,0 +1,260 @@
+#pragma once
+// edge.hpp: edge detection operators
+//
+// Sobel, Prewitt gradient operators; gradient magnitude;
+// Canny edge detector with non-maximum suppression and hysteresis.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <mtl/mat/dense2D.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/image/image.hpp>
+#include <sw/dsp/image/convolve2d.hpp>
+#include <sw/dsp/image/separable.hpp>
+
+namespace sw::dsp {
+
+// ---------- Gradient operators ----------
+
+// Sobel gradient in the X direction (horizontal edges).
+// ksize: 3 (default). Uses separable decomposition.
+template <DspField T>
+mtl::mat::dense2D<T> sobel_x(const mtl::mat::dense2D<T>& image,
+                              BorderMode border = BorderMode::reflect_101) {
+	// Sobel X kernel:  [-1 0 1; -2 0 2; -1 0 1]
+	// Separable: row=[-1,0,1] (horizontal derivative), col=[1,2,1] (vertical smooth)
+	mtl::vec::dense_vector<T> row_kernel(3);
+	row_kernel[0] = static_cast<T>(-1);
+	row_kernel[1] = static_cast<T>(0);
+	row_kernel[2] = static_cast<T>(1);
+
+	mtl::vec::dense_vector<T> col_kernel(3);
+	col_kernel[0] = static_cast<T>(1);
+	col_kernel[1] = static_cast<T>(2);
+	col_kernel[2] = static_cast<T>(1);
+
+	return separable_filter(image, row_kernel, col_kernel, border);
+}
+
+// Sobel gradient in the Y direction (vertical edges).
+template <DspField T>
+mtl::mat::dense2D<T> sobel_y(const mtl::mat::dense2D<T>& image,
+                              BorderMode border = BorderMode::reflect_101) {
+	// Sobel Y kernel: [-1 -2 -1; 0 0 0; 1 2 1]
+	// Separable: row=[1,2,1] (horizontal smooth), col=[-1,0,1] (vertical derivative)
+	mtl::vec::dense_vector<T> row_kernel(3);
+	row_kernel[0] = static_cast<T>(1);
+	row_kernel[1] = static_cast<T>(2);
+	row_kernel[2] = static_cast<T>(1);
+
+	mtl::vec::dense_vector<T> col_kernel(3);
+	col_kernel[0] = static_cast<T>(-1);
+	col_kernel[1] = static_cast<T>(0);
+	col_kernel[2] = static_cast<T>(1);
+
+	return separable_filter(image, row_kernel, col_kernel, border);
+}
+
+// Prewitt gradient in the X direction.
+template <DspField T>
+mtl::mat::dense2D<T> prewitt_x(const mtl::mat::dense2D<T>& image,
+                                BorderMode border = BorderMode::reflect_101) {
+	// Prewitt X kernel: [-1 0 1; -1 0 1; -1 0 1]
+	// Separable: row=[-1,0,1] (horizontal derivative), col=[1,1,1] (vertical smooth)
+	mtl::vec::dense_vector<T> row_kernel(3);
+	row_kernel[0] = static_cast<T>(-1);
+	row_kernel[1] = static_cast<T>(0);
+	row_kernel[2] = static_cast<T>(1);
+
+	mtl::vec::dense_vector<T> col_kernel(3);
+	col_kernel[0] = static_cast<T>(1);
+	col_kernel[1] = static_cast<T>(1);
+	col_kernel[2] = static_cast<T>(1);
+
+	return separable_filter(image, row_kernel, col_kernel, border);
+}
+
+// Prewitt gradient in the Y direction.
+template <DspField T>
+mtl::mat::dense2D<T> prewitt_y(const mtl::mat::dense2D<T>& image,
+                                BorderMode border = BorderMode::reflect_101) {
+	// Prewitt Y kernel: [-1 -1 -1; 0 0 0; 1 1 1]
+	// Separable: row=[1,1,1] (horizontal smooth), col=[-1,0,1] (vertical derivative)
+	mtl::vec::dense_vector<T> row_kernel(3);
+	row_kernel[0] = static_cast<T>(1);
+	row_kernel[1] = static_cast<T>(1);
+	row_kernel[2] = static_cast<T>(1);
+
+	mtl::vec::dense_vector<T> col_kernel(3);
+	col_kernel[0] = static_cast<T>(-1);
+	col_kernel[1] = static_cast<T>(0);
+	col_kernel[2] = static_cast<T>(1);
+
+	return separable_filter(image, row_kernel, col_kernel, border);
+}
+
+// Gradient magnitude: sqrt(gx^2 + gy^2)
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> gradient_magnitude(const mtl::mat::dense2D<T>& gx,
+                                        const mtl::mat::dense2D<T>& gy) {
+	std::size_t rows = gx.num_rows();
+	std::size_t cols = gx.num_cols();
+	mtl::mat::dense2D<T> mag(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			using std::sqrt;
+			double dx = static_cast<double>(gx(r, c));
+			double dy = static_cast<double>(gy(r, c));
+			mag(r, c) = static_cast<T>(sqrt(dx * dx + dy * dy));
+		}
+	}
+	return mag;
+}
+
+// ---------- Canny edge detector ----------
+
+// Canny edge detection with non-maximum suppression and hysteresis.
+//
+// Returns a binary edge map where edge pixels are T{1} and non-edges are T{0}.
+// Operates on single-channel (grayscale) input only.
+//
+// Parameters:
+//   low_threshold:  lower hysteresis threshold
+//   high_threshold: upper hysteresis threshold
+//   sigma:          Gaussian blur sigma (0 to skip blurring)
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> canny(const mtl::mat::dense2D<T>& image,
+                           double low_threshold,
+                           double high_threshold,
+                           double sigma = 1.0) {
+	std::size_t rows = image.num_rows();
+	std::size_t cols = image.num_cols();
+
+	// Step 1: Gaussian blur (noise reduction)
+	mtl::mat::dense2D<T> blurred = (sigma > 0.0)
+		? gaussian_blur(image, sigma)
+		: image;
+
+	// Step 2: Compute gradients
+	auto gx = sobel_x(blurred);
+	auto gy = sobel_y(blurred);
+	auto mag = gradient_magnitude(gx, gy);
+
+	// Step 3: Non-maximum suppression
+	// Quantize gradient direction to 4 angles (0, 45, 90, 135 degrees)
+	// and suppress pixels that are not local maxima along the gradient direction.
+	mtl::mat::dense2D<T> nms(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			nms(r, c) = T{};
+		}
+	}
+
+	for (std::size_t r = 1; r + 1 < rows; ++r) {
+		for (std::size_t c = 1; c + 1 < cols; ++c) {
+			double dx = static_cast<double>(gx(r, c));
+			double dy = static_cast<double>(gy(r, c));
+			using std::atan2;
+			double angle = atan2(dy, dx);
+			// Normalize to [0, pi)
+			if (angle < 0.0) angle += 3.14159265358979323846;
+
+			double m = static_cast<double>(mag(r, c));
+			double m1, m2;
+
+			// 0 degrees (horizontal)
+			if ((angle < 0.3927) || (angle >= 2.7489)) {
+				m1 = static_cast<double>(mag(r, c - 1));
+				m2 = static_cast<double>(mag(r, c + 1));
+			}
+			// 45 degrees
+			else if (angle < 1.1781) {
+				m1 = static_cast<double>(mag(r - 1, c + 1));
+				m2 = static_cast<double>(mag(r + 1, c - 1));
+			}
+			// 90 degrees (vertical)
+			else if (angle < 1.9635) {
+				m1 = static_cast<double>(mag(r - 1, c));
+				m2 = static_cast<double>(mag(r + 1, c));
+			}
+			// 135 degrees
+			else {
+				m1 = static_cast<double>(mag(r - 1, c - 1));
+				m2 = static_cast<double>(mag(r + 1, c + 1));
+			}
+
+			if (m >= m1 && m >= m2) {
+				nms(r, c) = mag(r, c);
+			}
+		}
+	}
+
+	// Step 4: Double threshold and hysteresis
+	// Mark strong edges, weak edges, and then connect weak edges
+	// that are adjacent to strong edges.
+	mtl::mat::dense2D<T> edges(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			edges(r, c) = T{};
+
+	T strong = static_cast<T>(1);
+	T weak = static_cast<T>(0.5);
+
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			double val = static_cast<double>(nms(r, c));
+			if (val >= high_threshold) {
+				edges(r, c) = strong;
+			} else if (val >= low_threshold) {
+				edges(r, c) = weak;
+			}
+		}
+	}
+
+	// Hysteresis: promote weak edges adjacent to strong edges.
+	// Simple iterative approach.
+	bool changed = true;
+	while (changed) {
+		changed = false;
+		for (std::size_t r = 1; r + 1 < rows; ++r) {
+			for (std::size_t c = 1; c + 1 < cols; ++c) {
+				if (static_cast<double>(edges(r, c)) < 0.4 ||
+				    static_cast<double>(edges(r, c)) > 0.9) continue;
+				// Check 8-connected neighbors for strong edge
+				bool has_strong = false;
+				for (int dr = -1; dr <= 1 && !has_strong; ++dr) {
+					for (int dc = -1; dc <= 1 && !has_strong; ++dc) {
+						if (dr == 0 && dc == 0) continue;
+						std::size_t nr = static_cast<std::size_t>(static_cast<int>(r) + dr);
+						std::size_t nc = static_cast<std::size_t>(static_cast<int>(c) + dc);
+						if (static_cast<double>(edges(nr, nc)) > 0.9) {
+							has_strong = true;
+						}
+					}
+				}
+				if (has_strong) {
+					edges(r, c) = strong;
+					changed = true;
+				}
+			}
+		}
+	}
+
+	// Suppress remaining weak edges
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			if (static_cast<double>(edges(r, c)) < 0.9) {
+				edges(r, c) = T{};
+			}
+		}
+	}
+
+	return edges;
+}
+
+} // namespace sw::dsp

--- a/include/sw/dsp/image/edge.hpp
+++ b/include/sw/dsp/image/edge.hpp
@@ -9,6 +9,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <stdexcept>
 #include <mtl/mat/dense2D.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
 #include <sw/dsp/image/image.hpp>
@@ -103,6 +104,8 @@ mtl::mat::dense2D<T> gradient_magnitude(const mtl::mat::dense2D<T>& gx,
                                         const mtl::mat::dense2D<T>& gy) {
 	std::size_t rows = gx.num_rows();
 	std::size_t cols = gx.num_cols();
+	if (rows != gy.num_rows() || cols != gy.num_cols())
+		throw std::invalid_argument("gradient_magnitude: gx and gy must have same dimensions");
 	mtl::mat::dense2D<T> mag(rows, cols);
 	for (std::size_t r = 0; r < rows; ++r) {
 		for (std::size_t c = 0; c < cols; ++c) {

--- a/include/sw/dsp/image/image.hpp
+++ b/include/sw/dsp/image/image.hpp
@@ -1,0 +1,165 @@
+#pragma once
+// image.hpp: planar image container and utilities for 2D signal processing
+//
+// Multi-channel images are represented as an array of single-channel
+// dense2D<T> planes. All core algorithms operate on individual planes;
+// multi-channel processing is handled by apply_per_channel().
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string_view>
+#include <mtl/mat/dense2D.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+// Border extrapolation mode for spatial filtering operations.
+enum class BorderMode : std::uint8_t {
+	zero,         // pad with T{0}
+	constant,     // pad with user-specified value
+	replicate,    // clamp to nearest edge pixel
+	reflect,      // mirror including the edge pixel: dcba|abcd|dcba
+	reflect_101,  // mirror excluding the edge pixel: dcb|abcd|cba (default)
+	wrap          // periodic tiling: abcd|abcd|abcd
+};
+
+constexpr std::string_view to_string(BorderMode mode) {
+	switch (mode) {
+	case BorderMode::zero:        return "Zero";
+	case BorderMode::constant:    return "Constant";
+	case BorderMode::replicate:   return "Replicate";
+	case BorderMode::reflect:     return "Reflect";
+	case BorderMode::reflect_101: return "Reflect101";
+	case BorderMode::wrap:        return "Wrap";
+	}
+	return "Unknown";
+}
+
+// Map an out-of-bounds coordinate to a valid index using the given border mode.
+// rows_or_cols is the size of the dimension being indexed.
+inline std::size_t border_index(int idx, std::size_t dim, BorderMode mode) {
+	int n = static_cast<int>(dim);
+	if (idx >= 0 && idx < n) return static_cast<std::size_t>(idx);
+
+	switch (mode) {
+	case BorderMode::zero:
+	case BorderMode::constant:
+		// Caller must handle these by returning a constant value
+		return 0;  // sentinel — caller checks bounds first
+	case BorderMode::replicate:
+		if (idx < 0) return 0;
+		return static_cast<std::size_t>(n - 1);
+	case BorderMode::reflect: {
+		// dcba|abcd|dcba  (edge pixel repeated)
+		if (n == 1) return 0;
+		int period = 2 * n - 2;
+		int p = ((idx % period) + period) % period;
+		return static_cast<std::size_t>(p < n ? p : period - p);
+	}
+	case BorderMode::reflect_101: {
+		// dcb|abcd|cba  (edge pixel not repeated)
+		if (n == 1) return 0;
+		int period = 2 * (n - 1);
+		int p = ((idx % period) + period) % period;
+		return static_cast<std::size_t>(p < n ? p : period - p);
+	}
+	case BorderMode::wrap: {
+		int p = ((idx % n) + n) % n;
+		return static_cast<std::size_t>(p);
+	}
+	}
+	return 0;
+}
+
+// Fetch a pixel with border handling.
+// For zero/constant modes, returns the pad value when out of bounds.
+template <DspScalar T>
+T fetch_pixel(const mtl::mat::dense2D<T>& img, int r, int c,
+              BorderMode mode, T pad = T{}) {
+	int rows = static_cast<int>(img.num_rows());
+	int cols = static_cast<int>(img.num_cols());
+
+	if (r >= 0 && r < rows && c >= 0 && c < cols) {
+		return img(static_cast<std::size_t>(r), static_cast<std::size_t>(c));
+	}
+
+	if (mode == BorderMode::zero) return T{};
+	if (mode == BorderMode::constant) return pad;
+
+	std::size_t ri = border_index(r, static_cast<std::size_t>(rows), mode);
+	std::size_t ci = border_index(c, static_cast<std::size_t>(cols), mode);
+	return img(ri, ci);
+}
+
+// Planar multi-channel image container.
+//
+// Stores Channels separate dense2D<T> matrices (one per channel).
+// All core 2D algorithms operate on individual planes; use
+// apply_per_channel() for multi-channel convenience.
+template <DspScalar T, std::size_t Channels = 1>
+struct Image {
+	std::array<mtl::mat::dense2D<T>, Channels> planes;
+
+	Image() = default;
+
+	Image(std::size_t rows, std::size_t cols)
+	{
+		for (auto& p : planes) p.change_dim(rows, cols);
+	}
+
+	std::size_t rows() const { return planes[0].num_rows(); }
+	std::size_t cols() const { return planes[0].num_cols(); }
+	static constexpr std::size_t channels() { return Channels; }
+
+	mtl::mat::dense2D<T>&       operator[](std::size_t c)       { return planes[c]; }
+	const mtl::mat::dense2D<T>& operator[](std::size_t c) const { return planes[c]; }
+};
+
+// Convenience aliases
+template <typename T> using GrayImage = Image<T, 1>;
+template <typename T> using RGBImage  = Image<T, 3>;
+template <typename T> using RGBAImage = Image<T, 4>;
+
+// Apply a function to each plane of a multi-channel image.
+// The function signature should be: dense2D<T> func(const dense2D<T>&)
+template <DspScalar T, std::size_t C, typename Func>
+Image<T, C> apply_per_channel(const Image<T, C>& img, Func&& func) {
+	Image<T, C> result;
+	for (std::size_t i = 0; i < C; ++i) {
+		result[i] = func(img[i]);
+	}
+	return result;
+}
+
+// Convert an RGB image to grayscale using luminance weights.
+// Y = 0.299*R + 0.587*G + 0.114*B (ITU-R BT.601)
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> rgb_to_gray(const Image<T, 3>& rgb) {
+	std::size_t rows = rgb.rows();
+	std::size_t cols = rgb.cols();
+	mtl::mat::dense2D<T> gray(rows, cols);
+	T wr = static_cast<T>(0.299);
+	T wg = static_cast<T>(0.587);
+	T wb = static_cast<T>(0.114);
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			gray(r, c) = wr * rgb[0](r, c) + wg * rgb[1](r, c) + wb * rgb[2](r, c);
+		}
+	}
+	return gray;
+}
+
+} // namespace sw::dsp
+
+// Umbrella: include all image processing sub-headers.
+// These depend on the types and utilities defined above.
+#include <sw/dsp/image/convolve2d.hpp>
+#include <sw/dsp/image/separable.hpp>
+#include <sw/dsp/image/morphology.hpp>
+#include <sw/dsp/image/edge.hpp>

--- a/include/sw/dsp/image/morphology.hpp
+++ b/include/sw/dsp/image/morphology.hpp
@@ -1,0 +1,194 @@
+#pragma once
+// morphology.hpp: mathematical morphology operations
+//
+// Dilation, erosion, and compound operations (open, close, gradient,
+// tophat, blackhat) using structuring elements.
+//
+// Requires DspOrderedField (min/max comparisons).
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <mtl/mat/dense2D.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/image/image.hpp>
+
+namespace sw::dsp {
+
+// ---------- Structuring element factories ----------
+
+// Rectangular structuring element (all true).
+inline mtl::mat::dense2D<bool> make_rect_element(std::size_t rows, std::size_t cols) {
+	mtl::mat::dense2D<bool> elem(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			elem(r, c) = true;
+	return elem;
+}
+
+// Square structuring element.
+inline mtl::mat::dense2D<bool> make_rect_element(std::size_t size) {
+	return make_rect_element(size, size);
+}
+
+// Cross-shaped structuring element.
+inline mtl::mat::dense2D<bool> make_cross_element(std::size_t size) {
+	mtl::mat::dense2D<bool> elem(size, size);
+	std::size_t center = size / 2;
+	for (std::size_t r = 0; r < size; ++r)
+		for (std::size_t c = 0; c < size; ++c)
+			elem(r, c) = (r == center || c == center);
+	return elem;
+}
+
+// Elliptical (disk-like) structuring element.
+inline mtl::mat::dense2D<bool> make_ellipse_element(std::size_t size) {
+	mtl::mat::dense2D<bool> elem(size, size);
+	double center = static_cast<double>(size - 1) * 0.5;
+	double rx = center + 0.5;
+	double ry = center + 0.5;
+	for (std::size_t r = 0; r < size; ++r) {
+		for (std::size_t c = 0; c < size; ++c) {
+			double dr = (static_cast<double>(r) - center) / ry;
+			double dc = (static_cast<double>(c) - center) / rx;
+			elem(r, c) = (dr * dr + dc * dc <= 1.0);
+		}
+	}
+	return elem;
+}
+
+// ---------- Basic morphological operations ----------
+
+// Dilation: each output pixel is the maximum over the structuring element neighborhood.
+template <DspOrderedField T>
+mtl::mat::dense2D<T> dilate(const mtl::mat::dense2D<T>& image,
+                            const mtl::mat::dense2D<bool>& element) {
+	std::size_t rows = image.num_rows();
+	std::size_t cols = image.num_cols();
+	std::size_t erows = element.num_rows();
+	std::size_t ecols = element.num_cols();
+	int er = static_cast<int>(erows / 2);
+	int ec = static_cast<int>(ecols / 2);
+
+	mtl::mat::dense2D<T> result(rows, cols);
+
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			T max_val = std::numeric_limits<T>::lowest();
+			for (std::size_t ei = 0; ei < erows; ++ei) {
+				for (std::size_t ej = 0; ej < ecols; ++ej) {
+					if (!element(ei, ej)) continue;
+					int ir = static_cast<int>(r) + static_cast<int>(ei) - er;
+					int ic = static_cast<int>(c) + static_cast<int>(ej) - ec;
+					T pixel = fetch_pixel(image, ir, ic,
+					                      BorderMode::replicate);
+					if (pixel > max_val) max_val = pixel;
+				}
+			}
+			result(r, c) = max_val;
+		}
+	}
+	return result;
+}
+
+// Erosion: each output pixel is the minimum over the structuring element neighborhood.
+template <DspOrderedField T>
+mtl::mat::dense2D<T> erode(const mtl::mat::dense2D<T>& image,
+                           const mtl::mat::dense2D<bool>& element) {
+	std::size_t rows = image.num_rows();
+	std::size_t cols = image.num_cols();
+	std::size_t erows = element.num_rows();
+	std::size_t ecols = element.num_cols();
+	int er = static_cast<int>(erows / 2);
+	int ec = static_cast<int>(ecols / 2);
+
+	mtl::mat::dense2D<T> result(rows, cols);
+
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			T min_val = std::numeric_limits<T>::max();
+			for (std::size_t ei = 0; ei < erows; ++ei) {
+				for (std::size_t ej = 0; ej < ecols; ++ej) {
+					if (!element(ei, ej)) continue;
+					int ir = static_cast<int>(r) + static_cast<int>(ei) - er;
+					int ic = static_cast<int>(c) + static_cast<int>(ej) - ec;
+					T pixel = fetch_pixel(image, ir, ic,
+					                      BorderMode::replicate);
+					if (pixel < min_val) min_val = pixel;
+				}
+			}
+			result(r, c) = min_val;
+		}
+	}
+	return result;
+}
+
+// ---------- Compound morphological operations ----------
+
+// Opening: erosion followed by dilation.
+// Removes small bright regions while preserving shape.
+template <DspOrderedField T>
+mtl::mat::dense2D<T> morphological_open(const mtl::mat::dense2D<T>& image,
+                                        const mtl::mat::dense2D<bool>& element) {
+	return dilate(erode(image, element), element);
+}
+
+// Closing: dilation followed by erosion.
+// Fills small dark regions while preserving shape.
+template <DspOrderedField T>
+mtl::mat::dense2D<T> morphological_close(const mtl::mat::dense2D<T>& image,
+                                         const mtl::mat::dense2D<bool>& element) {
+	return erode(dilate(image, element), element);
+}
+
+// Morphological gradient: dilation minus erosion.
+// Highlights edges/boundaries.
+template <DspOrderedField T>
+mtl::mat::dense2D<T> morphological_gradient(const mtl::mat::dense2D<T>& image,
+                                            const mtl::mat::dense2D<bool>& element) {
+	auto d = dilate(image, element);
+	auto e = erode(image, element);
+	std::size_t rows = image.num_rows();
+	std::size_t cols = image.num_cols();
+	mtl::mat::dense2D<T> result(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			result(r, c) = d(r, c) - e(r, c);
+	return result;
+}
+
+// Top-hat: image minus opening.
+// Extracts small bright features.
+template <DspOrderedField T>
+mtl::mat::dense2D<T> tophat(const mtl::mat::dense2D<T>& image,
+                            const mtl::mat::dense2D<bool>& element) {
+	auto opened = morphological_open(image, element);
+	std::size_t rows = image.num_rows();
+	std::size_t cols = image.num_cols();
+	mtl::mat::dense2D<T> result(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			result(r, c) = image(r, c) - opened(r, c);
+	return result;
+}
+
+// Black-hat: closing minus image.
+// Extracts small dark features.
+template <DspOrderedField T>
+mtl::mat::dense2D<T> blackhat(const mtl::mat::dense2D<T>& image,
+                              const mtl::mat::dense2D<bool>& element) {
+	auto closed = morphological_close(image, element);
+	std::size_t rows = image.num_rows();
+	std::size_t cols = image.num_cols();
+	mtl::mat::dense2D<T> result(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			result(r, c) = closed(r, c) - image(r, c);
+	return result;
+}
+
+} // namespace sw::dsp

--- a/include/sw/dsp/image/morphology.hpp
+++ b/include/sw/dsp/image/morphology.hpp
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <cstddef>
 #include <limits>
+#include <stdexcept>
 #include <mtl/mat/dense2D.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
 #include <sw/dsp/image/image.hpp>
@@ -61,12 +62,25 @@ inline mtl::mat::dense2D<bool> make_ellipse_element(std::size_t size) {
 	return elem;
 }
 
+// Validate that a structuring element has at least one active pixel.
+inline void validate_element(const mtl::mat::dense2D<bool>& element) {
+	if (element.num_rows() == 0 || element.num_cols() == 0)
+		throw std::invalid_argument("morphology: structuring element must not be empty");
+	bool has_true = false;
+	for (std::size_t r = 0; r < element.num_rows() && !has_true; ++r)
+		for (std::size_t c = 0; c < element.num_cols() && !has_true; ++c)
+			if (element(r, c)) has_true = true;
+	if (!has_true)
+		throw std::invalid_argument("morphology: structuring element must have at least one active pixel");
+}
+
 // ---------- Basic morphological operations ----------
 
 // Dilation: each output pixel is the maximum over the structuring element neighborhood.
 template <DspOrderedField T>
 mtl::mat::dense2D<T> dilate(const mtl::mat::dense2D<T>& image,
                             const mtl::mat::dense2D<bool>& element) {
+	validate_element(element);
 	std::size_t rows = image.num_rows();
 	std::size_t cols = image.num_cols();
 	std::size_t erows = element.num_rows();
@@ -99,6 +113,7 @@ mtl::mat::dense2D<T> dilate(const mtl::mat::dense2D<T>& image,
 template <DspOrderedField T>
 mtl::mat::dense2D<T> erode(const mtl::mat::dense2D<T>& image,
                            const mtl::mat::dense2D<bool>& element) {
+	validate_element(element);
 	std::size_t rows = image.num_rows();
 	std::size_t cols = image.num_cols();
 	std::size_t erows = element.num_rows();

--- a/include/sw/dsp/image/separable.hpp
+++ b/include/sw/dsp/image/separable.hpp
@@ -1,0 +1,118 @@
+#pragma once
+// separable.hpp: separable 2D filtering and kernel factories
+//
+// A separable kernel can be decomposed into a row filter and a column
+// filter, reducing complexity from O(k^2) to O(k) per pixel.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/image/image.hpp>
+
+namespace sw::dsp {
+
+// Apply a separable filter (row kernel then column kernel).
+//
+// This is equivalent to convolve2d(image, outer_product(col_kernel, row_kernel))
+// but runs in O(krow + kcol) per pixel instead of O(krow * kcol).
+template <DspField T, DspField K>
+mtl::mat::dense2D<T> separable_filter(const mtl::mat::dense2D<T>& image,
+                                      const mtl::vec::dense_vector<K>& row_kernel,
+                                      const mtl::vec::dense_vector<K>& col_kernel,
+                                      BorderMode border = BorderMode::reflect_101,
+                                      T pad = T{}) {
+	std::size_t rows = image.num_rows();
+	std::size_t cols = image.num_cols();
+	int rk = static_cast<int>(row_kernel.size() / 2);
+	int ck = static_cast<int>(col_kernel.size() / 2);
+
+	// Pass 1: filter along rows
+	mtl::mat::dense2D<T> temp(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			T sum{};
+			for (std::size_t k = 0; k < row_kernel.size(); ++k) {
+				int ic = static_cast<int>(c) + static_cast<int>(k) - rk;
+				T pixel = fetch_pixel(image, static_cast<int>(r), ic, border, pad);
+				sum = sum + static_cast<T>(row_kernel[k]) * pixel;
+			}
+			temp(r, c) = sum;
+		}
+	}
+
+	// Pass 2: filter along columns
+	mtl::mat::dense2D<T> result(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			T sum{};
+			for (std::size_t k = 0; k < col_kernel.size(); ++k) {
+				int ir = static_cast<int>(r) + static_cast<int>(k) - ck;
+				T pixel = fetch_pixel(temp, ir, static_cast<int>(c), border, pad);
+				sum = sum + static_cast<T>(col_kernel[k]) * pixel;
+			}
+			result(r, c) = sum;
+		}
+	}
+	return result;
+}
+
+// Create a 1D Gaussian kernel with the given sigma and radius.
+// The kernel size is 2*radius+1.
+template <DspField T>
+mtl::vec::dense_vector<T> gaussian_kernel_1d(double sigma, std::size_t radius) {
+	std::size_t size = 2 * radius + 1;
+	mtl::vec::dense_vector<T> kernel(size);
+	double sum = 0.0;
+	for (std::size_t i = 0; i < size; ++i) {
+		double x = static_cast<double>(i) - static_cast<double>(radius);
+		double val = std::exp(-0.5 * x * x / (sigma * sigma));
+		kernel[i] = static_cast<T>(val);
+		sum += val;
+	}
+	// Normalize
+	for (std::size_t i = 0; i < size; ++i) {
+		kernel[i] = static_cast<T>(static_cast<double>(kernel[i]) / sum);
+	}
+	return kernel;
+}
+
+// Create a 1D box (uniform) kernel of the given size.
+template <DspField T>
+mtl::vec::dense_vector<T> box_kernel_1d(std::size_t size) {
+	mtl::vec::dense_vector<T> kernel(size);
+	T val = static_cast<T>(1.0 / static_cast<double>(size));
+	for (std::size_t i = 0; i < size; ++i) {
+		kernel[i] = val;
+	}
+	return kernel;
+}
+
+// Gaussian blur using separable decomposition.
+template <DspField T>
+mtl::mat::dense2D<T> gaussian_blur(const mtl::mat::dense2D<T>& image,
+                                   double sigma,
+                                   std::size_t radius = 0,
+                                   BorderMode border = BorderMode::reflect_101) {
+	if (radius == 0) {
+		radius = static_cast<std::size_t>(std::ceil(3.0 * sigma));
+		if (radius < 1) radius = 1;
+	}
+	auto kernel = gaussian_kernel_1d<T>(sigma, radius);
+	return separable_filter(image, kernel, kernel, border);
+}
+
+// Box blur using separable decomposition.
+template <DspField T>
+mtl::mat::dense2D<T> box_blur(const mtl::mat::dense2D<T>& image,
+                               std::size_t size,
+                               BorderMode border = BorderMode::reflect_101) {
+	auto kernel = box_kernel_1d<T>(size);
+	return separable_filter(image, kernel, kernel, border);
+}
+
+} // namespace sw::dsp

--- a/include/sw/dsp/image/separable.hpp
+++ b/include/sw/dsp/image/separable.hpp
@@ -9,6 +9,8 @@
 
 #include <cmath>
 #include <cstddef>
+#include <stdexcept>
+#include <type_traits>
 #include <mtl/mat/dense2D.hpp>
 #include <mtl/vec/dense_vector.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
@@ -20,72 +22,83 @@ namespace sw::dsp {
 //
 // This is equivalent to convolve2d(image, outer_product(col_kernel, row_kernel))
 // but runs in O(krow + kcol) per pixel instead of O(krow * kcol).
+//
+// Accumulates in std::common_type_t<T, K> to preserve kernel precision.
+// The row-pass intermediate also uses the promoted type to avoid premature
+// narrowing back to the pixel type.
 template <DspField T, DspField K>
 mtl::mat::dense2D<T> separable_filter(const mtl::mat::dense2D<T>& image,
                                       const mtl::vec::dense_vector<K>& row_kernel,
                                       const mtl::vec::dense_vector<K>& col_kernel,
                                       BorderMode border = BorderMode::reflect_101,
                                       T pad = T{}) {
+	using acc_t = std::common_type_t<T, K>;
+
 	std::size_t rows = image.num_rows();
 	std::size_t cols = image.num_cols();
 	int rk = static_cast<int>(row_kernel.size() / 2);
 	int ck = static_cast<int>(col_kernel.size() / 2);
 
-	// Pass 1: filter along rows
-	mtl::mat::dense2D<T> temp(rows, cols);
+	// Pass 1: filter along rows into promoted-precision intermediate
+	mtl::mat::dense2D<acc_t> temp(rows, cols);
 	for (std::size_t r = 0; r < rows; ++r) {
 		for (std::size_t c = 0; c < cols; ++c) {
-			T sum{};
+			acc_t sum{};
 			for (std::size_t k = 0; k < row_kernel.size(); ++k) {
 				int ic = static_cast<int>(c) + static_cast<int>(k) - rk;
-				T pixel = fetch_pixel(image, static_cast<int>(r), ic, border, pad);
-				sum = sum + static_cast<T>(row_kernel[k]) * pixel;
+				acc_t pixel = static_cast<acc_t>(
+					fetch_pixel(image, static_cast<int>(r), ic, border, pad));
+				sum = sum + static_cast<acc_t>(row_kernel[k]) * pixel;
 			}
 			temp(r, c) = sum;
 		}
 	}
 
-	// Pass 2: filter along columns
+	// Pass 2: filter along columns using the row-filtered intermediate.
+	// fetch_pixel works on dense2D<acc_t> for correct border handling.
 	mtl::mat::dense2D<T> result(rows, cols);
 	for (std::size_t r = 0; r < rows; ++r) {
 		for (std::size_t c = 0; c < cols; ++c) {
-			T sum{};
+			acc_t sum{};
 			for (std::size_t k = 0; k < col_kernel.size(); ++k) {
 				int ir = static_cast<int>(r) + static_cast<int>(k) - ck;
-				T pixel = fetch_pixel(temp, ir, static_cast<int>(c), border, pad);
-				sum = sum + static_cast<T>(col_kernel[k]) * pixel;
+				acc_t pixel = fetch_pixel(temp, ir, static_cast<int>(c),
+				                          border, static_cast<acc_t>(pad));
+				sum = sum + static_cast<acc_t>(col_kernel[k]) * pixel;
 			}
-			result(r, c) = sum;
+			result(r, c) = static_cast<T>(sum);
 		}
 	}
 	return result;
 }
 
 // Create a 1D Gaussian kernel with the given sigma and radius.
-// The kernel size is 2*radius+1.
-template <DspField T>
-mtl::vec::dense_vector<T> gaussian_kernel_1d(double sigma, std::size_t radius) {
+// The kernel size is 2*radius+1. Kernel type K defaults to double
+// to avoid quantization for narrow pixel types.
+template <DspField K = double>
+mtl::vec::dense_vector<K> gaussian_kernel_1d(double sigma, std::size_t radius) {
 	std::size_t size = 2 * radius + 1;
-	mtl::vec::dense_vector<T> kernel(size);
+	mtl::vec::dense_vector<K> kernel(size);
 	double sum = 0.0;
 	for (std::size_t i = 0; i < size; ++i) {
 		double x = static_cast<double>(i) - static_cast<double>(radius);
 		double val = std::exp(-0.5 * x * x / (sigma * sigma));
-		kernel[i] = static_cast<T>(val);
+		kernel[i] = static_cast<K>(val);
 		sum += val;
 	}
 	// Normalize
 	for (std::size_t i = 0; i < size; ++i) {
-		kernel[i] = static_cast<T>(static_cast<double>(kernel[i]) / sum);
+		kernel[i] = static_cast<K>(static_cast<double>(kernel[i]) / sum);
 	}
 	return kernel;
 }
 
 // Create a 1D box (uniform) kernel of the given size.
-template <DspField T>
-mtl::vec::dense_vector<T> box_kernel_1d(std::size_t size) {
-	mtl::vec::dense_vector<T> kernel(size);
-	T val = static_cast<T>(1.0 / static_cast<double>(size));
+// Kernel type K defaults to double.
+template <DspField K = double>
+mtl::vec::dense_vector<K> box_kernel_1d(std::size_t size) {
+	mtl::vec::dense_vector<K> kernel(size);
+	K val = static_cast<K>(1.0 / static_cast<double>(size));
 	for (std::size_t i = 0; i < size; ++i) {
 		kernel[i] = val;
 	}
@@ -98,11 +111,13 @@ mtl::mat::dense2D<T> gaussian_blur(const mtl::mat::dense2D<T>& image,
                                    double sigma,
                                    std::size_t radius = 0,
                                    BorderMode border = BorderMode::reflect_101) {
+	if (sigma <= 0.0)
+		throw std::invalid_argument("gaussian_blur: sigma must be > 0");
 	if (radius == 0) {
 		radius = static_cast<std::size_t>(std::ceil(3.0 * sigma));
 		if (radius < 1) radius = 1;
 	}
-	auto kernel = gaussian_kernel_1d<T>(sigma, radius);
+	auto kernel = gaussian_kernel_1d<double>(sigma, radius);
 	return separable_filter(image, kernel, kernel, border);
 }
 
@@ -111,7 +126,9 @@ template <DspField T>
 mtl::mat::dense2D<T> box_blur(const mtl::mat::dense2D<T>& image,
                                std::size_t size,
                                BorderMode border = BorderMode::reflect_101) {
-	auto kernel = box_kernel_1d<T>(size);
+	if (size == 0)
+		throw std::invalid_argument("box_blur: size must be > 0");
+	auto kernel = box_kernel_1d<double>(size);
 	return separable_filter(image, kernel, kernel, border);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,3 +51,6 @@ dsp_add_test(test_conditioning)
 
 # Estimation: Kalman, LMS, RLS (Issue #7)
 dsp_add_test(test_kalman)
+
+# Image processing (Issue #8)
+dsp_add_test(test_image)

--- a/tests/test_image.cpp
+++ b/tests/test_image.cpp
@@ -1,0 +1,585 @@
+// test_image.cpp: test image processing — convolution, separable, morphology, edge
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/image/image.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+
+using namespace sw::dsp;
+
+bool near(double a, double b, double eps = 1e-4) {
+	return std::abs(a - b) < eps;
+}
+
+// ---------- Helper: create synthetic test images ----------
+
+// Create a constant image
+mtl::mat::dense2D<double> make_constant(std::size_t rows, std::size_t cols, double val) {
+	mtl::mat::dense2D<double> img(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = val;
+	return img;
+}
+
+// Create a horizontal ramp: pixel value = column index
+mtl::mat::dense2D<double> make_horizontal_ramp(std::size_t rows, std::size_t cols) {
+	mtl::mat::dense2D<double> img(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = static_cast<double>(c);
+	return img;
+}
+
+// Create a vertical ramp: pixel value = row index
+mtl::mat::dense2D<double> make_vertical_ramp(std::size_t rows, std::size_t cols) {
+	mtl::mat::dense2D<double> img(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = static_cast<double>(r);
+	return img;
+}
+
+// Create a step edge: left half = 0, right half = 1
+mtl::mat::dense2D<double> make_step_edge(std::size_t rows, std::size_t cols) {
+	mtl::mat::dense2D<double> img(rows, cols);
+	std::size_t mid = cols / 2;
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = (c >= mid) ? 1.0 : 0.0;
+	return img;
+}
+
+// Create an identity kernel (single 1 at center)
+mtl::mat::dense2D<double> make_identity_kernel() {
+	mtl::mat::dense2D<double> k(3, 3);
+	for (std::size_t r = 0; r < 3; ++r)
+		for (std::size_t c = 0; c < 3; ++c)
+			k(r, c) = 0.0;
+	k(1, 1) = 1.0;
+	return k;
+}
+
+// ========== Image Container Tests ==========
+
+void test_image_construction() {
+	Image<double, 3> rgb(10, 20);
+	if (!(rgb.rows() == 10)) throw std::runtime_error("test failed: Image rows");
+	if (!(rgb.cols() == 20)) throw std::runtime_error("test failed: Image cols");
+	if (!(rgb.channels() == 3)) throw std::runtime_error("test failed: Image channels");
+
+	// Default construction
+	GrayImage<double> gray;
+	RGBImage<float> rgb_f(5, 5);
+	RGBAImage<double> rgba(8, 8);
+	if (!(rgba.channels() == 4)) throw std::runtime_error("test failed: RGBA channels");
+
+	std::cout << "  image_construction: passed\n";
+}
+
+void test_apply_per_channel() {
+	RGBImage<double> rgb(4, 4);
+	// Fill each channel with a different constant
+	for (std::size_t r = 0; r < 4; ++r) {
+		for (std::size_t c = 0; c < 4; ++c) {
+			rgb[0](r, c) = 1.0;
+			rgb[1](r, c) = 2.0;
+			rgb[2](r, c) = 3.0;
+		}
+	}
+
+	// Double each channel
+	auto result = apply_per_channel(rgb, [](const mtl::mat::dense2D<double>& plane) {
+		mtl::mat::dense2D<double> out(plane.num_rows(), plane.num_cols());
+		for (std::size_t r = 0; r < plane.num_rows(); ++r)
+			for (std::size_t c = 0; c < plane.num_cols(); ++c)
+				out(r, c) = plane(r, c) * 2.0;
+		return out;
+	});
+
+	if (!(near(result[0](0, 0), 2.0))) throw std::runtime_error("test failed: apply_per_channel R");
+	if (!(near(result[1](0, 0), 4.0))) throw std::runtime_error("test failed: apply_per_channel G");
+	if (!(near(result[2](0, 0), 6.0))) throw std::runtime_error("test failed: apply_per_channel B");
+
+	std::cout << "  apply_per_channel: passed\n";
+}
+
+void test_rgb_to_gray() {
+	RGBImage<double> rgb(2, 2);
+	// White pixel: R=G=B=1.0
+	for (std::size_t r = 0; r < 2; ++r) {
+		for (std::size_t c = 0; c < 2; ++c) {
+			rgb[0](r, c) = 1.0;
+			rgb[1](r, c) = 1.0;
+			rgb[2](r, c) = 1.0;
+		}
+	}
+	auto gray = rgb_to_gray(rgb);
+	// 0.299 + 0.587 + 0.114 = 1.0
+	if (!(near(gray(0, 0), 1.0, 1e-3)))
+		throw std::runtime_error("test failed: rgb_to_gray white");
+
+	// Pure red
+	for (std::size_t r = 0; r < 2; ++r) {
+		for (std::size_t c = 0; c < 2; ++c) {
+			rgb[0](r, c) = 1.0;
+			rgb[1](r, c) = 0.0;
+			rgb[2](r, c) = 0.0;
+		}
+	}
+	gray = rgb_to_gray(rgb);
+	if (!(near(gray(0, 0), 0.299, 1e-3)))
+		throw std::runtime_error("test failed: rgb_to_gray red");
+
+	std::cout << "  rgb_to_gray: passed\n";
+}
+
+// ========== Border Handling Tests ==========
+
+void test_border_modes() {
+	// 4-pixel row image: [10, 20, 30, 40]
+	mtl::mat::dense2D<double> img(1, 4);
+	img(0, 0) = 10; img(0, 1) = 20; img(0, 2) = 30; img(0, 3) = 40;
+
+	// Zero padding
+	double val = fetch_pixel(img, 0, -1, BorderMode::zero);
+	if (!(near(val, 0.0))) throw std::runtime_error("test failed: border zero");
+
+	// Replicate
+	val = fetch_pixel(img, 0, -1, BorderMode::replicate);
+	if (!(near(val, 10.0))) throw std::runtime_error("test failed: border replicate left");
+	val = fetch_pixel(img, 0, 5, BorderMode::replicate);
+	if (!(near(val, 40.0))) throw std::runtime_error("test failed: border replicate right");
+
+	// Reflect (with edge): dcba|abcd|dcba -> at -1 we get b=20
+	val = fetch_pixel(img, 0, -1, BorderMode::reflect);
+	if (!(near(val, 20.0))) throw std::runtime_error("test failed: border reflect");
+
+	// Reflect_101 (without edge): dcb|abcd|cba -> at -1 we get b=20
+	val = fetch_pixel(img, 0, -1, BorderMode::reflect_101);
+	if (!(near(val, 20.0))) throw std::runtime_error("test failed: border reflect_101");
+
+	// Wrap
+	val = fetch_pixel(img, 0, -1, BorderMode::wrap);
+	if (!(near(val, 40.0))) throw std::runtime_error("test failed: border wrap left");
+	val = fetch_pixel(img, 0, 4, BorderMode::wrap);
+	if (!(near(val, 10.0))) throw std::runtime_error("test failed: border wrap right");
+
+	// Constant with pad value
+	val = fetch_pixel(img, 0, -1, BorderMode::constant, 99.0);
+	if (!(near(val, 99.0))) throw std::runtime_error("test failed: border constant");
+
+	std::cout << "  border_modes: passed\n";
+}
+
+// ========== Convolution Tests ==========
+
+void test_convolve2d_identity() {
+	auto img = make_horizontal_ramp(5, 5);
+	auto kernel = make_identity_kernel();
+	auto result = convolve2d(img, kernel);
+
+	// Identity kernel should reproduce the input
+	for (std::size_t r = 0; r < 5; ++r)
+		for (std::size_t c = 0; c < 5; ++c)
+			if (!(near(result(r, c), img(r, c))))
+				throw std::runtime_error("test failed: convolve2d identity");
+
+	std::cout << "  convolve2d_identity: passed\n";
+}
+
+void test_convolve2d_box_blur() {
+	// 5x5 constant image with value 7 — box blur should leave it unchanged
+	auto img = make_constant(5, 5, 7.0);
+	mtl::mat::dense2D<double> box(3, 3);
+	for (std::size_t r = 0; r < 3; ++r)
+		for (std::size_t c = 0; c < 3; ++c)
+			box(r, c) = 1.0 / 9.0;
+
+	auto result = convolve2d(img, box);
+	for (std::size_t r = 0; r < 5; ++r)
+		for (std::size_t c = 0; c < 5; ++c)
+			if (!(near(result(r, c), 7.0, 1e-6)))
+				throw std::runtime_error("test failed: box blur on constant");
+
+	std::cout << "  convolve2d_box_blur: passed\n";
+}
+
+void test_convolve2d_multichannel() {
+	RGBImage<double> rgb(5, 5);
+	for (std::size_t r = 0; r < 5; ++r)
+		for (std::size_t c = 0; c < 5; ++c) {
+			rgb[0](r, c) = 1.0;
+			rgb[1](r, c) = 2.0;
+			rgb[2](r, c) = 3.0;
+		}
+
+	auto kernel = make_identity_kernel();
+	auto result = convolve2d(rgb, kernel);
+
+	if (!(near(result[0](2, 2), 1.0))) throw std::runtime_error("test failed: multichannel conv R");
+	if (!(near(result[1](2, 2), 2.0))) throw std::runtime_error("test failed: multichannel conv G");
+	if (!(near(result[2](2, 2), 3.0))) throw std::runtime_error("test failed: multichannel conv B");
+
+	std::cout << "  convolve2d_multichannel: passed\n";
+}
+
+// ========== Separable Filter Tests ==========
+
+void test_separable_vs_2d() {
+	// Separable box blur should match 2D box blur
+	auto img = make_horizontal_ramp(8, 8);
+
+	// 2D box kernel
+	mtl::mat::dense2D<double> box2d(3, 3);
+	for (std::size_t r = 0; r < 3; ++r)
+		for (std::size_t c = 0; c < 3; ++c)
+			box2d(r, c) = 1.0 / 9.0;
+
+	// Separable box kernel: [1/3, 1/3, 1/3] x [1/3, 1/3, 1/3]
+	auto box1d = box_kernel_1d<double>(3);
+
+	auto result_2d = convolve2d(img, box2d);
+	auto result_sep = separable_filter(img, box1d, box1d);
+
+	for (std::size_t r = 0; r < 8; ++r)
+		for (std::size_t c = 0; c < 8; ++c)
+			if (!(near(result_2d(r, c), result_sep(r, c), 1e-10)))
+				throw std::runtime_error("test failed: separable vs 2D mismatch");
+
+	std::cout << "  separable_vs_2d: passed\n";
+}
+
+void test_gaussian_blur() {
+	// Gaussian blur of a constant image should be the same constant
+	auto img = make_constant(10, 10, 5.0);
+	auto blurred = gaussian_blur(img, 1.0);
+
+	for (std::size_t r = 1; r + 1 < 10; ++r)
+		for (std::size_t c = 1; c + 1 < 10; ++c)
+			if (!(near(blurred(r, c), 5.0, 1e-3)))
+				throw std::runtime_error("test failed: gaussian blur constant");
+
+	std::cout << "  gaussian_blur: passed\n";
+}
+
+void test_box_blur() {
+	auto img = make_constant(8, 8, 3.0);
+	auto blurred = box_blur(img, 3);
+	// Should remain 3.0
+	for (std::size_t r = 0; r < 8; ++r)
+		for (std::size_t c = 0; c < 8; ++c)
+			if (!(near(blurred(r, c), 3.0, 1e-6)))
+				throw std::runtime_error("test failed: box blur constant");
+
+	std::cout << "  box_blur: passed\n";
+}
+
+// ========== Morphology Tests ==========
+
+void test_structuring_elements() {
+	auto rect = make_rect_element(3, 3);
+	for (std::size_t r = 0; r < 3; ++r)
+		for (std::size_t c = 0; c < 3; ++c)
+			if (!rect(r, c))
+				throw std::runtime_error("test failed: rect element all true");
+
+	auto cross = make_cross_element(3);
+	if (!cross(1, 0)) throw std::runtime_error("test failed: cross center row");
+	if (!cross(0, 1)) throw std::runtime_error("test failed: cross center col");
+	if (cross(0, 0)) throw std::runtime_error("test failed: cross corner should be false");
+
+	auto ellipse = make_ellipse_element(5);
+	// Center should be true
+	if (!ellipse(2, 2)) throw std::runtime_error("test failed: ellipse center");
+	// Corners should be false for a 5x5 ellipse
+	if (ellipse(0, 0)) throw std::runtime_error("test failed: ellipse corner");
+
+	std::cout << "  structuring_elements: passed\n";
+}
+
+void test_dilate_erode() {
+	// Single bright pixel in a dark field
+	auto img = make_constant(7, 7, 0.0);
+	img(3, 3) = 1.0;
+
+	auto elem = make_rect_element(3, 3);
+
+	// Dilation should spread the bright pixel to its 3x3 neighborhood
+	auto dilated = dilate(img, elem);
+	if (!(near(dilated(3, 3), 1.0))) throw std::runtime_error("test failed: dilate center");
+	if (!(near(dilated(2, 2), 1.0))) throw std::runtime_error("test failed: dilate neighbor");
+	if (!(near(dilated(1, 1), 0.0))) throw std::runtime_error("test failed: dilate far");
+
+	// Erosion of the dilated result should shrink it back
+	auto eroded = erode(dilated, elem);
+	if (!(near(eroded(3, 3), 1.0))) throw std::runtime_error("test failed: erode center");
+	// One pixel away from center should be 0 after erode(dilate)
+	if (!(near(eroded(1, 1), 0.0))) throw std::runtime_error("test failed: erode far");
+
+	std::cout << "  dilate_erode: passed\n";
+}
+
+void test_morphological_open_idempotent() {
+	// Opening is idempotent: open(open(x)) == open(x)
+	auto img = make_step_edge(8, 8);
+	auto elem = make_rect_element(3, 3);
+
+	auto opened = morphological_open(img, elem);
+	auto opened2 = morphological_open(opened, elem);
+
+	for (std::size_t r = 0; r < 8; ++r)
+		for (std::size_t c = 0; c < 8; ++c)
+			if (!(near(opened(r, c), opened2(r, c), 1e-10)))
+				throw std::runtime_error("test failed: open idempotency");
+
+	std::cout << "  morphological_open_idempotent: passed\n";
+}
+
+void test_morphological_close_idempotent() {
+	auto img = make_step_edge(8, 8);
+	auto elem = make_rect_element(3, 3);
+
+	auto closed = morphological_close(img, elem);
+	auto closed2 = morphological_close(closed, elem);
+
+	for (std::size_t r = 0; r < 8; ++r)
+		for (std::size_t c = 0; c < 8; ++c)
+			if (!(near(closed(r, c), closed2(r, c), 1e-10)))
+				throw std::runtime_error("test failed: close idempotency");
+
+	std::cout << "  morphological_close_idempotent: passed\n";
+}
+
+void test_morphological_gradient() {
+	// Gradient of a constant image should be zero
+	auto img = make_constant(8, 8, 5.0);
+	auto elem = make_rect_element(3, 3);
+	auto grad = morphological_gradient(img, elem);
+
+	for (std::size_t r = 0; r < 8; ++r)
+		for (std::size_t c = 0; c < 8; ++c)
+			if (!(near(grad(r, c), 0.0, 1e-10)))
+				throw std::runtime_error("test failed: gradient of constant");
+
+	std::cout << "  morphological_gradient: passed\n";
+}
+
+void test_tophat_blackhat() {
+	auto img = make_constant(8, 8, 5.0);
+	auto elem = make_rect_element(3, 3);
+
+	// Top-hat and black-hat of a constant image should both be zero
+	auto th = tophat(img, elem);
+	auto bh = blackhat(img, elem);
+
+	for (std::size_t r = 0; r < 8; ++r) {
+		for (std::size_t c = 0; c < 8; ++c) {
+			if (!(near(th(r, c), 0.0, 1e-10)))
+				throw std::runtime_error("test failed: tophat constant");
+			if (!(near(bh(r, c), 0.0, 1e-10)))
+				throw std::runtime_error("test failed: blackhat constant");
+		}
+	}
+
+	std::cout << "  tophat_blackhat: passed\n";
+}
+
+// ========== Edge Detection Tests ==========
+
+void test_sobel_constant() {
+	// Sobel of a constant image should be zero everywhere
+	auto img = make_constant(8, 8, 5.0);
+	auto gx = sobel_x(img);
+	auto gy = sobel_y(img);
+
+	for (std::size_t r = 1; r + 1 < 8; ++r) {
+		for (std::size_t c = 1; c + 1 < 8; ++c) {
+			if (!(near(gx(r, c), 0.0, 1e-6)))
+				throw std::runtime_error("test failed: sobel_x constant");
+			if (!(near(gy(r, c), 0.0, 1e-6)))
+				throw std::runtime_error("test failed: sobel_y constant");
+		}
+	}
+
+	std::cout << "  sobel_constant: passed\n";
+}
+
+void test_sobel_horizontal_ramp() {
+	// Horizontal ramp: pixel = column index
+	// Sobel X should detect the constant horizontal gradient
+	// Sobel Y should be zero (no vertical variation)
+	auto img = make_horizontal_ramp(10, 10);
+	auto gx = sobel_x(img);
+	auto gy = sobel_y(img);
+
+	// Interior pixels should have constant gx (non-zero) and zero gy
+	// The Sobel X kernel on a unit-slope ramp gives:
+	// For f(r,c) = c: Sobel_X = [1,2,1]^T * [-1,0,1] applied to c
+	// = (c+1 - (c-1)) * (1+2+1) = 2*4 = 8
+	for (std::size_t r = 2; r + 2 < 10; ++r) {
+		for (std::size_t c = 2; c + 2 < 10; ++c) {
+			if (!(std::abs(gx(r, c)) > 0.1))
+				throw std::runtime_error("test failed: sobel_x ramp should be non-zero");
+			if (!(near(gy(r, c), 0.0, 1e-6)))
+				throw std::runtime_error("test failed: sobel_y of h-ramp should be zero");
+		}
+	}
+
+	// All interior gx values should be the same (constant gradient)
+	double ref = gx(4, 4);
+	for (std::size_t r = 2; r + 2 < 10; ++r) {
+		for (std::size_t c = 2; c + 2 < 10; ++c) {
+			if (!(near(gx(r, c), ref, 1e-6)))
+				throw std::runtime_error("test failed: sobel_x ramp not constant");
+		}
+	}
+
+	std::cout << "  sobel_horizontal_ramp: passed (gx=" << ref << ")\n";
+}
+
+void test_prewitt() {
+	auto img = make_horizontal_ramp(8, 8);
+	auto gx = prewitt_x(img);
+	auto gy = prewitt_y(img);
+
+	// Same logic as Sobel: constant horizontal gradient, zero vertical
+	for (std::size_t r = 2; r + 2 < 8; ++r) {
+		for (std::size_t c = 2; c + 2 < 8; ++c) {
+			if (!(std::abs(gx(r, c)) > 0.1))
+				throw std::runtime_error("test failed: prewitt_x ramp non-zero");
+			if (!(near(gy(r, c), 0.0, 1e-6)))
+				throw std::runtime_error("test failed: prewitt_y of h-ramp zero");
+		}
+	}
+
+	std::cout << "  prewitt: passed\n";
+}
+
+void test_gradient_magnitude() {
+	auto img = make_horizontal_ramp(8, 8);
+	auto gx = sobel_x(img);
+	auto gy = sobel_y(img);
+	auto mag = gradient_magnitude(gx, gy);
+
+	// Since gy ≈ 0 for horizontal ramp, magnitude ≈ |gx|
+	for (std::size_t r = 2; r + 2 < 8; ++r) {
+		for (std::size_t c = 2; c + 2 < 8; ++c) {
+			double expected = std::abs(gx(r, c));
+			if (!(near(mag(r, c), expected, 1e-6)))
+				throw std::runtime_error("test failed: gradient magnitude");
+		}
+	}
+
+	std::cout << "  gradient_magnitude: passed\n";
+}
+
+void test_canny_step_edge() {
+	// Canny on a step edge should produce edges near the transition
+	auto img = make_step_edge(20, 20);
+	auto edges = canny(img, 0.1, 0.3, 1.0);
+
+	// Check that edge pixels exist near column 10 (the step)
+	bool found_edge = false;
+	for (std::size_t r = 3; r + 3 < 20; ++r) {
+		for (std::size_t c = 8; c <= 12; ++c) {
+			if (static_cast<double>(edges(r, c)) > 0.9) {
+				found_edge = true;
+				break;
+			}
+		}
+		if (found_edge) break;
+	}
+	if (!found_edge)
+		throw std::runtime_error("test failed: canny should detect step edge");
+
+	// Check that far-from-edge pixels are not marked
+	bool clean_left = true;
+	for (std::size_t r = 3; r + 3 < 20; ++r) {
+		for (std::size_t c = 0; c < 5; ++c) {
+			if (static_cast<double>(edges(r, c)) > 0.9) {
+				clean_left = false;
+				break;
+			}
+		}
+	}
+	if (!clean_left)
+		throw std::runtime_error("test failed: canny should not mark flat regions");
+
+	std::cout << "  canny_step_edge: passed\n";
+}
+
+// ========== Mixed Precision Test ==========
+
+void test_mixed_precision_convolution() {
+	// float image convolved with double kernel
+	mtl::mat::dense2D<float> img(5, 5);
+	for (std::size_t r = 0; r < 5; ++r)
+		for (std::size_t c = 0; c < 5; ++c)
+			img(r, c) = static_cast<float>(c);
+
+	mtl::mat::dense2D<double> kernel(3, 3);
+	for (std::size_t r = 0; r < 3; ++r)
+		for (std::size_t c = 0; c < 3; ++c)
+			kernel(r, c) = 0.0;
+	kernel(1, 1) = 1.0;
+
+	auto result = convolve2d(img, kernel);
+	// Identity kernel should reproduce input
+	if (!(near(static_cast<double>(result(2, 3)), 3.0, 1e-5)))
+		throw std::runtime_error("test failed: mixed precision convolution");
+
+	std::cout << "  mixed_precision_convolution: passed\n";
+}
+
+int main() {
+	try {
+		std::cout << "Image Processing Tests\n";
+
+		// Container and utilities
+		test_image_construction();
+		test_apply_per_channel();
+		test_rgb_to_gray();
+
+		// Border handling
+		test_border_modes();
+
+		// Convolution
+		test_convolve2d_identity();
+		test_convolve2d_box_blur();
+		test_convolve2d_multichannel();
+
+		// Separable filters
+		test_separable_vs_2d();
+		test_gaussian_blur();
+		test_box_blur();
+
+		// Morphology
+		test_structuring_elements();
+		test_dilate_erode();
+		test_morphological_open_idempotent();
+		test_morphological_close_idempotent();
+		test_morphological_gradient();
+		test_tophat_blackhat();
+
+		// Edge detection
+		test_sobel_constant();
+		test_sobel_horizontal_ramp();
+		test_prewitt();
+		test_gradient_magnitude();
+		test_canny_step_edge();
+
+		// Mixed precision
+		test_mixed_precision_convolution();
+
+		std::cout << "All image processing tests passed.\n";
+		return 0;
+	} catch (const std::exception& e) {
+		std::cerr << "FAILED: " << e.what() << '\n';
+		return 1;
+	}
+}

--- a/tests/test_image.cpp
+++ b/tests/test_image.cpp
@@ -1,11 +1,16 @@
 // test_image.cpp: test image processing — convolution, separable, morphology, edge
 //
+// Tests use float as the primary pixel type (realistic for image data).
+// Algorithmic precision tests (Canny, Gaussian normalization) use double.
+// Mixed-precision tests validate float pixels with double kernels.
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
 #include <sw/dsp/image/image.hpp>
 
 #include <cmath>
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 
@@ -15,89 +20,72 @@ bool near(double a, double b, double eps = 1e-4) {
 	return std::abs(a - b) < eps;
 }
 
-// ---------- Helper: create synthetic test images ----------
+// ---------- Templated helpers for synthetic test images ----------
 
-// Create a constant image
-mtl::mat::dense2D<double> make_constant(std::size_t rows, std::size_t cols, double val) {
-	mtl::mat::dense2D<double> img(rows, cols);
+template <typename T>
+mtl::mat::dense2D<T> make_constant(std::size_t rows, std::size_t cols, T val) {
+	mtl::mat::dense2D<T> img(rows, cols);
 	for (std::size_t r = 0; r < rows; ++r)
 		for (std::size_t c = 0; c < cols; ++c)
 			img(r, c) = val;
 	return img;
 }
 
-// Create a horizontal ramp: pixel value = column index
-mtl::mat::dense2D<double> make_horizontal_ramp(std::size_t rows, std::size_t cols) {
-	mtl::mat::dense2D<double> img(rows, cols);
+template <typename T>
+mtl::mat::dense2D<T> make_horizontal_ramp(std::size_t rows, std::size_t cols) {
+	mtl::mat::dense2D<T> img(rows, cols);
 	for (std::size_t r = 0; r < rows; ++r)
 		for (std::size_t c = 0; c < cols; ++c)
-			img(r, c) = static_cast<double>(c);
+			img(r, c) = static_cast<T>(c);
 	return img;
 }
 
-// Create a vertical ramp: pixel value = row index
-mtl::mat::dense2D<double> make_vertical_ramp(std::size_t rows, std::size_t cols) {
-	mtl::mat::dense2D<double> img(rows, cols);
-	for (std::size_t r = 0; r < rows; ++r)
-		for (std::size_t c = 0; c < cols; ++c)
-			img(r, c) = static_cast<double>(r);
-	return img;
-}
-
-// Create a step edge: left half = 0, right half = 1
-mtl::mat::dense2D<double> make_step_edge(std::size_t rows, std::size_t cols) {
-	mtl::mat::dense2D<double> img(rows, cols);
+template <typename T>
+mtl::mat::dense2D<T> make_step_edge(std::size_t rows, std::size_t cols) {
+	mtl::mat::dense2D<T> img(rows, cols);
 	std::size_t mid = cols / 2;
 	for (std::size_t r = 0; r < rows; ++r)
 		for (std::size_t c = 0; c < cols; ++c)
-			img(r, c) = (c >= mid) ? 1.0 : 0.0;
+			img(r, c) = (c >= mid) ? static_cast<T>(1) : static_cast<T>(0);
 	return img;
-}
-
-// Create an identity kernel (single 1 at center)
-mtl::mat::dense2D<double> make_identity_kernel() {
-	mtl::mat::dense2D<double> k(3, 3);
-	for (std::size_t r = 0; r < 3; ++r)
-		for (std::size_t c = 0; c < 3; ++c)
-			k(r, c) = 0.0;
-	k(1, 1) = 1.0;
-	return k;
 }
 
 // ========== Image Container Tests ==========
 
 void test_image_construction() {
-	Image<double, 3> rgb(10, 20);
+	// float — the typical image pixel type
+	Image<float, 3> rgb(10, 20);
 	if (!(rgb.rows() == 10)) throw std::runtime_error("test failed: Image rows");
 	if (!(rgb.cols() == 20)) throw std::runtime_error("test failed: Image cols");
 	if (!(rgb.channels() == 3)) throw std::runtime_error("test failed: Image channels");
 
-	// Default construction
-	GrayImage<double> gray;
+	GrayImage<float> gray;
 	RGBImage<float> rgb_f(5, 5);
-	RGBAImage<double> rgba(8, 8);
+	RGBAImage<float> rgba(8, 8);
 	if (!(rgba.channels() == 4)) throw std::runtime_error("test failed: RGBA channels");
+
+	// Verify container compiles with double (for precision-sensitive algorithms)
+	Image<double, 1> gray_d(4, 4);
+	(void)gray_d;
 
 	std::cout << "  image_construction: passed\n";
 }
 
 void test_apply_per_channel() {
-	RGBImage<double> rgb(4, 4);
-	// Fill each channel with a different constant
+	RGBImage<float> rgb(4, 4);
 	for (std::size_t r = 0; r < 4; ++r) {
 		for (std::size_t c = 0; c < 4; ++c) {
-			rgb[0](r, c) = 1.0;
-			rgb[1](r, c) = 2.0;
-			rgb[2](r, c) = 3.0;
+			rgb[0](r, c) = 1.0f;
+			rgb[1](r, c) = 2.0f;
+			rgb[2](r, c) = 3.0f;
 		}
 	}
 
-	// Double each channel
-	auto result = apply_per_channel(rgb, [](const mtl::mat::dense2D<double>& plane) {
-		mtl::mat::dense2D<double> out(plane.num_rows(), plane.num_cols());
+	auto result = apply_per_channel(rgb, [](const mtl::mat::dense2D<float>& plane) {
+		mtl::mat::dense2D<float> out(plane.num_rows(), plane.num_cols());
 		for (std::size_t r = 0; r < plane.num_rows(); ++r)
 			for (std::size_t c = 0; c < plane.num_cols(); ++c)
-				out(r, c) = plane(r, c) * 2.0;
+				out(r, c) = plane(r, c) * 2.0f;
 		return out;
 	});
 
@@ -109,13 +97,13 @@ void test_apply_per_channel() {
 }
 
 void test_rgb_to_gray() {
-	RGBImage<double> rgb(2, 2);
+	RGBImage<float> rgb(2, 2);
 	// White pixel: R=G=B=1.0
 	for (std::size_t r = 0; r < 2; ++r) {
 		for (std::size_t c = 0; c < 2; ++c) {
-			rgb[0](r, c) = 1.0;
-			rgb[1](r, c) = 1.0;
-			rgb[2](r, c) = 1.0;
+			rgb[0](r, c) = 1.0f;
+			rgb[1](r, c) = 1.0f;
+			rgb[2](r, c) = 1.0f;
 		}
 	}
 	auto gray = rgb_to_gray(rgb);
@@ -126,9 +114,9 @@ void test_rgb_to_gray() {
 	// Pure red
 	for (std::size_t r = 0; r < 2; ++r) {
 		for (std::size_t c = 0; c < 2; ++c) {
-			rgb[0](r, c) = 1.0;
-			rgb[1](r, c) = 0.0;
-			rgb[2](r, c) = 0.0;
+			rgb[0](r, c) = 1.0f;
+			rgb[1](r, c) = 0.0f;
+			rgb[2](r, c) = 0.0f;
 		}
 	}
 	gray = rgb_to_gray(rgb);
@@ -141,12 +129,12 @@ void test_rgb_to_gray() {
 // ========== Border Handling Tests ==========
 
 void test_border_modes() {
-	// 4-pixel row image: [10, 20, 30, 40]
-	mtl::mat::dense2D<double> img(1, 4);
-	img(0, 0) = 10; img(0, 1) = 20; img(0, 2) = 30; img(0, 3) = 40;
+	// Test with float — the type users will actually use
+	mtl::mat::dense2D<float> img(1, 4);
+	img(0, 0) = 10.0f; img(0, 1) = 20.0f; img(0, 2) = 30.0f; img(0, 3) = 40.0f;
 
 	// Zero padding
-	double val = fetch_pixel(img, 0, -1, BorderMode::zero);
+	float val = fetch_pixel(img, 0, -1, BorderMode::zero);
 	if (!(near(val, 0.0))) throw std::runtime_error("test failed: border zero");
 
 	// Replicate
@@ -170,7 +158,7 @@ void test_border_modes() {
 	if (!(near(val, 10.0))) throw std::runtime_error("test failed: border wrap right");
 
 	// Constant with pad value
-	val = fetch_pixel(img, 0, -1, BorderMode::constant, 99.0);
+	val = fetch_pixel(img, 0, -1, BorderMode::constant, 99.0f);
 	if (!(near(val, 99.0))) throw std::runtime_error("test failed: border constant");
 
 	std::cout << "  border_modes: passed\n";
@@ -179,11 +167,16 @@ void test_border_modes() {
 // ========== Convolution Tests ==========
 
 void test_convolve2d_identity() {
-	auto img = make_horizontal_ramp(5, 5);
-	auto kernel = make_identity_kernel();
+	// float image, double kernel — the typical mixed-precision path
+	auto img = make_horizontal_ramp<float>(5, 5);
+	mtl::mat::dense2D<double> kernel(3, 3);
+	for (std::size_t r = 0; r < 3; ++r)
+		for (std::size_t c = 0; c < 3; ++c)
+			kernel(r, c) = 0.0;
+	kernel(1, 1) = 1.0;
+
 	auto result = convolve2d(img, kernel);
 
-	// Identity kernel should reproduce the input
 	for (std::size_t r = 0; r < 5; ++r)
 		for (std::size_t c = 0; c < 5; ++c)
 			if (!(near(result(r, c), img(r, c))))
@@ -193,8 +186,8 @@ void test_convolve2d_identity() {
 }
 
 void test_convolve2d_box_blur() {
-	// 5x5 constant image with value 7 — box blur should leave it unchanged
-	auto img = make_constant(5, 5, 7.0);
+	// float constant image, double box kernel
+	auto img = make_constant<float>(5, 5, 7.0f);
 	mtl::mat::dense2D<double> box(3, 3);
 	for (std::size_t r = 0; r < 3; ++r)
 		for (std::size_t c = 0; c < 3; ++c)
@@ -203,22 +196,27 @@ void test_convolve2d_box_blur() {
 	auto result = convolve2d(img, box);
 	for (std::size_t r = 0; r < 5; ++r)
 		for (std::size_t c = 0; c < 5; ++c)
-			if (!(near(result(r, c), 7.0, 1e-6)))
+			if (!(near(result(r, c), 7.0, 1e-5)))
 				throw std::runtime_error("test failed: box blur on constant");
 
 	std::cout << "  convolve2d_box_blur: passed\n";
 }
 
 void test_convolve2d_multichannel() {
-	RGBImage<double> rgb(5, 5);
+	RGBImage<float> rgb(5, 5);
 	for (std::size_t r = 0; r < 5; ++r)
 		for (std::size_t c = 0; c < 5; ++c) {
-			rgb[0](r, c) = 1.0;
-			rgb[1](r, c) = 2.0;
-			rgb[2](r, c) = 3.0;
+			rgb[0](r, c) = 1.0f;
+			rgb[1](r, c) = 2.0f;
+			rgb[2](r, c) = 3.0f;
 		}
 
-	auto kernel = make_identity_kernel();
+	mtl::mat::dense2D<double> kernel(3, 3);
+	for (std::size_t r = 0; r < 3; ++r)
+		for (std::size_t c = 0; c < 3; ++c)
+			kernel(r, c) = 0.0;
+	kernel(1, 1) = 1.0;
+
 	auto result = convolve2d(rgb, kernel);
 
 	if (!(near(result[0](2, 2), 1.0))) throw std::runtime_error("test failed: multichannel conv R");
@@ -231,16 +229,16 @@ void test_convolve2d_multichannel() {
 // ========== Separable Filter Tests ==========
 
 void test_separable_vs_2d() {
-	// Separable box blur should match 2D box blur
-	auto img = make_horizontal_ramp(8, 8);
+	// Both float image — verify separable matches non-separable
+	auto img = make_horizontal_ramp<float>(8, 8);
 
-	// 2D box kernel
+	// 2D box kernel (double precision coefficients)
 	mtl::mat::dense2D<double> box2d(3, 3);
 	for (std::size_t r = 0; r < 3; ++r)
 		for (std::size_t c = 0; c < 3; ++c)
 			box2d(r, c) = 1.0 / 9.0;
 
-	// Separable box kernel: [1/3, 1/3, 1/3] x [1/3, 1/3, 1/3]
+	// Separable box kernel (double precision)
 	auto box1d = box_kernel_1d<double>(3);
 
 	auto result_2d = convolve2d(img, box2d);
@@ -248,15 +246,15 @@ void test_separable_vs_2d() {
 
 	for (std::size_t r = 0; r < 8; ++r)
 		for (std::size_t c = 0; c < 8; ++c)
-			if (!(near(result_2d(r, c), result_sep(r, c), 1e-10)))
+			if (!(near(result_2d(r, c), result_sep(r, c), 1e-5)))
 				throw std::runtime_error("test failed: separable vs 2D mismatch");
 
 	std::cout << "  separable_vs_2d: passed\n";
 }
 
 void test_gaussian_blur() {
-	// Gaussian blur of a constant image should be the same constant
-	auto img = make_constant(10, 10, 5.0);
+	// Gaussian blur of a constant float image should preserve the value
+	auto img = make_constant<float>(10, 10, 5.0f);
 	auto blurred = gaussian_blur(img, 1.0);
 
 	for (std::size_t r = 1; r + 1 < 10; ++r)
@@ -268,15 +266,28 @@ void test_gaussian_blur() {
 }
 
 void test_box_blur() {
-	auto img = make_constant(8, 8, 3.0);
+	auto img = make_constant<float>(8, 8, 3.0f);
 	auto blurred = box_blur(img, 3);
-	// Should remain 3.0
 	for (std::size_t r = 0; r < 8; ++r)
 		for (std::size_t c = 0; c < 8; ++c)
-			if (!(near(blurred(r, c), 3.0, 1e-6)))
+			if (!(near(blurred(r, c), 3.0, 1e-5)))
 				throw std::runtime_error("test failed: box blur constant");
 
 	std::cout << "  box_blur: passed\n";
+}
+
+void test_blur_validation() {
+	auto img = make_constant<float>(4, 4, 1.0f);
+
+	bool caught = false;
+	try { gaussian_blur(img, 0.0); } catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: gaussian_blur should reject sigma=0");
+
+	caught = false;
+	try { box_blur(img, 0); } catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: box_blur should reject size=0");
+
+	std::cout << "  blur_validation: passed\n";
 }
 
 // ========== Morphology Tests ==========
@@ -294,39 +305,54 @@ void test_structuring_elements() {
 	if (cross(0, 0)) throw std::runtime_error("test failed: cross corner should be false");
 
 	auto ellipse = make_ellipse_element(5);
-	// Center should be true
 	if (!ellipse(2, 2)) throw std::runtime_error("test failed: ellipse center");
-	// Corners should be false for a 5x5 ellipse
 	if (ellipse(0, 0)) throw std::runtime_error("test failed: ellipse corner");
 
 	std::cout << "  structuring_elements: passed\n";
 }
 
 void test_dilate_erode() {
-	// Single bright pixel in a dark field
-	auto img = make_constant(7, 7, 0.0);
-	img(3, 3) = 1.0;
+	// Morphology on float — the typical use case
+	auto img = make_constant<float>(7, 7, 0.0f);
+	img(3, 3) = 1.0f;
 
 	auto elem = make_rect_element(3, 3);
 
-	// Dilation should spread the bright pixel to its 3x3 neighborhood
 	auto dilated = dilate(img, elem);
 	if (!(near(dilated(3, 3), 1.0))) throw std::runtime_error("test failed: dilate center");
 	if (!(near(dilated(2, 2), 1.0))) throw std::runtime_error("test failed: dilate neighbor");
 	if (!(near(dilated(1, 1), 0.0))) throw std::runtime_error("test failed: dilate far");
 
-	// Erosion of the dilated result should shrink it back
 	auto eroded = erode(dilated, elem);
 	if (!(near(eroded(3, 3), 1.0))) throw std::runtime_error("test failed: erode center");
-	// One pixel away from center should be 0 after erode(dilate)
 	if (!(near(eroded(1, 1), 0.0))) throw std::runtime_error("test failed: erode far");
 
 	std::cout << "  dilate_erode: passed\n";
 }
 
+void test_morphology_element_validation() {
+	auto img = make_constant<float>(4, 4, 1.0f);
+
+	// Empty element should throw
+	mtl::mat::dense2D<bool> empty(0, 0);
+	bool caught = false;
+	try { dilate(img, empty); } catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: dilate should reject empty element");
+
+	// Element with no active pixels should throw
+	mtl::mat::dense2D<bool> all_false(3, 3);
+	for (std::size_t r = 0; r < 3; ++r)
+		for (std::size_t c = 0; c < 3; ++c)
+			all_false(r, c) = false;
+	caught = false;
+	try { erode(img, all_false); } catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: erode should reject all-false element");
+
+	std::cout << "  morphology_element_validation: passed\n";
+}
+
 void test_morphological_open_idempotent() {
-	// Opening is idempotent: open(open(x)) == open(x)
-	auto img = make_step_edge(8, 8);
+	auto img = make_step_edge<float>(8, 8);
 	auto elem = make_rect_element(3, 3);
 
 	auto opened = morphological_open(img, elem);
@@ -334,14 +360,14 @@ void test_morphological_open_idempotent() {
 
 	for (std::size_t r = 0; r < 8; ++r)
 		for (std::size_t c = 0; c < 8; ++c)
-			if (!(near(opened(r, c), opened2(r, c), 1e-10)))
+			if (!(near(opened(r, c), opened2(r, c), 1e-6)))
 				throw std::runtime_error("test failed: open idempotency");
 
 	std::cout << "  morphological_open_idempotent: passed\n";
 }
 
 void test_morphological_close_idempotent() {
-	auto img = make_step_edge(8, 8);
+	auto img = make_step_edge<float>(8, 8);
 	auto elem = make_rect_element(3, 3);
 
 	auto closed = morphological_close(img, elem);
@@ -349,39 +375,37 @@ void test_morphological_close_idempotent() {
 
 	for (std::size_t r = 0; r < 8; ++r)
 		for (std::size_t c = 0; c < 8; ++c)
-			if (!(near(closed(r, c), closed2(r, c), 1e-10)))
+			if (!(near(closed(r, c), closed2(r, c), 1e-6)))
 				throw std::runtime_error("test failed: close idempotency");
 
 	std::cout << "  morphological_close_idempotent: passed\n";
 }
 
 void test_morphological_gradient() {
-	// Gradient of a constant image should be zero
-	auto img = make_constant(8, 8, 5.0);
+	auto img = make_constant<float>(8, 8, 5.0f);
 	auto elem = make_rect_element(3, 3);
 	auto grad = morphological_gradient(img, elem);
 
 	for (std::size_t r = 0; r < 8; ++r)
 		for (std::size_t c = 0; c < 8; ++c)
-			if (!(near(grad(r, c), 0.0, 1e-10)))
+			if (!(near(grad(r, c), 0.0, 1e-6)))
 				throw std::runtime_error("test failed: gradient of constant");
 
 	std::cout << "  morphological_gradient: passed\n";
 }
 
 void test_tophat_blackhat() {
-	auto img = make_constant(8, 8, 5.0);
+	auto img = make_constant<float>(8, 8, 5.0f);
 	auto elem = make_rect_element(3, 3);
 
-	// Top-hat and black-hat of a constant image should both be zero
 	auto th = tophat(img, elem);
 	auto bh = blackhat(img, elem);
 
 	for (std::size_t r = 0; r < 8; ++r) {
 		for (std::size_t c = 0; c < 8; ++c) {
-			if (!(near(th(r, c), 0.0, 1e-10)))
+			if (!(near(th(r, c), 0.0, 1e-6)))
 				throw std::runtime_error("test failed: tophat constant");
-			if (!(near(bh(r, c), 0.0, 1e-10)))
+			if (!(near(bh(r, c), 0.0, 1e-6)))
 				throw std::runtime_error("test failed: blackhat constant");
 		}
 	}
@@ -392,16 +416,15 @@ void test_tophat_blackhat() {
 // ========== Edge Detection Tests ==========
 
 void test_sobel_constant() {
-	// Sobel of a constant image should be zero everywhere
-	auto img = make_constant(8, 8, 5.0);
+	auto img = make_constant<float>(8, 8, 5.0f);
 	auto gx = sobel_x(img);
 	auto gy = sobel_y(img);
 
 	for (std::size_t r = 1; r + 1 < 8; ++r) {
 		for (std::size_t c = 1; c + 1 < 8; ++c) {
-			if (!(near(gx(r, c), 0.0, 1e-6)))
+			if (!(near(gx(r, c), 0.0, 1e-4)))
 				throw std::runtime_error("test failed: sobel_x constant");
-			if (!(near(gy(r, c), 0.0, 1e-6)))
+			if (!(near(gy(r, c), 0.0, 1e-4)))
 				throw std::runtime_error("test failed: sobel_y constant");
 		}
 	}
@@ -410,31 +433,25 @@ void test_sobel_constant() {
 }
 
 void test_sobel_horizontal_ramp() {
-	// Horizontal ramp: pixel = column index
-	// Sobel X should detect the constant horizontal gradient
-	// Sobel Y should be zero (no vertical variation)
-	auto img = make_horizontal_ramp(10, 10);
+	auto img = make_horizontal_ramp<float>(10, 10);
 	auto gx = sobel_x(img);
 	auto gy = sobel_y(img);
 
-	// Interior pixels should have constant gx (non-zero) and zero gy
-	// The Sobel X kernel on a unit-slope ramp gives:
-	// For f(r,c) = c: Sobel_X = [1,2,1]^T * [-1,0,1] applied to c
-	// = (c+1 - (c-1)) * (1+2+1) = 2*4 = 8
+	// Interior pixels: constant gx, zero gy
 	for (std::size_t r = 2; r + 2 < 10; ++r) {
 		for (std::size_t c = 2; c + 2 < 10; ++c) {
-			if (!(std::abs(gx(r, c)) > 0.1))
+			if (!(std::abs(static_cast<double>(gx(r, c))) > 0.1))
 				throw std::runtime_error("test failed: sobel_x ramp should be non-zero");
-			if (!(near(gy(r, c), 0.0, 1e-6)))
+			if (!(near(gy(r, c), 0.0, 1e-4)))
 				throw std::runtime_error("test failed: sobel_y of h-ramp should be zero");
 		}
 	}
 
 	// All interior gx values should be the same (constant gradient)
-	double ref = gx(4, 4);
+	float ref = gx(4, 4);
 	for (std::size_t r = 2; r + 2 < 10; ++r) {
 		for (std::size_t c = 2; c + 2 < 10; ++c) {
-			if (!(near(gx(r, c), ref, 1e-6)))
+			if (!(near(gx(r, c), ref, 1e-4)))
 				throw std::runtime_error("test failed: sobel_x ramp not constant");
 		}
 	}
@@ -443,16 +460,15 @@ void test_sobel_horizontal_ramp() {
 }
 
 void test_prewitt() {
-	auto img = make_horizontal_ramp(8, 8);
+	auto img = make_horizontal_ramp<float>(8, 8);
 	auto gx = prewitt_x(img);
 	auto gy = prewitt_y(img);
 
-	// Same logic as Sobel: constant horizontal gradient, zero vertical
 	for (std::size_t r = 2; r + 2 < 8; ++r) {
 		for (std::size_t c = 2; c + 2 < 8; ++c) {
-			if (!(std::abs(gx(r, c)) > 0.1))
+			if (!(std::abs(static_cast<double>(gx(r, c))) > 0.1))
 				throw std::runtime_error("test failed: prewitt_x ramp non-zero");
-			if (!(near(gy(r, c), 0.0, 1e-6)))
+			if (!(near(gy(r, c), 0.0, 1e-4)))
 				throw std::runtime_error("test failed: prewitt_y of h-ramp zero");
 		}
 	}
@@ -461,16 +477,15 @@ void test_prewitt() {
 }
 
 void test_gradient_magnitude() {
-	auto img = make_horizontal_ramp(8, 8);
+	auto img = make_horizontal_ramp<float>(8, 8);
 	auto gx = sobel_x(img);
 	auto gy = sobel_y(img);
 	auto mag = gradient_magnitude(gx, gy);
 
-	// Since gy ≈ 0 for horizontal ramp, magnitude ≈ |gx|
 	for (std::size_t r = 2; r + 2 < 8; ++r) {
 		for (std::size_t c = 2; c + 2 < 8; ++c) {
-			double expected = std::abs(gx(r, c));
-			if (!(near(mag(r, c), expected, 1e-6)))
+			double expected = std::abs(static_cast<double>(gx(r, c)));
+			if (!(near(mag(r, c), expected, 1e-4)))
 				throw std::runtime_error("test failed: gradient magnitude");
 		}
 	}
@@ -478,12 +493,20 @@ void test_gradient_magnitude() {
 	std::cout << "  gradient_magnitude: passed\n";
 }
 
+void test_gradient_magnitude_validation() {
+	mtl::mat::dense2D<float> a(4, 4), b(3, 3);
+	bool caught = false;
+	try { gradient_magnitude(a, b); } catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: gradient_magnitude should reject dim mismatch");
+
+	std::cout << "  gradient_magnitude_validation: passed\n";
+}
+
 void test_canny_step_edge() {
-	// Canny on a step edge should produce edges near the transition
-	auto img = make_step_edge(20, 20);
+	// Canny requires double for threshold math — test with double pixels
+	auto img = make_step_edge<double>(20, 20);
 	auto edges = canny(img, 0.1, 0.3, 1.0);
 
-	// Check that edge pixels exist near column 10 (the step)
 	bool found_edge = false;
 	for (std::size_t r = 3; r + 3 < 20; ++r) {
 		for (std::size_t c = 8; c <= 12; ++c) {
@@ -497,7 +520,6 @@ void test_canny_step_edge() {
 	if (!found_edge)
 		throw std::runtime_error("test failed: canny should detect step edge");
 
-	// Check that far-from-edge pixels are not marked
 	bool clean_left = true;
 	for (std::size_t r = 3; r + 3 < 20; ++r) {
 		for (std::size_t c = 0; c < 5; ++c) {
@@ -513,10 +535,12 @@ void test_canny_step_edge() {
 	std::cout << "  canny_step_edge: passed\n";
 }
 
-// ========== Mixed Precision Test ==========
+// ========== Mixed Precision Tests ==========
 
 void test_mixed_precision_convolution() {
-	// float image convolved with double kernel
+	// float image + double kernel: the primary mixed-precision use case.
+	// The accumulator should use double precision, avoiding float rounding
+	// in the inner product.
 	mtl::mat::dense2D<float> img(5, 5);
 	for (std::size_t r = 0; r < 5; ++r)
 		for (std::size_t c = 0; c < 5; ++c)
@@ -529,52 +553,85 @@ void test_mixed_precision_convolution() {
 	kernel(1, 1) = 1.0;
 
 	auto result = convolve2d(img, kernel);
-	// Identity kernel should reproduce input
 	if (!(near(static_cast<double>(result(2, 3)), 3.0, 1e-5)))
-		throw std::runtime_error("test failed: mixed precision convolution");
+		throw std::runtime_error("test failed: float+double convolution");
 
 	std::cout << "  mixed_precision_convolution: passed\n";
+}
+
+void test_mixed_precision_separable() {
+	// float image + double kernel via separable filter
+	auto img = make_constant<float>(6, 6, 4.0f);
+	auto kernel = box_kernel_1d<double>(3);  // double kernel coefficients
+
+	auto result = separable_filter(img, kernel, kernel);
+	// Constant image should be unchanged
+	for (std::size_t r = 0; r < 6; ++r)
+		for (std::size_t c = 0; c < 6; ++c)
+			if (!(near(result(r, c), 4.0, 1e-5)))
+				throw std::runtime_error("test failed: float+double separable");
+
+	std::cout << "  mixed_precision_separable: passed\n";
+}
+
+void test_mixed_precision_gaussian() {
+	// float image with double-precision Gaussian kernel
+	// (gaussian_blur already uses double kernels internally)
+	auto img = make_constant<float>(8, 8, 2.5f);
+	auto blurred = gaussian_blur(img, 1.0);
+
+	for (std::size_t r = 1; r + 1 < 8; ++r)
+		for (std::size_t c = 1; c + 1 < 8; ++c)
+			if (!(near(blurred(r, c), 2.5, 1e-3)))
+				throw std::runtime_error("test failed: float gaussian blur");
+
+	std::cout << "  mixed_precision_gaussian: passed\n";
 }
 
 int main() {
 	try {
 		std::cout << "Image Processing Tests\n";
 
-		// Container and utilities
+		// Container and utilities (float)
 		test_image_construction();
 		test_apply_per_channel();
 		test_rgb_to_gray();
 
-		// Border handling
+		// Border handling (float)
 		test_border_modes();
 
-		// Convolution
+		// Convolution (float image + double kernel)
 		test_convolve2d_identity();
 		test_convolve2d_box_blur();
 		test_convolve2d_multichannel();
 
-		// Separable filters
+		// Separable filters (float image + double kernel)
 		test_separable_vs_2d();
 		test_gaussian_blur();
 		test_box_blur();
+		test_blur_validation();
 
-		// Morphology
+		// Morphology (float)
 		test_structuring_elements();
 		test_dilate_erode();
+		test_morphology_element_validation();
 		test_morphological_open_idempotent();
 		test_morphological_close_idempotent();
 		test_morphological_gradient();
 		test_tophat_blackhat();
 
-		// Edge detection
+		// Edge detection (float + double for Canny)
 		test_sobel_constant();
 		test_sobel_horizontal_ramp();
 		test_prewitt();
 		test_gradient_magnitude();
+		test_gradient_magnitude_validation();
 		test_canny_step_edge();
 
-		// Mixed precision
+		// Mixed precision (float pixel + double kernel)
 		test_mixed_precision_convolution();
+		test_mixed_precision_separable();
+		test_mixed_precision_gaussian();
 
 		std::cout << "All image processing tests passed.\n";
 		return 0;


### PR DESCRIPTION
## Summary
- Implements Phase 10 image processing using planar `Image<T, Channels>` container built on `mtl::mat::dense2D<T>`
- All core algorithms operate on single `dense2D<T>` channels; multi-channel images processed via `apply_per_channel()`
- Design assessment comparing our API to OpenCV's included in `docs/assessments/`

## Changes
- `include/sw/dsp/image/image.hpp` — `Image<T,C>` container, `BorderMode` enum (6 modes), border pixel fetch, `rgb_to_gray`, `apply_per_channel`
- `include/sw/dsp/image/convolve2d.hpp` — 2D spatial convolution with mixed-precision kernel support
- `include/sw/dsp/image/separable.hpp` — separable row+col filtering, Gaussian/box kernel factories
- `include/sw/dsp/image/morphology.hpp` — erode, dilate, open, close, gradient, tophat, blackhat + structuring element factories
- `include/sw/dsp/image/edge.hpp` — Sobel, Prewitt, gradient magnitude, Canny edge detector
- `tests/test_image.cpp` — 22 tests covering all components
- `applications/image_demo/edge_detection.cpp` — demo application
- `docs/assessments/image-api-opencv-comparison.md` — OpenCV API comparison and design rationale

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_image | OK | 22/22 PASS | OK | 22/22 PASS |
| edge_detection | OK | runs | OK | runs |
| all tests (ctest) | OK | 16/16 PASS | OK | 16/16 PASS |

## Test plan
- [x] Fast CI passes (gcc + clang + MSVC + Apple Clang + RISC-V)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full image-processing API: multi-channel images, border modes, 2D convolution, separable filtering, Gaussian/box blur, morphology, Sobel/Prewitt gradients, gradient magnitude, and Canny edge detector
  * RGB-to-grayscale and per-channel helpers
  * New command-line image demo included in the build

* **Documentation**
  * Added design assessment comparing the image API with existing industry practices

* **Tests**
  * Comprehensive test suite covering image types, filters, morphology, border modes, and edge detectors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->