### PR TITLE
fix(app): rename fp32/fp16 aliases to avoid sw::universal collision

### DIFF
--- a/applications/mp_comparison/iir_precision_sweep.cpp
+++ b/applications/mp_comparison/iir_precision_sweep.cpp
@@ -1,6 +1,6 @@
 // iir_precision_sweep.cpp: mixed-precision IIR filter comparison
 //
-// Sweeps 6 IIR filter families across 6 arithmetic types, measuring:
+// Sweeps 6 IIR filter families across 8 arithmetic types, measuring:
 //   - Impulse response error (max absolute and relative)
 //   - SQNR when filtering a test signal
 //   - Pole displacement from double reference
@@ -236,8 +236,13 @@ void sweep_type(const std::string& family, const std::string& type_name,
 
 using cf24  = cfloat<24, 5, uint32_t, true, false, false>;
 using half_ = cfloat<16, 5, uint16_t, true, false, false>;
-using fp32  = fixpnt<32, 16>;
-using fp16  = fixpnt<16, 8>;
+// NOTE: avoid the names fp32/fp16 here. `using namespace sw::universal`
+// above pulls in sw::universal::fp32 (== single) and sw::universal::fp16
+// (== half) from cfloat.hpp. A local `using fp32 = ...` would collide
+// and make the name ambiguous inside template-argument contexts, which
+// GCC reports as the cryptic "template argument is invalid" (issue #51).
+using fxp32 = fixpnt<32, 16>;
+using fxp16 = fixpnt<16, 8>;
 using p32   = posit<32, 2>;
 using p16   = posit<16, 1>;
 
@@ -255,9 +260,8 @@ std::vector<MetricRow> sweep_lp(const std::string& fam) {
 	sweep_type<LP<ORDER, double, half_,  half_>> (fam, "half",           16, ref, rows, s);
 	sweep_type<LP<ORDER, double, p32,    p32>>   (fam, "posit<32,2>",    32, ref, rows, s);
 	sweep_type<LP<ORDER, double, p16,    p16>>   (fam, "posit<16,1>",    16, ref, rows, s);
-	// fixpnt types require explicit arithmetic template parameter
-	// sweep_type<LP<ORDER, double, fp32, fp32>>(fam, "fixpnt<32,16>", 32, ref, rows, s);
-	// sweep_type<LP<ORDER, double, fp16, fp16>>(fam, "fixpnt<16,8>",  16, ref, rows, s);
+	sweep_type<LP<ORDER, double, fxp32,  fxp32>> (fam, "fixpnt<32,16>",  32, ref, rows, s);
+	sweep_type<LP<ORDER, double, fxp16,  fxp16>> (fam, "fixpnt<16,8>",   16, ref, rows, s);
 	return rows;
 }
 
@@ -279,9 +283,8 @@ std::vector<MetricRow> sweep_cheby1(const std::string& fam) {
 	sweep_type<LP<ORDER, double, half_,  half_>> (fam, "half",           16, ref, rows, s);
 	sweep_type<LP<ORDER, double, p32,    p32>>   (fam, "posit<32,2>",    32, ref, rows, s);
 	sweep_type<LP<ORDER, double, p16,    p16>>   (fam, "posit<16,1>",    16, ref, rows, s);
-	// fixpnt types require explicit arithmetic template parameter
-	// sweep_type<LP<ORDER, double, fp32, fp32>>(fam, "fixpnt<32,16>", 32, ref, rows, s);
-	// sweep_type<LP<ORDER, double, fp16, fp16>>(fam, "fixpnt<16,8>",  16, ref, rows, s);
+	sweep_type<LP<ORDER, double, fxp32,  fxp32>> (fam, "fixpnt<32,16>",  32, ref, rows, s);
+	sweep_type<LP<ORDER, double, fxp16,  fxp16>> (fam, "fixpnt<16,8>",   16, ref, rows, s);
 	return rows;
 }
 
@@ -299,9 +302,8 @@ std::vector<MetricRow> sweep_cheby2(const std::string& fam) {
 	sweep_type<LP<ORDER, double, half_,  half_>> (fam, "half",           16, ref, rows, s);
 	sweep_type<LP<ORDER, double, p32,    p32>>   (fam, "posit<32,2>",    32, ref, rows, s);
 	sweep_type<LP<ORDER, double, p16,    p16>>   (fam, "posit<16,1>",    16, ref, rows, s);
-	// fixpnt types require explicit arithmetic template parameter
-	// sweep_type<LP<ORDER, double, fp32, fp32>>(fam, "fixpnt<32,16>", 32, ref, rows, s);
-	// sweep_type<LP<ORDER, double, fp16, fp16>>(fam, "fixpnt<16,8>",  16, ref, rows, s);
+	sweep_type<LP<ORDER, double, fxp32,  fxp32>> (fam, "fixpnt<32,16>",  32, ref, rows, s);
+	sweep_type<LP<ORDER, double, fxp16,  fxp16>> (fam, "fixpnt<16,8>",   16, ref, rows, s);
 	return rows;
 }
 
@@ -319,9 +321,8 @@ std::vector<MetricRow> sweep_elliptic_family(const std::string& fam) {
 	sweep_type<LP<ORDER, double, half_,  half_>> (fam, "half",           16, ref, rows, s);
 	sweep_type<LP<ORDER, double, p32,    p32>>   (fam, "posit<32,2>",    32, ref, rows, s);
 	sweep_type<LP<ORDER, double, p16,    p16>>   (fam, "posit<16,1>",    16, ref, rows, s);
-	// fixpnt types require explicit arithmetic template parameter
-	// sweep_type<LP<ORDER, double, fp32, fp32>>(fam, "fixpnt<32,16>", 32, ref, rows, s);
-	// sweep_type<LP<ORDER, double, fp16, fp16>>(fam, "fixpnt<16,8>",  16, ref, rows, s);
+	sweep_type<LP<ORDER, double, fxp32,  fxp32>> (fam, "fixpnt<32,16>",  32, ref, rows, s);
+	sweep_type<LP<ORDER, double, fxp16,  fxp16>> (fam, "fixpnt<16,8>",   16, ref, rows, s);
 	return rows;
 }
 
@@ -434,7 +435,7 @@ int main(int argc, char* argv[]) {
 	if (argc > 1) outdir = argv[1];
 	std::cout << std::string(100, '=') << "\n";
 	std::cout << "  Mixed-Precision IIR Filter Comparison\n";
-	std::cout << "  6 filter families x 6 arithmetic types\n";
+	std::cout << "  6 filter families x 8 arithmetic types\n";
 	std::cout << "  Order=" << ORDER << ", fs=" << SAMPLE_RATE
 	          << " Hz, fc=" << CUTOFF << " Hz\n";
 	std::cout << std::string(100, '=') << "\n";
@@ -462,7 +463,7 @@ int main(int argc, char* argv[]) {
 
 	std::cout << "\n" << std::string(100, '=') << "\n";
 	std::cout << "  Summary: " << all_rows.size() << " measurements ("
-	          << "6 families x 6 types)\n";
+	          << "6 families x 8 types)\n";
 	std::cout << "  CSV files in: " << outdir << "/\n";
 	std::cout << "    iir_precision_sweep.csv  (" << all_rows.size() << " rows)\n";
 	std::cout << "    frequency_response.csv   (" << g_freq_rows.size() << " rows)\n";


### PR DESCRIPTION
## Summary
- The reported bug (#51, "template argument 3 is invalid" when fixpnt appears in a template template parameter context) is not actually a template template deduction issue — it's a **namespace-pollution name collision**.
- `sw/universal/number/cfloat/cfloat.hpp:91` defines `using fp32 = single;` (IEEE-754 binary32 alias) and `fp16 = half`. `iir_precision_sweep.cpp` does `using namespace sw::universal;` and then redeclares `using fp32 = fixpnt<32,16>;`. Inside template-argument contexts the name becomes ambiguous and GCC emits the generic "template argument is invalid" error.
- Verified by bisecting reproducers: removing `#include <sw/universal/number/cfloat/cfloat.hpp>` makes the original repro compile; renaming the local alias to `fxp32` also makes it compile. Both point at the collision.

## Changes
- `applications/mp_comparison/iir_precision_sweep.cpp`
  - Rename `fp32` → `fxp32` (fixpnt<32,16>) and `fp16` → `fxp16` (fixpnt<16,8>)
  - Add a documentation comment at the alias site noting the collision so the name is not reintroduced.
  - Re-enable the four commented-out fixpnt `sweep_type<...>` calls in `sweep_lp`, `sweep_cheby1`, `sweep_cheby2`, and `sweep_elliptic_family`.
  - Update header/summary text from "6 arithmetic types" to "8 arithmetic types" (48 measurements vs. 36).

## Test Results
| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| iir_precision_sweep | OK | 48 rows, all finite | OK | 48 rows, identical |
| full ctest | OK | 20/20 PASS | OK | 20/20 PASS |

### fixpnt rows now populate (Butterworth excerpt, gcc)
```
Type              Bits    Abs Error    Rel Error   SQNR(dB)
fixpnt<32,16>       32     6.06e-04     5.59e-03       46.1
fixpnt<16,8>        16     1.08e-01     1.00e+00        0.0
```
(fixpnt<16,8>'s 0 dB SQNR is the expected behavior — 8 fractional bits saturate heavily; the data is honest, not a bug.)

## Why this is better than the workaround floated in the issue
The issue body hypothesized that an explicit 4th template parameter (`fixpnt<32,16,Modulo,uint8_t>`) was required. That would have worked incidentally (forcing a fresh substitution) but would have left the root cause (name collision) lurking for anyone who reuses the `fp32` name later. Renaming + a one-line comment is narrower and self-documenting.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready: `gh pr ready <N>`

Resolves #51

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded IIR filter precision sweep functionality to support 8 arithmetic types across all filter families (lowpass, Chebyshev I/II, elliptic), up from 6 previously. Includes additional fixed-point precision variants.

* **Refactor**
  * Updated internal type naming conventions to prevent conflicts with standard definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->