### PR TITLE
feat(image): synthetic image generators for testing and demonstration

### DIFF
--- a/include/sw/dsp/image/generators.hpp
+++ b/include/sw/dsp/image/generators.hpp
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <cstddef>
 #include <random>
+#include <stdexcept>
 #include <mtl/mat/dense2D.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
 
@@ -31,6 +32,8 @@ template <DspField T>
 mtl::mat::dense2D<T> checkerboard(std::size_t rows, std::size_t cols,
                                    std::size_t block_size,
                                    T low = T{}, T high = static_cast<T>(1)) {
+	if (block_size == 0)
+		throw std::invalid_argument("checkerboard: block_size must be > 0");
 	mtl::mat::dense2D<T> img(rows, cols);
 	for (std::size_t r = 0; r < rows; ++r)
 		for (std::size_t c = 0; c < cols; ++c)
@@ -43,6 +46,8 @@ template <DspField T>
 mtl::mat::dense2D<T> stripes_horizontal(std::size_t rows, std::size_t cols,
                                          std::size_t stripe_width,
                                          T low = T{}, T high = static_cast<T>(1)) {
+	if (stripe_width == 0)
+		throw std::invalid_argument("stripes_horizontal: stripe_width must be > 0");
 	mtl::mat::dense2D<T> img(rows, cols);
 	for (std::size_t r = 0; r < rows; ++r)
 		for (std::size_t c = 0; c < cols; ++c)
@@ -55,6 +60,8 @@ template <DspField T>
 mtl::mat::dense2D<T> stripes_vertical(std::size_t rows, std::size_t cols,
                                        std::size_t stripe_width,
                                        T low = T{}, T high = static_cast<T>(1)) {
+	if (stripe_width == 0)
+		throw std::invalid_argument("stripes_vertical: stripe_width must be > 0");
 	mtl::mat::dense2D<T> img(rows, cols);
 	for (std::size_t r = 0; r < rows; ++r)
 		for (std::size_t c = 0; c < cols; ++c)
@@ -67,6 +74,8 @@ template <DspField T>
 mtl::mat::dense2D<T> grid(std::size_t rows, std::size_t cols,
                            std::size_t spacing,
                            T background = T{}, T line = static_cast<T>(1)) {
+	if (spacing == 0)
+		throw std::invalid_argument("grid: spacing must be > 0");
 	mtl::mat::dense2D<T> img(rows, cols);
 	for (std::size_t r = 0; r < rows; ++r)
 		for (std::size_t c = 0; c < cols; ++c)
@@ -146,6 +155,8 @@ template <DspField T>
 mtl::mat::dense2D<T> gaussian_blob(std::size_t rows, std::size_t cols,
                                     double sigma,
                                     T amplitude = static_cast<T>(1)) {
+	if (sigma <= 0.0)
+		throw std::invalid_argument("gaussian_blob: sigma must be > 0");
 	mtl::mat::dense2D<T> img(rows, cols);
 	double cy = static_cast<double>(rows - 1) * 0.5;
 	double cx = static_cast<double>(cols - 1) * 0.5;

--- a/include/sw/dsp/image/generators.hpp
+++ b/include/sw/dsp/image/generators.hpp
@@ -1,0 +1,267 @@
+#pragma once
+// generators.hpp: synthetic image generator functions
+//
+// Free functions that produce standard test images as mtl::mat::dense2D<T>.
+// All generators are templated on DspField T for mixed-precision support.
+//
+// Categories:
+//   Geometric patterns: checkerboard, stripes, grid
+//   Gradients: horizontal, vertical, radial
+//   Shapes: gaussian_blob, circle, rectangle
+//   Noise: uniform, gaussian, salt-and-pepper
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <random>
+#include <mtl/mat/dense2D.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+// ============================================================================
+// Geometric patterns
+// ============================================================================
+
+// Alternating blocks of low/high values.
+// Ideal for testing edge detectors and morphological operations.
+template <DspField T>
+mtl::mat::dense2D<T> checkerboard(std::size_t rows, std::size_t cols,
+                                   std::size_t block_size,
+                                   T low = T{}, T high = static_cast<T>(1)) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = ((r / block_size + c / block_size) % 2 == 0) ? high : low;
+	return img;
+}
+
+// Horizontal stripes of alternating low/high values.
+template <DspField T>
+mtl::mat::dense2D<T> stripes_horizontal(std::size_t rows, std::size_t cols,
+                                         std::size_t stripe_width,
+                                         T low = T{}, T high = static_cast<T>(1)) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = ((r / stripe_width) % 2 == 0) ? high : low;
+	return img;
+}
+
+// Vertical stripes of alternating low/high values.
+template <DspField T>
+mtl::mat::dense2D<T> stripes_vertical(std::size_t rows, std::size_t cols,
+                                       std::size_t stripe_width,
+                                       T low = T{}, T high = static_cast<T>(1)) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = ((c / stripe_width) % 2 == 0) ? high : low;
+	return img;
+}
+
+// Grid pattern: thin lines at regular spacing.
+template <DspField T>
+mtl::mat::dense2D<T> grid(std::size_t rows, std::size_t cols,
+                           std::size_t spacing,
+                           T background = T{}, T line = static_cast<T>(1)) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = (r % spacing == 0 || c % spacing == 0) ? line : background;
+	return img;
+}
+
+// ============================================================================
+// Gradients
+// ============================================================================
+
+// Linear ramp from left (start) to right (end).
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> gradient_horizontal(std::size_t rows, std::size_t cols,
+                                          T start = T{}, T end = static_cast<T>(1)) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			double t = (cols > 1) ? static_cast<double>(c) / static_cast<double>(cols - 1) : 0.0;
+			img(r, c) = static_cast<T>(static_cast<double>(start) * (1.0 - t)
+			                           + static_cast<double>(end) * t);
+		}
+	}
+	return img;
+}
+
+// Linear ramp from top (start) to bottom (end).
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> gradient_vertical(std::size_t rows, std::size_t cols,
+                                        T start = T{}, T end = static_cast<T>(1)) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r) {
+		double t = (rows > 1) ? static_cast<double>(r) / static_cast<double>(rows - 1) : 0.0;
+		T val = static_cast<T>(static_cast<double>(start) * (1.0 - t)
+		                       + static_cast<double>(end) * t);
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = val;
+	}
+	return img;
+}
+
+// Radial gradient: center_val at image center, edge_val at corners.
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> gradient_radial(std::size_t rows, std::size_t cols,
+                                      T center_val = static_cast<T>(1),
+                                      T edge_val = T{}) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	double cy = static_cast<double>(rows - 1) * 0.5;
+	double cx = static_cast<double>(cols - 1) * 0.5;
+	double max_dist = std::sqrt(cy * cy + cx * cx);
+	if (max_dist < 1e-20) max_dist = 1.0;
+
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			double dy = static_cast<double>(r) - cy;
+			double dx = static_cast<double>(c) - cx;
+			double t = std::sqrt(dy * dy + dx * dx) / max_dist;
+			if (t > 1.0) t = 1.0;
+			img(r, c) = static_cast<T>(static_cast<double>(center_val) * (1.0 - t)
+			                           + static_cast<double>(edge_val) * t);
+		}
+	}
+	return img;
+}
+
+// ============================================================================
+// Shapes
+// ============================================================================
+
+// 2D Gaussian blob centered in the image.
+// Useful for testing separable filters and blur operations.
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> gaussian_blob(std::size_t rows, std::size_t cols,
+                                    double sigma,
+                                    T amplitude = static_cast<T>(1)) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	double cy = static_cast<double>(rows - 1) * 0.5;
+	double cx = static_cast<double>(cols - 1) * 0.5;
+	double inv_2sigma2 = 1.0 / (2.0 * sigma * sigma);
+
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			double dy = static_cast<double>(r) - cy;
+			double dx = static_cast<double>(c) - cx;
+			double val = std::exp(-(dy * dy + dx * dx) * inv_2sigma2);
+			img(r, c) = static_cast<T>(static_cast<double>(amplitude) * val);
+		}
+	}
+	return img;
+}
+
+// Filled circle centered in the image.
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> circle(std::size_t rows, std::size_t cols,
+                             std::size_t radius,
+                             T foreground = static_cast<T>(1), T background = T{}) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	double cy = static_cast<double>(rows - 1) * 0.5;
+	double cx = static_cast<double>(cols - 1) * 0.5;
+	double r2 = static_cast<double>(radius) * static_cast<double>(radius);
+
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			double dy = static_cast<double>(r) - cy;
+			double dx = static_cast<double>(c) - cx;
+			img(r, c) = (dy * dy + dx * dx <= r2) ? foreground : background;
+		}
+	}
+	return img;
+}
+
+// Filled rectangle at specified position (y, x) with dimensions (h, w).
+template <DspField T>
+mtl::mat::dense2D<T> rectangle(std::size_t rows, std::size_t cols,
+                                std::size_t y, std::size_t x,
+                                std::size_t h, std::size_t w,
+                                T foreground = static_cast<T>(1), T background = T{}) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = (r >= y && r < y + h && c >= x && c < x + w)
+				? foreground : background;
+	return img;
+}
+
+// ============================================================================
+// Noise
+// ============================================================================
+
+// Uniform random noise in [low, high].
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> uniform_noise_image(std::size_t rows, std::size_t cols,
+                                          T low = T{}, T high = static_cast<T>(1),
+                                          unsigned seed = 0) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	std::mt19937 gen(seed);
+	std::uniform_real_distribution<double> dist(static_cast<double>(low),
+	                                            static_cast<double>(high));
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = static_cast<T>(dist(gen));
+	return img;
+}
+
+// Gaussian random noise with specified mean and standard deviation.
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> gaussian_noise_image(std::size_t rows, std::size_t cols,
+                                           T mean = T{}, T stddev = static_cast<T>(1),
+                                           unsigned seed = 0) {
+	mtl::mat::dense2D<T> img(rows, cols);
+	std::mt19937 gen(seed);
+	std::normal_distribution<double> dist(static_cast<double>(mean),
+	                                      static_cast<double>(stddev));
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = static_cast<T>(dist(gen));
+	return img;
+}
+
+// Salt-and-pepper (impulse) noise.
+// Randomly sets a fraction (density) of pixels to low or high values.
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> salt_and_pepper(std::size_t rows, std::size_t cols,
+                                      double density = 0.05,
+                                      T low = T{}, T high = static_cast<T>(1),
+                                      unsigned seed = 0) {
+	// Start with a mid-gray image
+	mtl::mat::dense2D<T> img(rows, cols);
+	T mid = static_cast<T>((static_cast<double>(low) + static_cast<double>(high)) * 0.5);
+	for (std::size_t r = 0; r < rows; ++r)
+		for (std::size_t c = 0; c < cols; ++c)
+			img(r, c) = mid;
+
+	std::mt19937 gen(seed);
+	std::uniform_real_distribution<double> dist(0.0, 1.0);
+	double half_density = density * 0.5;
+
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			double p = dist(gen);
+			if (p < half_density)
+				img(r, c) = low;   // pepper
+			else if (p < density)
+				img(r, c) = high;  // salt
+		}
+	}
+	return img;
+}
+
+} // namespace sw::dsp

--- a/include/sw/dsp/image/image.hpp
+++ b/include/sw/dsp/image/image.hpp
@@ -163,3 +163,4 @@ mtl::mat::dense2D<T> rgb_to_gray(const Image<T, 3>& rgb) {
 #include <sw/dsp/image/separable.hpp>
 #include <sw/dsp/image/morphology.hpp>
 #include <sw/dsp/image/edge.hpp>
+#include <sw/dsp/image/generators.hpp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,3 +57,6 @@ dsp_add_test(test_image)
 
 # Numerical analysis (Issue #9)
 dsp_add_test(test_analysis)
+
+# Image generators (Issue #12)
+dsp_add_test(test_image_generators)

--- a/tests/test_image_generators.cpp
+++ b/tests/test_image_generators.cpp
@@ -1,0 +1,270 @@
+// test_image_generators.cpp: test synthetic image generators
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/image/image.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+
+using namespace sw::dsp;
+
+bool near(double a, double b, double eps = 1e-4) {
+	return std::abs(a - b) < eps;
+}
+
+// ========== Geometric Patterns ==========
+
+void test_checkerboard() {
+	auto img = checkerboard<float>(8, 8, 2);
+	if (!(img.num_rows() == 8 && img.num_cols() == 8))
+		throw std::runtime_error("test failed: checkerboard dimensions");
+
+	// Block (0,0) should be high (1), block (0,1) should be low (0)
+	if (!(near(img(0, 0), 1.0f))) throw std::runtime_error("test failed: checkerboard (0,0)");
+	if (!(near(img(0, 2), 0.0f))) throw std::runtime_error("test failed: checkerboard (0,2)");
+	if (!(near(img(2, 0), 0.0f))) throw std::runtime_error("test failed: checkerboard (2,0)");
+	if (!(near(img(2, 2), 1.0f))) throw std::runtime_error("test failed: checkerboard (2,2)");
+
+	std::cout << "  checkerboard: passed\n";
+}
+
+void test_stripes_horizontal() {
+	auto img = stripes_horizontal<float>(8, 4, 2);
+	// Rows 0-1: high, rows 2-3: low, rows 4-5: high, rows 6-7: low
+	if (!(near(img(0, 0), 1.0f))) throw std::runtime_error("test failed: h-stripes row 0");
+	if (!(near(img(2, 0), 0.0f))) throw std::runtime_error("test failed: h-stripes row 2");
+	// All columns in a row should be the same
+	if (!(near(img(0, 0), img(0, 3)))) throw std::runtime_error("test failed: h-stripes uniform cols");
+
+	std::cout << "  stripes_horizontal: passed\n";
+}
+
+void test_stripes_vertical() {
+	auto img = stripes_vertical<float>(4, 8, 2);
+	if (!(near(img(0, 0), 1.0f))) throw std::runtime_error("test failed: v-stripes col 0");
+	if (!(near(img(0, 2), 0.0f))) throw std::runtime_error("test failed: v-stripes col 2");
+	// All rows in a column should be the same
+	if (!(near(img(0, 0), img(3, 0)))) throw std::runtime_error("test failed: v-stripes uniform rows");
+
+	std::cout << "  stripes_vertical: passed\n";
+}
+
+void test_grid() {
+	auto img = grid<float>(10, 10, 5);
+	// Row 0 and col 0 should be lines
+	if (!(near(img(0, 3), 1.0f))) throw std::runtime_error("test failed: grid row 0");
+	if (!(near(img(3, 0), 1.0f))) throw std::runtime_error("test failed: grid col 0");
+	// Interior point not on grid
+	if (!(near(img(1, 1), 0.0f))) throw std::runtime_error("test failed: grid interior");
+	// Row 5 should be a line
+	if (!(near(img(5, 3), 1.0f))) throw std::runtime_error("test failed: grid row 5");
+
+	std::cout << "  grid: passed\n";
+}
+
+// ========== Gradients ==========
+
+void test_gradient_horizontal() {
+	auto img = gradient_horizontal<float>(4, 11);
+	// First column should be 0, last column should be 1
+	if (!(near(img(0, 0), 0.0, 1e-3))) throw std::runtime_error("test failed: h-gradient start");
+	if (!(near(img(0, 10), 1.0, 1e-3))) throw std::runtime_error("test failed: h-gradient end");
+	// Middle should be ~0.5
+	if (!(near(img(0, 5), 0.5, 1e-2))) throw std::runtime_error("test failed: h-gradient middle");
+	// All rows should be identical
+	if (!(near(img(0, 5), img(3, 5), 1e-6))) throw std::runtime_error("test failed: h-gradient row invariant");
+
+	std::cout << "  gradient_horizontal: passed\n";
+}
+
+void test_gradient_vertical() {
+	auto img = gradient_vertical<float>(11, 4);
+	if (!(near(img(0, 0), 0.0, 1e-3))) throw std::runtime_error("test failed: v-gradient start");
+	if (!(near(img(10, 0), 1.0, 1e-3))) throw std::runtime_error("test failed: v-gradient end");
+	if (!(near(img(5, 0), 0.5, 1e-2))) throw std::runtime_error("test failed: v-gradient middle");
+
+	std::cout << "  gradient_vertical: passed\n";
+}
+
+void test_gradient_radial() {
+	auto img = gradient_radial<float>(11, 11);
+	// Center should be center_val (1.0)
+	if (!(near(img(5, 5), 1.0, 1e-2))) throw std::runtime_error("test failed: radial center");
+	// Corners should be near edge_val (0.0)
+	if (!(near(img(0, 0), 0.0, 1e-2))) throw std::runtime_error("test failed: radial corner");
+	// Midpoint between center and corner should be ~0.5
+	double mid_val = static_cast<double>(img(5, 0));
+	if (!(mid_val > 0.2 && mid_val < 0.8))
+		throw std::runtime_error("test failed: radial mid-distance");
+
+	std::cout << "  gradient_radial: passed\n";
+}
+
+// ========== Shapes ==========
+
+void test_gaussian_blob() {
+	auto img = gaussian_blob<float>(21, 21, 3.0);
+	// Center should be maximum (amplitude = 1)
+	if (!(near(img(10, 10), 1.0, 1e-3))) throw std::runtime_error("test failed: blob center");
+	// Far from center should be near zero
+	if (!(static_cast<double>(img(0, 0)) < 0.01))
+		throw std::runtime_error("test failed: blob corner should be near zero");
+	// Should be symmetric
+	if (!(near(img(10, 7), img(10, 13), 1e-3)))
+		throw std::runtime_error("test failed: blob symmetry");
+
+	std::cout << "  gaussian_blob: passed\n";
+}
+
+void test_circle() {
+	auto img = circle<float>(21, 21, 5);
+	// Center should be foreground
+	if (!(near(img(10, 10), 1.0f))) throw std::runtime_error("test failed: circle center");
+	// Corner should be background
+	if (!(near(img(0, 0), 0.0f))) throw std::runtime_error("test failed: circle corner");
+	// Just inside radius
+	if (!(near(img(10, 14), 1.0f))) throw std::runtime_error("test failed: circle edge inside");
+	// Just outside radius
+	if (!(near(img(10, 16), 0.0f))) throw std::runtime_error("test failed: circle edge outside");
+
+	std::cout << "  circle: passed\n";
+}
+
+void test_rectangle() {
+	auto img = rectangle<float>(10, 10, 2, 3, 4, 5);
+	// Inside rectangle
+	if (!(near(img(3, 5), 1.0f))) throw std::runtime_error("test failed: rect inside");
+	// Outside rectangle
+	if (!(near(img(0, 0), 0.0f))) throw std::runtime_error("test failed: rect outside");
+	// Boundary
+	if (!(near(img(2, 3), 1.0f))) throw std::runtime_error("test failed: rect top-left corner");
+	if (!(near(img(5, 7), 1.0f))) throw std::runtime_error("test failed: rect bottom-right inside");
+	if (!(near(img(6, 8), 0.0f))) throw std::runtime_error("test failed: rect past bottom-right");
+
+	std::cout << "  rectangle: passed\n";
+}
+
+// ========== Noise ==========
+
+void test_uniform_noise() {
+	auto img = uniform_noise_image<float>(50, 50, 0.0f, 1.0f, 42);
+	if (!(img.num_rows() == 50 && img.num_cols() == 50))
+		throw std::runtime_error("test failed: uniform noise dimensions");
+
+	// All values should be in [0, 1]
+	double sum = 0;
+	for (std::size_t r = 0; r < 50; ++r) {
+		for (std::size_t c = 0; c < 50; ++c) {
+			double v = static_cast<double>(img(r, c));
+			if (!(v >= 0.0 && v <= 1.0))
+				throw std::runtime_error("test failed: uniform noise out of range");
+			sum += v;
+		}
+	}
+	// Mean should be near 0.5
+	double mean = sum / 2500.0;
+	if (!(near(mean, 0.5, 0.05)))
+		throw std::runtime_error("test failed: uniform noise mean");
+
+	std::cout << "  uniform_noise: passed (mean=" << mean << ")\n";
+}
+
+void test_gaussian_noise() {
+	auto img = gaussian_noise_image<float>(50, 50, 0.0f, 1.0f, 42);
+
+	double sum = 0, sum_sq = 0;
+	for (std::size_t r = 0; r < 50; ++r) {
+		for (std::size_t c = 0; c < 50; ++c) {
+			double v = static_cast<double>(img(r, c));
+			sum += v;
+			sum_sq += v * v;
+		}
+	}
+	double mean = sum / 2500.0;
+	double variance = sum_sq / 2500.0 - mean * mean;
+
+	// Mean should be near 0, variance near 1
+	if (!(near(mean, 0.0, 0.1)))
+		throw std::runtime_error("test failed: gaussian noise mean");
+	if (!(near(variance, 1.0, 0.2)))
+		throw std::runtime_error("test failed: gaussian noise variance");
+
+	std::cout << "  gaussian_noise: passed (mean=" << mean << ", var=" << variance << ")\n";
+}
+
+void test_salt_and_pepper() {
+	auto img = salt_and_pepper<float>(100, 100, 0.1, 0.0f, 1.0f, 42);
+
+	int salt_count = 0, pepper_count = 0, mid_count = 0;
+	for (std::size_t r = 0; r < 100; ++r) {
+		for (std::size_t c = 0; c < 100; ++c) {
+			float v = img(r, c);
+			if (near(v, 0.0f, 1e-6)) ++pepper_count;
+			else if (near(v, 1.0f, 1e-6)) ++salt_count;
+			else ++mid_count;
+		}
+	}
+
+	// density=0.1 means ~5% salt + ~5% pepper = ~10% total noise
+	int noise_total = salt_count + pepper_count;
+	if (!(noise_total > 500 && noise_total < 1500))
+		throw std::runtime_error("test failed: salt_and_pepper noise density");
+	if (!(mid_count > 8500))
+		throw std::runtime_error("test failed: salt_and_pepper mid pixels");
+
+	std::cout << "  salt_and_pepper: passed (salt=" << salt_count
+	          << ", pepper=" << pepper_count << ", mid=" << mid_count << ")\n";
+}
+
+// ========== Determinism ==========
+
+void test_deterministic_seed() {
+	auto img1 = uniform_noise_image<float>(10, 10, 0.0f, 1.0f, 123);
+	auto img2 = uniform_noise_image<float>(10, 10, 0.0f, 1.0f, 123);
+
+	for (std::size_t r = 0; r < 10; ++r)
+		for (std::size_t c = 0; c < 10; ++c)
+			if (!(img1(r, c) == img2(r, c)))
+				throw std::runtime_error("test failed: same seed should produce identical images");
+
+	std::cout << "  deterministic_seed: passed\n";
+}
+
+int main() {
+	try {
+		std::cout << "Image Generator Tests\n";
+
+		// Geometric patterns
+		test_checkerboard();
+		test_stripes_horizontal();
+		test_stripes_vertical();
+		test_grid();
+
+		// Gradients
+		test_gradient_horizontal();
+		test_gradient_vertical();
+		test_gradient_radial();
+
+		// Shapes
+		test_gaussian_blob();
+		test_circle();
+		test_rectangle();
+
+		// Noise
+		test_uniform_noise();
+		test_gaussian_noise();
+		test_salt_and_pepper();
+
+		// Determinism
+		test_deterministic_seed();
+
+		std::cout << "All image generator tests passed.\n";
+		return 0;
+	} catch (const std::exception& e) {
+		std::cerr << "FAILED: " << e.what() << '\n';
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary
- 13 synthetic image generators returning `dense2D<T>`, templated on `DspField T`
- Covers geometric patterns, gradients, shapes, and noise — everything needed for testing and demoing image processing algorithms
- Added to `image.hpp` umbrella

## Changes
- `include/sw/dsp/image/generators.hpp` — all 13 generators
- `include/sw/dsp/image/image.hpp` — added generators to umbrella includes
- `tests/test_image_generators.cpp` — 14 tests
- `tests/CMakeLists.txt` — registered test

## Generators
| Category | Functions |
|----------|-----------|
| Geometric | `checkerboard`, `stripes_horizontal`, `stripes_vertical`, `grid` |
| Gradients | `gradient_horizontal`, `gradient_vertical`, `gradient_radial` |
| Shapes | `gaussian_blob`, `circle`, `rectangle` |
| Noise | `uniform_noise_image`, `gaussian_noise_image`, `salt_and_pepper` |

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_image_generators | OK | 14/14 PASS | OK | 14/14 PASS |
| all tests (ctest) | OK | 18/18 PASS | OK | 18/18 PASS |

## Test plan
- [x] Fast CI passes (gcc + clang + MSVC + Apple Clang + RISC-V)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added synthetic image generator library with support for geometric patterns (checkerboard, stripes, grids), gradient functions (horizontal, vertical, radial), shape generation (Gaussian blobs, circles, rectangles), and noise sources (uniform, Gaussian, salt-and-pepper). Supports mixed-precision numeric types.

* **Tests**
  * Added comprehensive test suite validating all image generators and output properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->