### PR TITLE
feat(io): PGM, PPM, and BMP image file I/O

### DIFF
--- a/include/sw/dsp/io/bmp.hpp
+++ b/include/sw/dsp/io/bmp.hpp
@@ -1,0 +1,271 @@
+#pragma once
+// bmp.hpp: BMP (Windows Bitmap) reader/writer
+//
+// Supports 8-bit grayscale (with palette) and 24-bit RGB.
+// Little-endian per the BMP specification.
+// Header-only, no external dependencies.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <mtl/mat/dense2D.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp::io {
+
+namespace detail {
+
+inline void bmp_write_le16(std::ostream& os, uint16_t v) {
+	char b[2] = { static_cast<char>(v & 0xFF), static_cast<char>((v >> 8) & 0xFF) };
+	os.write(b, 2);
+}
+
+inline void bmp_write_le32(std::ostream& os, uint32_t v) {
+	char b[4] = { static_cast<char>(v & 0xFF), static_cast<char>((v >> 8) & 0xFF),
+	              static_cast<char>((v >> 16) & 0xFF), static_cast<char>((v >> 24) & 0xFF) };
+	os.write(b, 4);
+}
+
+inline uint16_t bmp_read_le16(std::istream& is) {
+	uint8_t b[2];
+	is.read(reinterpret_cast<char*>(b), 2);
+	return static_cast<uint16_t>(b[0]) | (static_cast<uint16_t>(b[1]) << 8);
+}
+
+inline uint32_t bmp_read_le32(std::istream& is) {
+	uint8_t b[4];
+	is.read(reinterpret_cast<char*>(b), 4);
+	return static_cast<uint32_t>(b[0]) | (static_cast<uint32_t>(b[1]) << 8) |
+	       (static_cast<uint32_t>(b[2]) << 16) | (static_cast<uint32_t>(b[3]) << 24);
+}
+
+} // namespace detail
+
+// Write an 8-bit grayscale BMP with a 256-entry grayscale palette.
+template <DspField T>
+	requires ConvertibleToDouble<T>
+void write_bmp(const std::string& path, const mtl::mat::dense2D<T>& image) {
+	std::ofstream ofs(path, std::ios::binary);
+	if (!ofs)
+		throw std::runtime_error("write_bmp: cannot open file: " + path);
+
+	uint32_t rows = static_cast<uint32_t>(image.num_rows());
+	uint32_t cols = static_cast<uint32_t>(image.num_cols());
+
+	// BMP rows must be padded to 4-byte boundaries
+	uint32_t row_stride = (cols + 3) & ~3u;
+	uint32_t palette_size = 256 * 4;  // 256 RGBQUAD entries
+	uint32_t header_size = 14 + 40;   // BITMAPFILEHEADER + BITMAPINFOHEADER
+	uint32_t pixel_offset = header_size + palette_size;
+	uint32_t image_size = row_stride * rows;
+	uint32_t file_size = pixel_offset + image_size;
+
+	// BITMAPFILEHEADER (14 bytes)
+	ofs.write("BM", 2);
+	detail::bmp_write_le32(ofs, file_size);
+	detail::bmp_write_le16(ofs, 0);  // reserved
+	detail::bmp_write_le16(ofs, 0);  // reserved
+	detail::bmp_write_le32(ofs, pixel_offset);
+
+	// BITMAPINFOHEADER (40 bytes)
+	detail::bmp_write_le32(ofs, 40);         // header size
+	detail::bmp_write_le32(ofs, cols);        // width
+	detail::bmp_write_le32(ofs, rows);        // height (positive = bottom-up)
+	detail::bmp_write_le16(ofs, 1);           // planes
+	detail::bmp_write_le16(ofs, 8);           // bits per pixel
+	detail::bmp_write_le32(ofs, 0);           // compression (BI_RGB)
+	detail::bmp_write_le32(ofs, image_size);  // image size
+	detail::bmp_write_le32(ofs, 2835);        // x pixels per meter (~72 DPI)
+	detail::bmp_write_le32(ofs, 2835);        // y pixels per meter
+	detail::bmp_write_le32(ofs, 256);         // colors used
+	detail::bmp_write_le32(ofs, 0);           // important colors
+
+	// Grayscale palette: 256 entries of (B, G, R, 0)
+	for (int i = 0; i < 256; ++i) {
+		uint8_t entry[4] = { static_cast<uint8_t>(i), static_cast<uint8_t>(i),
+		                     static_cast<uint8_t>(i), 0 };
+		ofs.write(reinterpret_cast<const char*>(entry), 4);
+	}
+
+	// Pixel data (bottom-up row order)
+	std::vector<uint8_t> row_buf(row_stride, 0);
+	for (uint32_t r = 0; r < rows; ++r) {
+		uint32_t src_row = rows - 1 - r;  // BMP is bottom-up
+		for (uint32_t c = 0; c < cols; ++c) {
+			double v = static_cast<double>(image(src_row, c));
+			if (v < 0.0) v = 0.0;
+			if (v > 1.0) v = 1.0;
+			row_buf[c] = static_cast<uint8_t>(v * 255.0 + 0.5);
+		}
+		ofs.write(reinterpret_cast<const char*>(row_buf.data()),
+		          static_cast<std::streamsize>(row_stride));
+	}
+}
+
+// Write a 24-bit color BMP from three channel matrices.
+template <DspField T>
+	requires ConvertibleToDouble<T>
+void write_bmp(const std::string& path,
+               const mtl::mat::dense2D<T>& red,
+               const mtl::mat::dense2D<T>& green,
+               const mtl::mat::dense2D<T>& blue) {
+	std::size_t rows = red.num_rows();
+	std::size_t cols = red.num_cols();
+	if (green.num_rows() != rows || green.num_cols() != cols ||
+	    blue.num_rows() != rows || blue.num_cols() != cols)
+		throw std::invalid_argument("write_bmp: channel dimensions must match");
+
+	std::ofstream ofs(path, std::ios::binary);
+	if (!ofs)
+		throw std::runtime_error("write_bmp: cannot open file: " + path);
+
+	uint32_t h = static_cast<uint32_t>(rows);
+	uint32_t w = static_cast<uint32_t>(cols);
+	uint32_t row_stride = (w * 3 + 3) & ~3u;
+	uint32_t header_size = 14 + 40;
+	uint32_t image_size = row_stride * h;
+	uint32_t file_size = header_size + image_size;
+
+	// BITMAPFILEHEADER
+	ofs.write("BM", 2);
+	detail::bmp_write_le32(ofs, file_size);
+	detail::bmp_write_le16(ofs, 0);
+	detail::bmp_write_le16(ofs, 0);
+	detail::bmp_write_le32(ofs, header_size);
+
+	// BITMAPINFOHEADER
+	detail::bmp_write_le32(ofs, 40);
+	detail::bmp_write_le32(ofs, w);
+	detail::bmp_write_le32(ofs, h);
+	detail::bmp_write_le16(ofs, 1);
+	detail::bmp_write_le16(ofs, 24);
+	detail::bmp_write_le32(ofs, 0);
+	detail::bmp_write_le32(ofs, image_size);
+	detail::bmp_write_le32(ofs, 2835);
+	detail::bmp_write_le32(ofs, 2835);
+	detail::bmp_write_le32(ofs, 0);
+	detail::bmp_write_le32(ofs, 0);
+
+	auto clamp_byte = [](double v) -> uint8_t {
+		if (v < 0.0) v = 0.0;
+		if (v > 1.0) v = 1.0;
+		return static_cast<uint8_t>(v * 255.0 + 0.5);
+	};
+
+	// Pixel data (bottom-up, BGR order)
+	std::vector<uint8_t> row_buf(row_stride, 0);
+	for (uint32_t r = 0; r < h; ++r) {
+		uint32_t src_row = h - 1 - r;
+		for (uint32_t c = 0; c < w; ++c) {
+			row_buf[c * 3 + 0] = clamp_byte(static_cast<double>(blue(src_row, c)));
+			row_buf[c * 3 + 1] = clamp_byte(static_cast<double>(green(src_row, c)));
+			row_buf[c * 3 + 2] = clamp_byte(static_cast<double>(red(src_row, c)));
+		}
+		ofs.write(reinterpret_cast<const char*>(row_buf.data()),
+		          static_cast<std::streamsize>(row_stride));
+	}
+}
+
+// BMP read result.
+template <typename T>
+struct BmpData {
+	mtl::mat::dense2D<T> r, g, b;
+	int bits_per_pixel{0};
+	std::size_t rows() const { return r.num_rows(); }
+	std::size_t cols() const { return r.num_cols(); }
+	bool is_grayscale() const { return bits_per_pixel == 8; }
+};
+
+// Read a BMP file. Supports 8-bit (grayscale palette) and 24-bit RGB.
+// Returns BmpData with channels normalized to [0, 1].
+// For 8-bit, r == g == b (all contain the grayscale values).
+template <DspField T>
+	requires ConvertibleToDouble<T>
+BmpData<T> read_bmp(const std::string& path) {
+	std::ifstream ifs(path, std::ios::binary);
+	if (!ifs)
+		throw std::runtime_error("read_bmp: cannot open file: " + path);
+
+	// BITMAPFILEHEADER
+	char sig[2];
+	ifs.read(sig, 2);
+	if (sig[0] != 'B' || sig[1] != 'M')
+		throw std::runtime_error("read_bmp: not a BMP file");
+
+	detail::bmp_read_le32(ifs);  // file size
+	detail::bmp_read_le16(ifs);  // reserved
+	detail::bmp_read_le16(ifs);  // reserved
+	uint32_t pixel_offset = detail::bmp_read_le32(ifs);
+
+	// BITMAPINFOHEADER
+	uint32_t info_size = detail::bmp_read_le32(ifs);
+	if (info_size < 40)
+		throw std::runtime_error("read_bmp: unsupported header size");
+
+	int32_t width = static_cast<int32_t>(detail::bmp_read_le32(ifs));
+	int32_t height = static_cast<int32_t>(detail::bmp_read_le32(ifs));
+	detail::bmp_read_le16(ifs);  // planes
+	uint16_t bpp = detail::bmp_read_le16(ifs);
+	uint32_t compression = detail::bmp_read_le32(ifs);
+
+	if (compression != 0)
+		throw std::runtime_error("read_bmp: only uncompressed BMP supported");
+	if (bpp != 8 && bpp != 24)
+		throw std::runtime_error("read_bmp: only 8-bit and 24-bit BMP supported");
+
+	bool bottom_up = (height > 0);
+	uint32_t h = static_cast<uint32_t>(bottom_up ? height : -height);
+	uint32_t w = static_cast<uint32_t>(width);
+
+	// Seek to pixel data
+	ifs.seekg(pixel_offset, std::ios::beg);
+
+	BmpData<T> data;
+	data.bits_per_pixel = bpp;
+	data.r = mtl::mat::dense2D<T>(h, w);
+	data.g = mtl::mat::dense2D<T>(h, w);
+	data.b = mtl::mat::dense2D<T>(h, w);
+
+	if (bpp == 8) {
+		// Read palette (we assume grayscale: palette[i] = (i, i, i, 0))
+		// Skip to pixel data (already seeked)
+		uint32_t row_stride = (w + 3) & ~3u;
+		std::vector<uint8_t> row_buf(row_stride);
+
+		for (uint32_t r = 0; r < h; ++r) {
+			uint32_t dst_row = bottom_up ? (h - 1 - r) : r;
+			ifs.read(reinterpret_cast<char*>(row_buf.data()),
+			         static_cast<std::streamsize>(row_stride));
+			for (uint32_t c = 0; c < w; ++c) {
+				T val = static_cast<T>(static_cast<double>(row_buf[c]) / 255.0);
+				data.r(dst_row, c) = val;
+				data.g(dst_row, c) = val;
+				data.b(dst_row, c) = val;
+			}
+		}
+	} else {  // 24-bit
+		uint32_t row_stride = (w * 3 + 3) & ~3u;
+		std::vector<uint8_t> row_buf(row_stride);
+
+		for (uint32_t r = 0; r < h; ++r) {
+			uint32_t dst_row = bottom_up ? (h - 1 - r) : r;
+			ifs.read(reinterpret_cast<char*>(row_buf.data()),
+			         static_cast<std::streamsize>(row_stride));
+			for (uint32_t c = 0; c < w; ++c) {
+				data.b(dst_row, c) = static_cast<T>(row_buf[c * 3 + 0] / 255.0);
+				data.g(dst_row, c) = static_cast<T>(row_buf[c * 3 + 1] / 255.0);
+				data.r(dst_row, c) = static_cast<T>(row_buf[c * 3 + 2] / 255.0);
+			}
+		}
+	}
+
+	return data;
+}
+
+} // namespace sw::dsp::io

--- a/include/sw/dsp/io/bmp.hpp
+++ b/include/sw/dsp/io/bmp.hpp
@@ -8,6 +8,7 @@
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
@@ -35,12 +36,16 @@ inline void bmp_write_le32(std::ostream& os, uint32_t v) {
 inline uint16_t bmp_read_le16(std::istream& is) {
 	uint8_t b[2];
 	is.read(reinterpret_cast<char*>(b), 2);
+	if (!is.good())
+		throw std::runtime_error("read_bmp: unexpected end of file");
 	return static_cast<uint16_t>(b[0]) | (static_cast<uint16_t>(b[1]) << 8);
 }
 
 inline uint32_t bmp_read_le32(std::istream& is) {
 	uint8_t b[4];
 	is.read(reinterpret_cast<char*>(b), 4);
+	if (!is.good())
+		throw std::runtime_error("read_bmp: unexpected end of file");
 	return static_cast<uint32_t>(b[0]) | (static_cast<uint32_t>(b[1]) << 8) |
 	       (static_cast<uint32_t>(b[2]) << 16) | (static_cast<uint32_t>(b[3]) << 24);
 }
@@ -58,33 +63,32 @@ void write_bmp(const std::string& path, const mtl::mat::dense2D<T>& image) {
 	uint32_t rows = static_cast<uint32_t>(image.num_rows());
 	uint32_t cols = static_cast<uint32_t>(image.num_cols());
 
-	// BMP rows must be padded to 4-byte boundaries
 	uint32_t row_stride = (cols + 3) & ~3u;
-	uint32_t palette_size = 256 * 4;  // 256 RGBQUAD entries
-	uint32_t header_size = 14 + 40;   // BITMAPFILEHEADER + BITMAPINFOHEADER
+	uint32_t palette_size = 256 * 4;
+	uint32_t header_size = 14 + 40;
 	uint32_t pixel_offset = header_size + palette_size;
 	uint32_t image_size = row_stride * rows;
 	uint32_t file_size = pixel_offset + image_size;
 
-	// BITMAPFILEHEADER (14 bytes)
+	// BITMAPFILEHEADER
 	ofs.write("BM", 2);
 	detail::bmp_write_le32(ofs, file_size);
-	detail::bmp_write_le16(ofs, 0);  // reserved
-	detail::bmp_write_le16(ofs, 0);  // reserved
+	detail::bmp_write_le16(ofs, 0);
+	detail::bmp_write_le16(ofs, 0);
 	detail::bmp_write_le32(ofs, pixel_offset);
 
-	// BITMAPINFOHEADER (40 bytes)
-	detail::bmp_write_le32(ofs, 40);         // header size
-	detail::bmp_write_le32(ofs, cols);        // width
-	detail::bmp_write_le32(ofs, rows);        // height (positive = bottom-up)
-	detail::bmp_write_le16(ofs, 1);           // planes
-	detail::bmp_write_le16(ofs, 8);           // bits per pixel
-	detail::bmp_write_le32(ofs, 0);           // compression (BI_RGB)
-	detail::bmp_write_le32(ofs, image_size);  // image size
-	detail::bmp_write_le32(ofs, 2835);        // x pixels per meter (~72 DPI)
-	detail::bmp_write_le32(ofs, 2835);        // y pixels per meter
-	detail::bmp_write_le32(ofs, 256);         // colors used
-	detail::bmp_write_le32(ofs, 0);           // important colors
+	// BITMAPINFOHEADER
+	detail::bmp_write_le32(ofs, 40);
+	detail::bmp_write_le32(ofs, cols);
+	detail::bmp_write_le32(ofs, rows);
+	detail::bmp_write_le16(ofs, 1);
+	detail::bmp_write_le16(ofs, 8);
+	detail::bmp_write_le32(ofs, 0);
+	detail::bmp_write_le32(ofs, image_size);
+	detail::bmp_write_le32(ofs, 2835);
+	detail::bmp_write_le32(ofs, 2835);
+	detail::bmp_write_le32(ofs, 256);
+	detail::bmp_write_le32(ofs, 0);
 
 	// Grayscale palette: 256 entries of (B, G, R, 0)
 	for (int i = 0; i < 256; ++i) {
@@ -96,7 +100,7 @@ void write_bmp(const std::string& path, const mtl::mat::dense2D<T>& image) {
 	// Pixel data (bottom-up row order)
 	std::vector<uint8_t> row_buf(row_stride, 0);
 	for (uint32_t r = 0; r < rows; ++r) {
-		uint32_t src_row = rows - 1 - r;  // BMP is bottom-up
+		uint32_t src_row = rows - 1 - r;
 		for (uint32_t c = 0; c < cols; ++c) {
 			double v = static_cast<double>(image(src_row, c));
 			if (v < 0.0) v = 0.0;
@@ -132,14 +136,12 @@ void write_bmp(const std::string& path,
 	uint32_t image_size = row_stride * h;
 	uint32_t file_size = header_size + image_size;
 
-	// BITMAPFILEHEADER
 	ofs.write("BM", 2);
 	detail::bmp_write_le32(ofs, file_size);
 	detail::bmp_write_le16(ofs, 0);
 	detail::bmp_write_le16(ofs, 0);
 	detail::bmp_write_le32(ofs, header_size);
 
-	// BITMAPINFOHEADER
 	detail::bmp_write_le32(ofs, 40);
 	detail::bmp_write_le32(ofs, w);
 	detail::bmp_write_le32(ofs, h);
@@ -158,7 +160,6 @@ void write_bmp(const std::string& path,
 		return static_cast<uint8_t>(v * 255.0 + 0.5);
 	};
 
-	// Pixel data (bottom-up, BGR order)
 	std::vector<uint8_t> row_buf(row_stride, 0);
 	for (uint32_t r = 0; r < h; ++r) {
 		uint32_t src_row = h - 1 - r;
@@ -182,9 +183,9 @@ struct BmpData {
 	bool is_grayscale() const { return bits_per_pixel == 8; }
 };
 
-// Read a BMP file. Supports 8-bit (grayscale palette) and 24-bit RGB.
+// Read a BMP file. Supports 8-bit (with palette lookup) and 24-bit RGB.
 // Returns BmpData with channels normalized to [0, 1].
-// For 8-bit, r == g == b (all contain the grayscale values).
+// For 8-bit, palette entries are read and applied (not assumed grayscale).
 template <DspField T>
 	requires ConvertibleToDouble<T>
 BmpData<T> read_bmp(const std::string& path) {
@@ -195,8 +196,8 @@ BmpData<T> read_bmp(const std::string& path) {
 	// BITMAPFILEHEADER
 	char sig[2];
 	ifs.read(sig, 2);
-	if (sig[0] != 'B' || sig[1] != 'M')
-		throw std::runtime_error("read_bmp: not a BMP file");
+	if (!ifs.good() || sig[0] != 'B' || sig[1] != 'M')
+		throw std::runtime_error("read_bmp: not a BMP file or truncated");
 
 	detail::bmp_read_le32(ifs);  // file size
 	detail::bmp_read_le16(ifs);  // reserved
@@ -210,6 +211,12 @@ BmpData<T> read_bmp(const std::string& path) {
 
 	int32_t width = static_cast<int32_t>(detail::bmp_read_le32(ifs));
 	int32_t height = static_cast<int32_t>(detail::bmp_read_le32(ifs));
+
+	if (width <= 0)
+		throw std::runtime_error("read_bmp: invalid width");
+	if (height == 0)
+		throw std::runtime_error("read_bmp: invalid height");
+
 	detail::bmp_read_le16(ifs);  // planes
 	uint16_t bpp = detail::bmp_read_le16(ifs);
 	uint32_t compression = detail::bmp_read_le32(ifs);
@@ -223,9 +230,6 @@ BmpData<T> read_bmp(const std::string& path) {
 	uint32_t h = static_cast<uint32_t>(bottom_up ? height : -height);
 	uint32_t w = static_cast<uint32_t>(width);
 
-	// Seek to pixel data
-	ifs.seekg(pixel_offset, std::ios::beg);
-
 	BmpData<T> data;
 	data.bits_per_pixel = bpp;
 	data.r = mtl::mat::dense2D<T>(h, w);
@@ -233,8 +237,20 @@ BmpData<T> read_bmp(const std::string& path) {
 	data.b = mtl::mat::dense2D<T>(h, w);
 
 	if (bpp == 8) {
-		// Read palette (we assume grayscale: palette[i] = (i, i, i, 0))
-		// Skip to pixel data (already seeked)
+		// Read the 256-entry palette (RGBQUAD: B, G, R, reserved)
+		// Palette starts right after the info header; seek to header + 14 + info_size
+		ifs.seekg(14 + info_size, std::ios::beg);
+		std::array<std::array<uint8_t, 3>, 256> palette{};
+		for (int i = 0; i < 256; ++i) {
+			uint8_t entry[4];
+			ifs.read(reinterpret_cast<char*>(entry), 4);
+			if (!ifs.good())
+				throw std::runtime_error("read_bmp: truncated palette");
+			palette[static_cast<std::size_t>(i)] = { entry[2], entry[1], entry[0] }; // BGR -> RGB
+		}
+
+		// Seek to pixel data
+		ifs.seekg(pixel_offset, std::ios::beg);
 		uint32_t row_stride = (w + 3) & ~3u;
 		std::vector<uint8_t> row_buf(row_stride);
 
@@ -242,14 +258,17 @@ BmpData<T> read_bmp(const std::string& path) {
 			uint32_t dst_row = bottom_up ? (h - 1 - r) : r;
 			ifs.read(reinterpret_cast<char*>(row_buf.data()),
 			         static_cast<std::streamsize>(row_stride));
+			if (!ifs.good())
+				throw std::runtime_error("read_bmp: truncated pixel data");
 			for (uint32_t c = 0; c < w; ++c) {
-				T val = static_cast<T>(static_cast<double>(row_buf[c]) / 255.0);
-				data.r(dst_row, c) = val;
-				data.g(dst_row, c) = val;
-				data.b(dst_row, c) = val;
+				auto& pal = palette[row_buf[c]];
+				data.r(dst_row, c) = static_cast<T>(pal[0] / 255.0);
+				data.g(dst_row, c) = static_cast<T>(pal[1] / 255.0);
+				data.b(dst_row, c) = static_cast<T>(pal[2] / 255.0);
 			}
 		}
 	} else {  // 24-bit
+		ifs.seekg(pixel_offset, std::ios::beg);
 		uint32_t row_stride = (w * 3 + 3) & ~3u;
 		std::vector<uint8_t> row_buf(row_stride);
 
@@ -257,6 +276,8 @@ BmpData<T> read_bmp(const std::string& path) {
 			uint32_t dst_row = bottom_up ? (h - 1 - r) : r;
 			ifs.read(reinterpret_cast<char*>(row_buf.data()),
 			         static_cast<std::streamsize>(row_stride));
+			if (!ifs.good())
+				throw std::runtime_error("read_bmp: truncated pixel data");
 			for (uint32_t c = 0; c < w; ++c) {
 				data.b(dst_row, c) = static_cast<T>(row_buf[c * 3 + 0] / 255.0);
 				data.g(dst_row, c) = static_cast<T>(row_buf[c * 3 + 1] / 255.0);

--- a/include/sw/dsp/io/io.hpp
+++ b/include/sw/dsp/io/io.hpp
@@ -1,9 +1,15 @@
 #pragma once
-// io.hpp: umbrella header for signal file I/O
+// io.hpp: umbrella header for signal and image file I/O
 //
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
+// Signal I/O
 #include <sw/dsp/io/wav.hpp>
 #include <sw/dsp/io/csv.hpp>
 #include <sw/dsp/io/raw.hpp>
+
+// Image I/O
+#include <sw/dsp/io/pgm.hpp>
+#include <sw/dsp/io/ppm.hpp>
+#include <sw/dsp/io/bmp.hpp>

--- a/include/sw/dsp/io/pgm.hpp
+++ b/include/sw/dsp/io/pgm.hpp
@@ -1,0 +1,133 @@
+#pragma once
+// pgm.hpp: PGM (Portable Graymap) reader/writer
+//
+// Supports P2 (ASCII) and P5 (binary) PGM formats.
+// 8-bit and 16-bit max values.
+// Header-only, no external dependencies.
+//
+// Write: T values in [0, 1] mapped to [0, max_val].
+// Read: pixel values normalized to [0, 1] as T.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstdint>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <mtl/mat/dense2D.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp::io {
+
+// Write a grayscale image as binary PGM (P5).
+// T values are clamped to [0, 1] and mapped to [0, max_val].
+template <DspField T>
+	requires ConvertibleToDouble<T>
+void write_pgm(const std::string& path, const mtl::mat::dense2D<T>& image,
+               int max_val = 255) {
+	if (max_val < 1 || max_val > 65535)
+		throw std::invalid_argument("write_pgm: max_val must be in [1, 65535]");
+
+	std::ofstream ofs(path, std::ios::binary);
+	if (!ofs)
+		throw std::runtime_error("write_pgm: cannot open file: " + path);
+
+	std::size_t rows = image.num_rows();
+	std::size_t cols = image.num_cols();
+
+	// Header
+	ofs << "P5\n" << cols << " " << rows << "\n" << max_val << "\n";
+
+	// Pixel data
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			double v = static_cast<double>(image(r, c));
+			if (v < 0.0) v = 0.0;
+			if (v > 1.0) v = 1.0;
+			int pixel = static_cast<int>(v * max_val + 0.5);
+			if (pixel > max_val) pixel = max_val;
+
+			if (max_val <= 255) {
+				uint8_t b = static_cast<uint8_t>(pixel);
+				ofs.write(reinterpret_cast<const char*>(&b), 1);
+			} else {
+				// 16-bit PGM: big-endian per PNM spec
+				uint8_t hi = static_cast<uint8_t>((pixel >> 8) & 0xFF);
+				uint8_t lo = static_cast<uint8_t>(pixel & 0xFF);
+				ofs.write(reinterpret_cast<const char*>(&hi), 1);
+				ofs.write(reinterpret_cast<const char*>(&lo), 1);
+			}
+		}
+	}
+}
+
+// Read a PGM file (P2 ASCII or P5 binary), return dense2D<T> normalized to [0, 1].
+template <DspField T>
+	requires ConvertibleToDouble<T>
+mtl::mat::dense2D<T> read_pgm(const std::string& path) {
+	std::ifstream ifs(path, std::ios::binary);
+	if (!ifs)
+		throw std::runtime_error("read_pgm: cannot open file: " + path);
+
+	// Read magic number
+	std::string magic;
+	ifs >> magic;
+	if (magic != "P2" && magic != "P5")
+		throw std::runtime_error("read_pgm: unsupported format: " + magic);
+
+	bool binary = (magic == "P5");
+
+	// Skip comments
+	auto skip_comments = [&]() {
+		while (ifs.peek() == '#' || ifs.peek() == '\n' || ifs.peek() == '\r' || ifs.peek() == ' ') {
+			if (ifs.peek() == '#') {
+				std::string line;
+				std::getline(ifs, line);
+			} else {
+				ifs.get();
+			}
+		}
+	};
+
+	skip_comments();
+	int width, height, max_val;
+	ifs >> width >> height;
+	skip_comments();
+	ifs >> max_val;
+
+	if (width <= 0 || height <= 0 || max_val <= 0)
+		throw std::runtime_error("read_pgm: invalid dimensions or max_val");
+
+	// Skip single whitespace after max_val (before binary data)
+	if (binary) ifs.get();
+
+	std::size_t rows = static_cast<std::size_t>(height);
+	std::size_t cols = static_cast<std::size_t>(width);
+	mtl::mat::dense2D<T> image(rows, cols);
+	double inv_max = 1.0 / static_cast<double>(max_val);
+
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			int pixel;
+			if (binary) {
+				if (max_val <= 255) {
+					uint8_t b;
+					ifs.read(reinterpret_cast<char*>(&b), 1);
+					pixel = b;
+				} else {
+					uint8_t b[2];
+					ifs.read(reinterpret_cast<char*>(b), 2);
+					pixel = (static_cast<int>(b[0]) << 8) | b[1];
+				}
+			} else {
+				ifs >> pixel;
+			}
+			image(r, c) = static_cast<T>(static_cast<double>(pixel) * inv_max);
+		}
+	}
+
+	return image;
+}
+
+} // namespace sw::dsp::io

--- a/include/sw/dsp/io/pgm.hpp
+++ b/include/sw/dsp/io/pgm.hpp
@@ -91,10 +91,14 @@ mtl::mat::dense2D<T> read_pgm(const std::string& path) {
 	};
 
 	skip_comments();
-	int width, height, max_val;
+	int width = 0, height = 0, max_val = 0;
 	ifs >> width >> height;
+	if (!ifs.good())
+		throw std::runtime_error("read_pgm: failed to read dimensions");
 	skip_comments();
 	ifs >> max_val;
+	if (!ifs.good())
+		throw std::runtime_error("read_pgm: failed to read max_val");
 
 	if (width <= 0 || height <= 0 || max_val <= 0)
 		throw std::runtime_error("read_pgm: invalid dimensions or max_val");

--- a/include/sw/dsp/io/ppm.hpp
+++ b/include/sw/dsp/io/ppm.hpp
@@ -1,0 +1,136 @@
+#pragma once
+// ppm.hpp: PPM (Portable Pixmap) reader/writer
+//
+// Supports P3 (ASCII) and P6 (binary) PPM formats.
+// Color images stored as three separate dense2D<T> channel matrices
+// (planar layout, consistent with Image<T, 3>).
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstdint>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <mtl/mat/dense2D.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp::io {
+
+// Result of reading a PPM file: three channel matrices.
+template <typename T>
+struct PpmData {
+	mtl::mat::dense2D<T> r, g, b;
+	std::size_t rows() const { return r.num_rows(); }
+	std::size_t cols() const { return r.num_cols(); }
+};
+
+// Write a color image as binary PPM (P6).
+// Each channel's T values are clamped to [0, 1] and mapped to [0, max_val].
+template <DspField T>
+	requires ConvertibleToDouble<T>
+void write_ppm(const std::string& path,
+               const mtl::mat::dense2D<T>& red,
+               const mtl::mat::dense2D<T>& green,
+               const mtl::mat::dense2D<T>& blue,
+               int max_val = 255) {
+	if (max_val < 1 || max_val > 255)
+		throw std::invalid_argument("write_ppm: max_val must be in [1, 255]");
+
+	std::size_t rows = red.num_rows();
+	std::size_t cols = red.num_cols();
+	if (green.num_rows() != rows || green.num_cols() != cols ||
+	    blue.num_rows() != rows || blue.num_cols() != cols)
+		throw std::invalid_argument("write_ppm: channel dimensions must match");
+
+	std::ofstream ofs(path, std::ios::binary);
+	if (!ofs)
+		throw std::runtime_error("write_ppm: cannot open file: " + path);
+
+	ofs << "P6\n" << cols << " " << rows << "\n" << max_val << "\n";
+
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			auto clamp_pixel = [max_val](double v) -> uint8_t {
+				if (v < 0.0) v = 0.0;
+				if (v > 1.0) v = 1.0;
+				int p = static_cast<int>(v * max_val + 0.5);
+				if (p > max_val) p = max_val;
+				return static_cast<uint8_t>(p);
+			};
+			uint8_t rgb[3] = {
+				clamp_pixel(static_cast<double>(red(r, c))),
+				clamp_pixel(static_cast<double>(green(r, c))),
+				clamp_pixel(static_cast<double>(blue(r, c)))
+			};
+			ofs.write(reinterpret_cast<const char*>(rgb), 3);
+		}
+	}
+}
+
+// Read a PPM file (P3 ASCII or P6 binary), return PpmData<T> with channels normalized to [0, 1].
+template <DspField T>
+	requires ConvertibleToDouble<T>
+PpmData<T> read_ppm(const std::string& path) {
+	std::ifstream ifs(path, std::ios::binary);
+	if (!ifs)
+		throw std::runtime_error("read_ppm: cannot open file: " + path);
+
+	std::string magic;
+	ifs >> magic;
+	if (magic != "P3" && magic != "P6")
+		throw std::runtime_error("read_ppm: unsupported format: " + magic);
+
+	bool binary = (magic == "P6");
+
+	auto skip_comments = [&]() {
+		while (ifs.peek() == '#' || ifs.peek() == '\n' || ifs.peek() == '\r' || ifs.peek() == ' ') {
+			if (ifs.peek() == '#') {
+				std::string line;
+				std::getline(ifs, line);
+			} else {
+				ifs.get();
+			}
+		}
+	};
+
+	skip_comments();
+	int width, height, max_val;
+	ifs >> width >> height;
+	skip_comments();
+	ifs >> max_val;
+
+	if (width <= 0 || height <= 0 || max_val <= 0)
+		throw std::runtime_error("read_ppm: invalid dimensions or max_val");
+
+	if (binary) ifs.get();
+
+	std::size_t rows = static_cast<std::size_t>(height);
+	std::size_t cols = static_cast<std::size_t>(width);
+	double inv_max = 1.0 / static_cast<double>(max_val);
+
+	PpmData<T> data;
+	data.r = mtl::mat::dense2D<T>(rows, cols);
+	data.g = mtl::mat::dense2D<T>(rows, cols);
+	data.b = mtl::mat::dense2D<T>(rows, cols);
+
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			int rv, gv, bv;
+			if (binary) {
+				uint8_t rgb[3];
+				ifs.read(reinterpret_cast<char*>(rgb), 3);
+				rv = rgb[0]; gv = rgb[1]; bv = rgb[2];
+			} else {
+				ifs >> rv >> gv >> bv;
+			}
+			data.r(r, c) = static_cast<T>(rv * inv_max);
+			data.g(r, c) = static_cast<T>(gv * inv_max);
+			data.b(r, c) = static_cast<T>(bv * inv_max);
+		}
+	}
+
+	return data;
+}
+
+} // namespace sw::dsp::io

--- a/include/sw/dsp/io/ppm.hpp
+++ b/include/sw/dsp/io/ppm.hpp
@@ -95,16 +95,23 @@ PpmData<T> read_ppm(const std::string& path) {
 	};
 
 	skip_comments();
-	int width, height, max_val;
+	int width = 0, height = 0, max_val = 0;
 	ifs >> width >> height;
+	if (!ifs.good())
+		throw std::runtime_error("read_ppm: failed to read dimensions");
 	skip_comments();
 	ifs >> max_val;
+	if (!ifs.good())
+		throw std::runtime_error("read_ppm: failed to read max_val");
 
 	if (width <= 0 || height <= 0 || max_val <= 0)
 		throw std::runtime_error("read_ppm: invalid dimensions or max_val");
+	if (max_val > 65535)
+		throw std::runtime_error("read_ppm: max_val exceeds 65535");
 
 	if (binary) ifs.get();
 
+	bool wide = (max_val > 255);  // 16-bit samples
 	std::size_t rows = static_cast<std::size_t>(height);
 	std::size_t cols = static_cast<std::size_t>(width);
 	double inv_max = 1.0 / static_cast<double>(max_val);
@@ -118,11 +125,26 @@ PpmData<T> read_ppm(const std::string& path) {
 		for (std::size_t c = 0; c < cols; ++c) {
 			int rv, gv, bv;
 			if (binary) {
-				uint8_t rgb[3];
-				ifs.read(reinterpret_cast<char*>(rgb), 3);
-				rv = rgb[0]; gv = rgb[1]; bv = rgb[2];
+				if (wide) {
+					// 16-bit: 2 bytes per channel, big-endian per PNM spec
+					uint8_t buf[6];
+					ifs.read(reinterpret_cast<char*>(buf), 6);
+					if (!ifs.good())
+						throw std::runtime_error("read_ppm: truncated pixel data");
+					rv = (static_cast<int>(buf[0]) << 8) | buf[1];
+					gv = (static_cast<int>(buf[2]) << 8) | buf[3];
+					bv = (static_cast<int>(buf[4]) << 8) | buf[5];
+				} else {
+					uint8_t rgb[3];
+					ifs.read(reinterpret_cast<char*>(rgb), 3);
+					if (!ifs.good())
+						throw std::runtime_error("read_ppm: truncated pixel data");
+					rv = rgb[0]; gv = rgb[1]; bv = rgb[2];
+				}
 			} else {
 				ifs >> rv >> gv >> bv;
+				if (!ifs.good())
+					throw std::runtime_error("read_ppm: failed to read pixel values");
 			}
 			data.r(r, c) = static_cast<T>(rv * inv_max);
 			data.g(r, c) = static_cast<T>(gv * inv_max);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,3 +60,6 @@ dsp_add_test(test_analysis)
 
 # Image generators (Issue #12)
 dsp_add_test(test_image_generators)
+
+# Image file I/O (Issue #13)
+dsp_add_test(test_image_io)

--- a/tests/test_image_io.cpp
+++ b/tests/test_image_io.cpp
@@ -11,6 +11,7 @@
 #include <sw/dsp/io/bmp.hpp>
 #include <sw/dsp/image/generators.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>

--- a/tests/test_image_io.cpp
+++ b/tests/test_image_io.cpp
@@ -1,0 +1,275 @@
+// test_image_io.cpp: test PGM, PPM, and BMP image file I/O
+//
+// Tests round-trip: generate → write → read → compare.
+// Uses temporary files cleaned up after each test.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/io/pgm.hpp>
+#include <sw/dsp/io/ppm.hpp>
+#include <sw/dsp/io/bmp.hpp>
+#include <sw/dsp/image/generators.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+using namespace sw::dsp;
+
+bool near(double a, double b, double eps = 1e-4) {
+	return std::abs(a - b) < eps;
+}
+
+// RAII temp file that deletes on destruction
+struct TempFile {
+	std::string path;
+	TempFile(const std::string& name) : path("/tmp/dsp_test_" + name) {}
+	~TempFile() { std::remove(path.c_str()); }
+};
+
+// ========== PGM Tests ==========
+
+void test_pgm_roundtrip_checkerboard() {
+	// Generate a checkerboard, write PGM, read back, compare.
+	// 8-bit quantization: values are exact for 0 and 1.
+	auto img = checkerboard<float>(8, 8, 2, 0.0f, 1.0f);
+
+	TempFile tmp("checker.pgm");
+	io::write_pgm(tmp.path, img);
+	auto loaded = io::read_pgm<float>(tmp.path);
+
+	if (!(loaded.num_rows() == 8 && loaded.num_cols() == 8))
+		throw std::runtime_error("test failed: PGM roundtrip dimensions");
+
+	for (std::size_t r = 0; r < 8; ++r)
+		for (std::size_t c = 0; c < 8; ++c)
+			if (!(near(loaded(r, c), img(r, c), 1.0 / 255.0 + 1e-6)))
+				throw std::runtime_error("test failed: PGM roundtrip pixel mismatch");
+
+	std::cout << "  pgm_roundtrip_checkerboard: passed\n";
+}
+
+void test_pgm_roundtrip_gradient() {
+	auto img = gradient_horizontal<float>(4, 256);
+
+	TempFile tmp("gradient.pgm");
+	io::write_pgm(tmp.path, img);
+	auto loaded = io::read_pgm<float>(tmp.path);
+
+	// 8-bit quantization: error should be <= 1/255 ≈ 0.004
+	double max_err = 0;
+	for (std::size_t r = 0; r < 4; ++r) {
+		for (std::size_t c = 0; c < 256; ++c) {
+			double err = std::abs(static_cast<double>(loaded(r, c))
+			                    - static_cast<double>(img(r, c)));
+			if (err > max_err) max_err = err;
+		}
+	}
+	if (!(max_err < 1.0 / 255.0 + 1e-6))
+		throw std::runtime_error("test failed: PGM gradient max error too large: "
+			+ std::to_string(max_err));
+
+	std::cout << "  pgm_roundtrip_gradient: passed (max_err=" << max_err << ")\n";
+}
+
+void test_pgm_16bit() {
+	auto img = gradient_horizontal<double>(2, 100);
+
+	TempFile tmp("gradient16.pgm");
+	io::write_pgm(tmp.path, img, 65535);
+	auto loaded = io::read_pgm<double>(tmp.path);
+
+	// 16-bit: error should be <= 1/65535 ≈ 1.5e-5
+	double max_err = 0;
+	for (std::size_t r = 0; r < 2; ++r) {
+		for (std::size_t c = 0; c < 100; ++c) {
+			double err = std::abs(loaded(r, c) - img(r, c));
+			if (err > max_err) max_err = err;
+		}
+	}
+	if (!(max_err < 1.0 / 65535.0 + 1e-6))
+		throw std::runtime_error("test failed: PGM 16-bit max error: "
+			+ std::to_string(max_err));
+
+	std::cout << "  pgm_16bit: passed (max_err=" << max_err << ")\n";
+}
+
+void test_pgm_validation() {
+	auto img = checkerboard<float>(4, 4, 2);
+
+	bool caught = false;
+	try { io::write_pgm("/tmp/dsp_test_bad.pgm", img, 0); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: write_pgm should reject max_val=0");
+
+	caught = false;
+	try { io::read_pgm<float>("/nonexistent/path.pgm"); }
+	catch (const std::runtime_error&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: read_pgm should throw on missing file");
+
+	std::cout << "  pgm_validation: passed\n";
+}
+
+// ========== PPM Tests ==========
+
+void test_ppm_roundtrip() {
+	std::size_t rows = 6, cols = 8;
+	auto red = gradient_horizontal<float>(rows, cols);
+	auto green = gradient_vertical<float>(rows, cols);
+	auto blue = checkerboard<float>(rows, cols, 2, 0.2f, 0.8f);
+
+	TempFile tmp("color.ppm");
+	io::write_ppm(tmp.path, red, green, blue);
+	auto loaded = io::read_ppm<float>(tmp.path);
+
+	if (!(loaded.rows() == rows && loaded.cols() == cols))
+		throw std::runtime_error("test failed: PPM roundtrip dimensions");
+
+	double max_err = 0;
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			double er = std::abs(static_cast<double>(loaded.r(r, c) - red(r, c)));
+			double eg = std::abs(static_cast<double>(loaded.g(r, c) - green(r, c)));
+			double eb = std::abs(static_cast<double>(loaded.b(r, c) - blue(r, c)));
+			double e = std::max({er, eg, eb});
+			if (e > max_err) max_err = e;
+		}
+	}
+	if (!(max_err < 1.0 / 255.0 + 1e-6))
+		throw std::runtime_error("test failed: PPM roundtrip max error: "
+			+ std::to_string(max_err));
+
+	std::cout << "  ppm_roundtrip: passed (max_err=" << max_err << ")\n";
+}
+
+void test_ppm_validation() {
+	auto r = checkerboard<float>(4, 4, 2);
+	auto g = checkerboard<float>(4, 4, 2);
+	auto b = checkerboard<float>(3, 4, 2);  // wrong size
+
+	bool caught = false;
+	try { io::write_ppm("/tmp/dsp_test_bad.ppm", r, g, b); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: write_ppm should reject mismatched channels");
+
+	std::cout << "  ppm_validation: passed\n";
+}
+
+// ========== BMP Tests ==========
+
+void test_bmp_grayscale_roundtrip() {
+	auto img = checkerboard<float>(10, 12, 3, 0.0f, 1.0f);
+
+	TempFile tmp("gray.bmp");
+	io::write_bmp(tmp.path, img);
+	auto loaded = io::read_bmp<float>(tmp.path);
+
+	if (!(loaded.rows() == 10 && loaded.cols() == 12))
+		throw std::runtime_error("test failed: BMP grayscale roundtrip dimensions");
+	if (!(loaded.bits_per_pixel == 8))
+		throw std::runtime_error("test failed: BMP should be 8-bit");
+
+	double max_err = 0;
+	for (std::size_t r = 0; r < 10; ++r) {
+		for (std::size_t c = 0; c < 12; ++c) {
+			double err = std::abs(static_cast<double>(loaded.r(r, c) - img(r, c)));
+			if (err > max_err) max_err = err;
+		}
+	}
+	if (!(max_err < 1.0 / 255.0 + 1e-6))
+		throw std::runtime_error("test failed: BMP grayscale max error: "
+			+ std::to_string(max_err));
+
+	std::cout << "  bmp_grayscale_roundtrip: passed (max_err=" << max_err << ")\n";
+}
+
+void test_bmp_color_roundtrip() {
+	std::size_t rows = 8, cols = 10;
+	auto red = gradient_horizontal<float>(rows, cols);
+	auto green = gradient_vertical<float>(rows, cols);
+	auto blue = checkerboard<float>(rows, cols, 2, 0.1f, 0.9f);
+
+	TempFile tmp("color.bmp");
+	io::write_bmp(tmp.path, red, green, blue);
+	auto loaded = io::read_bmp<float>(tmp.path);
+
+	if (!(loaded.rows() == rows && loaded.cols() == cols))
+		throw std::runtime_error("test failed: BMP color roundtrip dimensions");
+	if (!(loaded.bits_per_pixel == 24))
+		throw std::runtime_error("test failed: BMP should be 24-bit");
+
+	double max_err = 0;
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			double er = std::abs(static_cast<double>(loaded.r(r, c) - red(r, c)));
+			double eg = std::abs(static_cast<double>(loaded.g(r, c) - green(r, c)));
+			double eb = std::abs(static_cast<double>(loaded.b(r, c) - blue(r, c)));
+			double e = std::max({er, eg, eb});
+			if (e > max_err) max_err = e;
+		}
+	}
+	if (!(max_err < 1.0 / 255.0 + 1e-6))
+		throw std::runtime_error("test failed: BMP color max error: "
+			+ std::to_string(max_err));
+
+	std::cout << "  bmp_color_roundtrip: passed (max_err=" << max_err << ")\n";
+}
+
+// ========== Cross-format Test ==========
+
+void test_pgm_bmp_consistency() {
+	// Write the same image as PGM and BMP, read both, compare
+	auto img = gaussian_blob<float>(16, 16, 3.0f);
+
+	TempFile pgm_file("blob.pgm");
+	TempFile bmp_file("blob.bmp");
+	io::write_pgm(pgm_file.path, img);
+	io::write_bmp(bmp_file.path, img);
+
+	auto pgm = io::read_pgm<float>(pgm_file.path);
+	auto bmp = io::read_bmp<float>(bmp_file.path);
+
+	double max_diff = 0;
+	for (std::size_t r = 0; r < 16; ++r)
+		for (std::size_t c = 0; c < 16; ++c) {
+			double d = std::abs(static_cast<double>(pgm(r, c) - bmp.r(r, c)));
+			if (d > max_diff) max_diff = d;
+		}
+	// Both 8-bit, should be identical
+	if (!(max_diff < 1e-6))
+		throw std::runtime_error("test failed: PGM/BMP should produce same 8-bit values");
+
+	std::cout << "  pgm_bmp_consistency: passed\n";
+}
+
+int main() {
+	try {
+		std::cout << "Image I/O Tests\n";
+
+		// PGM
+		test_pgm_roundtrip_checkerboard();
+		test_pgm_roundtrip_gradient();
+		test_pgm_16bit();
+		test_pgm_validation();
+
+		// PPM
+		test_ppm_roundtrip();
+		test_ppm_validation();
+
+		// BMP
+		test_bmp_grayscale_roundtrip();
+		test_bmp_color_roundtrip();
+
+		// Cross-format
+		test_pgm_bmp_consistency();
+
+		std::cout << "All image I/O tests passed.\n";
+		return 0;
+	} catch (const std::exception& e) {
+		std::cerr << "FAILED: " << e.what() << '\n';
+		return 1;
+	}
+}

--- a/tests/test_image_io.cpp
+++ b/tests/test_image_io.cpp
@@ -13,6 +13,8 @@
 
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -23,10 +25,16 @@ bool near(double a, double b, double eps = 1e-4) {
 	return std::abs(a - b) < eps;
 }
 
+// Platform-portable temp directory
+inline std::string temp_dir() {
+	auto p = std::filesystem::temp_directory_path();
+	return p.string();
+}
+
 // RAII temp file that deletes on destruction
 struct TempFile {
 	std::string path;
-	TempFile(const std::string& name) : path("/tmp/dsp_test_" + name) {}
+	TempFile(const std::string& name) : path(temp_dir() + "/dsp_test_" + name) {}
 	~TempFile() { std::remove(path.c_str()); }
 };
 
@@ -101,7 +109,7 @@ void test_pgm_validation() {
 	auto img = checkerboard<float>(4, 4, 2);
 
 	bool caught = false;
-	try { io::write_pgm("/tmp/dsp_test_bad.pgm", img, 0); }
+	try { io::write_pgm((temp_dir() + "/dsp_test_bad.pgm").c_str(), img, 0); }
 	catch (const std::invalid_argument&) { caught = true; }
 	if (!caught) throw std::runtime_error("test failed: write_pgm should reject max_val=0");
 
@@ -151,7 +159,7 @@ void test_ppm_validation() {
 	auto b = checkerboard<float>(3, 4, 2);  // wrong size
 
 	bool caught = false;
-	try { io::write_ppm("/tmp/dsp_test_bad.ppm", r, g, b); }
+	try { io::write_ppm((temp_dir() + "/dsp_test_bad.ppm").c_str(), r, g, b); }
 	catch (const std::invalid_argument&) { caught = true; }
 	if (!caught) throw std::runtime_error("test failed: write_ppm should reject mismatched channels");
 


### PR DESCRIPTION
## Summary
- Header-only readers/writers for PGM, PPM, and BMP image formats
- No external dependencies — all formats are simple enough to implement directly
- Updated `io.hpp` umbrella to include image formats alongside WAV/CSV/raw

## Changes
- `include/sw/dsp/io/pgm.hpp` — P2/P5 PGM, 8-bit and 16-bit, read/write
- `include/sw/dsp/io/ppm.hpp` — P3/P6 PPM color, read/write with PpmData<T> struct
- `include/sw/dsp/io/bmp.hpp` — 8-bit grayscale (palette) and 24-bit RGB BMP, read/write
- `include/sw/dsp/io/io.hpp` — umbrella updated
- `tests/test_image_io.cpp` — 9 round-trip tests
- `tests/CMakeLists.txt` — registered test

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_image_io | OK | 9/9 PASS | OK | 9/9 PASS |
| all tests (ctest) | OK | 19/19 PASS | OK | 19/19 PASS |

## Test plan
- [x] Fast CI passes (gcc + clang + MSVC + Apple Clang + RISC-V)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BMP image I/O support (8-bit grayscale and 24-bit color formats)
  * Added PGM (grayscale) image I/O support with configurable bit depth
  * Added PPM (color) image I/O support with full RGB channel access
  * All image formats support reading and writing with automatic normalization

* **Tests**
  * Added comprehensive image I/O test suite covering round-trip validation and format consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->