### PR TITLE
fix(elliptic): reject out-of-range rolloff instead of producing NaN

### DIFF
--- a/applications/mp_comparison/iir_precision_sweep.cpp
+++ b/applications/mp_comparison/iir_precision_sweep.cpp
@@ -1,6 +1,6 @@
 // iir_precision_sweep.cpp: mixed-precision IIR filter comparison
 //
-// Sweeps 5 IIR filter families across 6 arithmetic types, measuring:
+// Sweeps 6 IIR filter families across 6 arithmetic types, measuring:
 //   - Impulse response error (max absolute and relative)
 //   - SQNR when filtering a test signal
 //   - Pole displacement from double reference
@@ -49,13 +49,16 @@ using namespace sw::universal;
 // Test parameters
 // ============================================================================
 
-constexpr int    ORDER       = 4;
-constexpr double SAMPLE_RATE = 44100.0;
-constexpr double CUTOFF      = 2000.0;
-constexpr double RIPPLE_DB   = 1.0;
-constexpr double STOPBAND_DB = 40.0;
-constexpr int    IMPULSE_LEN = 200;
-constexpr int    SIGNAL_LEN  = 2000;
+constexpr int    ORDER           = 4;
+constexpr double SAMPLE_RATE     = 44100.0;
+constexpr double CUTOFF          = 2000.0;
+constexpr double RIPPLE_DB       = 1.0;
+constexpr double STOPBAND_DB     = 40.0;
+// Elliptic uses a DSPFilters-style selectivity parameter, not stopband dB.
+// Valid range is [0.1, 5.0]; see elliptic.hpp.
+constexpr double ELLIPTIC_ROLLOFF = 1.0;
+constexpr int    IMPULSE_LEN     = 200;
+constexpr int    SIGNAL_LEN      = 2000;
 
 // ============================================================================
 // Result structure
@@ -302,13 +305,13 @@ std::vector<MetricRow> sweep_cheby2(const std::string& fam) {
 	return rows;
 }
 
-// Helper: generate sweep for Elliptic (ripple + stopband)
+// Helper: generate sweep for Elliptic (ripple + rolloff selectivity)
 template <template <int, typename, typename, typename> class LP>
 std::vector<MetricRow> sweep_elliptic_family(const std::string& fam) {
 	std::vector<MetricRow> rows;
 	SimpleFilter<LP<ORDER, double, double, double>> ref;
-	ref.setup(ORDER, SAMPLE_RATE, CUTOFF, RIPPLE_DB, STOPBAND_DB);
-	auto s = [](auto& f) { f.setup(ORDER, SAMPLE_RATE, CUTOFF, RIPPLE_DB, STOPBAND_DB); };
+	ref.setup(ORDER, SAMPLE_RATE, CUTOFF, RIPPLE_DB, ELLIPTIC_ROLLOFF);
+	auto s = [](auto& f) { f.setup(ORDER, SAMPLE_RATE, CUTOFF, RIPPLE_DB, ELLIPTIC_ROLLOFF); };
 
 	sweep_type<LP<ORDER, double, double, double>>(fam, "double",         64, ref, rows, s);
 	sweep_type<LP<ORDER, double, float,  float>> (fam, "float",          32, ref, rows, s);
@@ -431,7 +434,7 @@ int main(int argc, char* argv[]) {
 	if (argc > 1) outdir = argv[1];
 	std::cout << std::string(100, '=') << "\n";
 	std::cout << "  Mixed-Precision IIR Filter Comparison\n";
-	std::cout << "  5 filter families x 6 arithmetic types\n";
+	std::cout << "  6 filter families x 6 arithmetic types\n";
 	std::cout << "  Order=" << ORDER << ", fs=" << SAMPLE_RATE
 	          << " Hz, fc=" << CUTOFF << " Hz\n";
 	std::cout << std::string(100, '=') << "\n";
@@ -447,8 +450,7 @@ int main(int argc, char* argv[]) {
 	run("Butterworth",            sweep_butterworth);
 	run("Chebyshev I (1dB)",      sweep_chebyshev1);
 	run("Chebyshev II (40dB)",    sweep_chebyshev2);
-	// Elliptic produces NaN — known issue, excluded until fixed
-	// run("Elliptic (1dB/40dB)",    sweep_elliptic);
+	run("Elliptic (1dB, rolloff=1.0)", sweep_elliptic);
 	run("Bessel",                 sweep_bessel);
 	run("Legendre",               sweep_legendre);
 
@@ -460,7 +462,7 @@ int main(int argc, char* argv[]) {
 
 	std::cout << "\n" << std::string(100, '=') << "\n";
 	std::cout << "  Summary: " << all_rows.size() << " measurements ("
-	          << "5 families x 6 types)\n";
+	          << "6 families x 6 types)\n";
 	std::cout << "  CSV files in: " << outdir << "/\n";
 	std::cout << "    iir_precision_sweep.csv  (" << all_rows.size() << " rows)\n";
 	std::cout << "    frequency_response.csv   (" << g_freq_rows.size() << " rows)\n";

--- a/include/sw/dsp/filter/iir/elliptic.hpp
+++ b/include/sw/dsp/filter/iir/elliptic.hpp
@@ -5,6 +5,13 @@
 // and rolloff. Has the steepest transition of any classical IIR filter
 // for a given order, at the cost of ripple in both bands.
 //
+// NOTE on `rolloff`: this is a DSPFilters-style selectivity parameter,
+// NOT a stopband attenuation in dB. Internally the elliptic modulus is
+// k = 1/xi with xi = 5*exp(rolloff-1)+1. Typical usable range is
+// [0.1, 5.0]; values outside this range produce a degenerate modulus
+// and are rejected. For Matlab/scipy-style (Ap, As) control, a Cauer-
+// Darlington design variant would be needed (not implemented).
+//
 // All arithmetic parameterized on T. Uses std::array for temporaries.
 // ADL-friendly math calls throughout.
 //
@@ -42,6 +49,15 @@ public:
 			throw std::invalid_argument("elliptic: num_poles must be > 0");
 		if (num_poles > MaxOrder)
 			throw std::out_of_range("elliptic: num_poles exceeds MaxOrder");
+		// rolloff is a selectivity parameter, NOT stopband dB. Values outside
+		// [0.1, 5.0] drive the elliptic modulus k = 1/xi = 1/(5*exp(r-1)+1)
+		// to degenerate regimes and produce NaN coefficients.
+		if (!(rolloff >= T{0.1} && rolloff <= T{5}))
+			throw std::invalid_argument(
+				"elliptic: rolloff must be in [0.1, 5.0] (selectivity "
+				"parameter, not stopband dB)");
+		if (!(ripple_db > T{0}))
+			throw std::invalid_argument("elliptic: ripple_db must be > 0");
 
 		using std::sqrt;
 		using std::exp;

--- a/tests/test_elliptic.cpp
+++ b/tests/test_elliptic.cpp
@@ -149,6 +149,51 @@ void test_elliptic_simple_filter() {
 	std::cout << "  elliptic_simple_filter: passed\n";
 }
 
+// Regression for issue #50: passing stopband-dB-style value (e.g. 40.0)
+// as rolloff used to silently produce NaN. It must now throw.
+void test_elliptic_rejects_rolloff_out_of_range() {
+	iir::EllipticLowPass<4> f;
+
+	bool threw_high = false;
+	try {
+		f.setup(4, 44100.0, 2000.0, 1.0, 40.0);
+	} catch (const std::invalid_argument&) {
+		threw_high = true;
+	}
+	if (!threw_high)
+		throw std::runtime_error("test failed: rolloff=40.0 must throw invalid_argument");
+
+	bool threw_low = false;
+	try {
+		f.setup(4, 44100.0, 2000.0, 1.0, 0.0);
+	} catch (const std::invalid_argument&) {
+		threw_low = true;
+	}
+	if (!threw_low)
+		throw std::runtime_error("test failed: rolloff=0.0 must throw invalid_argument");
+
+	std::cout << "  elliptic_rejects_rolloff_out_of_range: passed\n";
+}
+
+// Regression for issue #50: impulse response at the issue's fs/fc/order
+// must be finite with a valid rolloff.
+void test_elliptic_issue50_impulse_finite() {
+	SimpleFilter<iir::EllipticLowPass<4>> f;
+	f.setup(4, 44100.0, 2000.0, 1.0, 1.0);
+
+	double y = f.process(1.0);
+	if (!std::isfinite(y))
+		throw std::runtime_error("test failed: issue #50 impulse head is NaN");
+	for (int i = 0; i < 199; ++i) {
+		double s = f.process(0.0);
+		if (!std::isfinite(s))
+			throw std::runtime_error(
+				"test failed: issue #50 impulse sample " + std::to_string(i + 1) + " is NaN");
+	}
+
+	std::cout << "  elliptic_issue50_impulse_finite: passed\n";
+}
+
 int main() {
 	try {
 		std::cout << "Elliptic Filter Tests\n";
@@ -162,6 +207,8 @@ int main() {
 		test_elliptic_orders();
 		test_elliptic_steeper_than_butterworth();
 		test_elliptic_simple_filter();
+		test_elliptic_rejects_rolloff_out_of_range();
+		test_elliptic_issue50_impulse_finite();
 
 		std::cout << "All Elliptic filter tests passed.\n";
 		return 0;


### PR DESCRIPTION
## Summary
- `EllipticLowPass<...>::setup(order, fs, fc, ripple_db, rolloff)` was silently producing NaN for plausible-looking inputs like `rolloff=40.0` — the parameter is actually a DSPFilters-style selectivity knob (typical range 0.1–5.0), not stopband attenuation in dB. The `iir_precision_sweep` application (from #23) was reusing `STOPBAND_DB=40.0` for Elliptic's 5th argument, which is why Elliptic had been excluded from the sweep.
- Root cause: `xi = 5*exp(rolloff-1)+1` → ~4.3e17 at rolloff=40 → Jacobi modulus ~2e-18 → NaN through the Bairstow root-finder in `findfact()`.

## Changes
- `include/sw/dsp/filter/iir/elliptic.hpp` — validate `rolloff ∈ [0.1, 5.0]` and `ripple_db > 0` in `EllipticAnalogPrototype::design()`; header docstring clarifies what `rolloff` is (and notes that Matlab/scipy-style `(Ap, As)` control would need a Cauer–Darlington variant, not implemented).
- `applications/mp_comparison/iir_precision_sweep.cpp` — introduce `ELLIPTIC_ROLLOFF=1.0`, stop reusing `STOPBAND_DB` for the Elliptic call, re-enable the Elliptic row (now 6 families × 6 types). Updated header/summary counts.
- `tests/test_elliptic.cpp` — two regressions: (a) rolloff=40.0 and rolloff=0.0 each throw `std::invalid_argument`; (b) issue #50's exact `(4, 44100, 2000, 1.0, 1.0)` produces a fully finite 200-sample impulse response.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_elliptic | OK | 11/11 PASS | OK | 11/11 PASS |
| iir_precision_sweep | OK | runs, Elliptic row populates | OK | runs, Elliptic row populates |
| full ctest | OK | 20/20 PASS | OK | 20/20 PASS |

### Elliptic sweep output (identical under gcc and clang)
```
Type              Bits    Abs Error    Rel Error   SQNR(dB)
double              64            0            0        inf
float               32     2.17e-07     2.23e-06      115.4
cfloat<24,5>        24     6.82e-06     6.99e-05       79.7
half                16     1.12e-03     1.14e-02       34.2
posit<32,2>         32     6.47e-09     6.64e-08      144.1
posit<16,1>         16     3.92e-04     4.02e-03       43.7
```

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready: `gh pr ready <N>`

## Follow-up (not in this PR)
If users want Matlab/scipy-style `(Ap, As)` control over the Elliptic filter, that would be a separate enhancement — a Cauer–Darlington design variant that takes explicit stopband attenuation. Worth a separate issue if there is demand.

Resolves #50

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Elliptic filter measurements are now actively included in the precision sweep analysis, expanding comparison coverage.

* **Bug Fixes**
  * Implemented parameter validation to prevent invalid filter configurations and provide clearer error messages.
  * Enhanced input validation to ensure proper filter parameter ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->