### PR TITLE
feat(estimation): Unscented Kalman Filter with LDL^T sigma-point generation

### DIFF
--- a/applications/estimation_demo/CMakeLists.txt
+++ b/applications/estimation_demo/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_executable(ekf_bearing_range ekf_bearing_range.cpp)
 target_link_libraries(ekf_bearing_range PRIVATE sw::dsp)
+
+add_executable(ukf_tracking ukf_tracking.cpp)
+target_link_libraries(ukf_tracking PRIVATE sw::dsp)

--- a/applications/estimation_demo/ukf_tracking.cpp
+++ b/applications/estimation_demo/ukf_tracking.cpp
@@ -1,0 +1,106 @@
+// ukf_tracking.cpp: 2D target tracking with the Unscented Kalman Filter
+//
+// Same bearing-range scenario as the EKF demo, but the UKF needs no
+// Jacobians — it propagates sigma points directly through the nonlinear
+// observation model h(x) = [range, bearing].
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/estimation/ukf.hpp>
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <random>
+
+using namespace sw::dsp;
+
+int main() {
+	using vec = mtl::vec::dense_vector<double>;
+	constexpr int N = 80;
+
+	UnscentedKalmanFilter<double> ukf(4, 2);
+
+	ukf.set_state_function([](const vec& s) -> vec {
+		constexpr double dt = 1.0;
+		vec s_new(4);
+		s_new[0] = s[0] + dt * s[2];
+		s_new[1] = s[1] + dt * s[3];
+		s_new[2] = s[2];
+		s_new[3] = s[3];
+		return s_new;
+	});
+
+	ukf.set_observation_function([](const vec& s) -> vec {
+		vec z(2);
+		z[0] = std::sqrt(s[0] * s[0] + s[1] * s[1]);
+		z[1] = std::atan2(s[1], s[0]);
+		return z;
+	});
+
+	ukf.Q()(0, 0) = 0.1;  ukf.Q()(1, 1) = 0.1;
+	ukf.Q()(2, 2) = 0.01; ukf.Q()(3, 3) = 0.01;
+	ukf.R()(0, 0) = 4.0;
+	ukf.R()(1, 1) = 0.0025;
+
+	ukf.state()[0] = 90.0;
+	ukf.state()[1] = 10.0;
+	ukf.state()[2] = 0.0;
+	ukf.state()[3] = 0.0;
+	ukf.P()(0, 0) = 200.0; ukf.P()(1, 1) = 200.0;
+	ukf.P()(2, 2) = 20.0;  ukf.P()(3, 3) = 20.0;
+
+	double true_x = 100.0, true_y = 0.0;
+	double true_vx = -0.5, true_vy = 10.0;
+
+	std::mt19937 gen(42);
+	std::normal_distribution<double> range_noise(0.0, 2.0);
+	std::normal_distribution<double> bearing_noise(0.0, 0.05);
+
+	std::cout << "=== UKF Bearing-Range Tracking Demo ===\n";
+	std::cout << "Sigma-point sampling (no Jacobians required)\n";
+	std::cout << "Target: (100, 0) velocity (-0.5, 10)\n\n";
+	std::cout << std::left
+	          << std::setw(5) << "t"
+	          << std::setw(14) << "true_x"
+	          << std::setw(14) << "true_y"
+	          << std::setw(14) << "est_x"
+	          << std::setw(14) << "est_y"
+	          << std::setw(14) << "err_pos"
+	          << "\n";
+	std::cout << std::string(75, '-') << "\n";
+
+	vec z(2);
+	for (int t = 1; t <= N; ++t) {
+		true_x += true_vx;
+		true_y += true_vy;
+		z[0] = std::sqrt(true_x * true_x + true_y * true_y) + range_noise(gen);
+		z[1] = std::atan2(true_y, true_x) + bearing_noise(gen);
+
+		ukf.predict();
+		ukf.update(z);
+
+		double ex = ukf.state()[0], ey = ukf.state()[1];
+		double err = std::sqrt((ex - true_x) * (ex - true_x) +
+		                       (ey - true_y) * (ey - true_y));
+		if (t <= 10 || t % 10 == 0) {
+			std::cout << std::setw(5) << t
+			          << std::setw(14) << std::fixed << std::setprecision(2) << true_x
+			          << std::setw(14) << true_y
+			          << std::setw(14) << ex
+			          << std::setw(14) << ey
+			          << std::setw(14) << err << "\n";
+		}
+	}
+
+	double final_err = std::sqrt(
+		(ukf.state()[0] - true_x) * (ukf.state()[0] - true_x) +
+		(ukf.state()[1] - true_y) * (ukf.state()[1] - true_y));
+	std::cout << "\nFinal position error: " << std::fixed << std::setprecision(3)
+	          << final_err << " m\n";
+	std::cout << "Estimated velocity:   (" << ukf.state()[2] << ", " << ukf.state()[3]
+	          << ") (true: " << true_vx << ", " << true_vy << ")\n";
+
+	return 0;
+}

--- a/include/sw/dsp/estimation/estimation.hpp
+++ b/include/sw/dsp/estimation/estimation.hpp
@@ -6,6 +6,6 @@
 
 #include <sw/dsp/estimation/kalman.hpp>
 #include <sw/dsp/estimation/ekf.hpp>
+#include <sw/dsp/estimation/ukf.hpp>
 #include <sw/dsp/estimation/lms.hpp>
 #include <sw/dsp/estimation/rls.hpp>
-// Future: ukf.hpp

--- a/include/sw/dsp/estimation/ukf.hpp
+++ b/include/sw/dsp/estimation/ukf.hpp
@@ -1,0 +1,278 @@
+#pragma once
+// ukf.hpp: Unscented Kalman Filter with sigma-point sampling
+//
+// The UKF propagates a deterministic set of 2n+1 "sigma points" through
+// the nonlinear state-transition f(x) and observation h(x) functions,
+// then reconstructs the predicted mean and covariance from the propagated
+// points. Unlike the EKF, no Jacobians are required.
+//
+// Sigma-point scaling follows the Julier/Merwe parameterization
+// (alpha, beta, kappa). Defaults are alpha=0.5, beta=2, kappa=3-n
+// per Wan & van der Merwe 2001 recommendations for moderate nonlinearity.
+//
+// The matrix square root for sigma-point generation uses LDL^T
+// decomposition (mtl::ldlt_factor) instead of standard Cholesky (LL^T).
+// LDL^T avoids intermediate square roots, giving better numerical
+// stability for ill-conditioned covariances — especially important
+// for mixed-precision arithmetic where P can lose positive-definiteness
+// after informative observations.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <stdexcept>
+#include <vector>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/mat/operators.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/vec/operators.hpp>
+#include <mtl/operation/trans.hpp>
+#include <mtl/operation/inv.hpp>
+#include <mtl/operation/ldlt.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+template <DspField T>
+class UnscentedKalmanFilter {
+public:
+	using matrix_t   = mtl::mat::dense2D<T>;
+	using vector_t   = mtl::vec::dense_vector<T>;
+	using state_func = std::function<vector_t(const vector_t&)>;
+	using obs_func   = std::function<vector_t(const vector_t&)>;
+
+	// alpha: spread of sigma points around the mean (0 < alpha <= 1).
+	// beta:  prior knowledge of distribution (2 is optimal for Gaussian).
+	// kappa: secondary scaling parameter (3-n is the Julier convention).
+	UnscentedKalmanFilter(std::size_t state_dim, std::size_t meas_dim,
+	                      T alpha = T{0.5}, T beta = T{2},
+	                      T kappa = T{})
+		: n_(state_dim), m_(meas_dim),
+		  alpha_(alpha), beta_(beta),
+		  x_(state_dim, T{}),
+		  P_(state_dim, state_dim),
+		  Q_(state_dim, state_dim),
+		  R_(meas_dim, meas_dim)
+	{
+		if (state_dim == 0)
+			throw std::invalid_argument("UnscentedKalmanFilter: state_dim must be > 0");
+		if (meas_dim == 0)
+			throw std::invalid_argument("UnscentedKalmanFilter: meas_dim must be > 0");
+
+		// Default kappa = 3 - n (Julier convention)
+		if (kappa == T{})
+			kappa_ = T{3} - static_cast<T>(state_dim);
+		else
+			kappa_ = kappa;
+
+		compute_weights();
+		identity_matrix(P_);
+		identity_matrix(Q_);
+		identity_matrix(R_);
+	}
+
+	void set_state_function(state_func f) { f_ = std::move(f); }
+	void set_observation_function(obs_func h) { h_ = std::move(h); }
+
+	// Predict: generate sigma points from (x, P), propagate through f,
+	// reconstruct predicted mean and covariance.
+	void predict() {
+		if (!f_)
+			throw std::logic_error("UnscentedKalmanFilter::predict: state function not set");
+
+		auto sigma = generate_sigma_points(x_, P_);
+
+		// Propagate each sigma point through f.
+		std::size_t num_pts = 2 * n_ + 1;
+		std::vector<vector_t> chi_pred(num_pts);
+		for (std::size_t i = 0; i < num_pts; ++i) {
+			chi_pred[i] = f_(column(sigma, i));
+		}
+
+		// Reconstruct predicted mean.
+		x_ = weighted_mean(chi_pred);
+
+		// Reconstruct predicted covariance + process noise.
+		P_ = weighted_covariance(chi_pred, x_, chi_pred, x_);
+		P_ = P_ + Q_;
+	}
+
+	// Update: generate sigma points from predicted (x, P), propagate
+	// through h, compute cross-covariance, Kalman gain, and update.
+	void update(const vector_t& z) {
+		if (!h_)
+			throw std::logic_error("UnscentedKalmanFilter::update: observation function not set");
+		if (z.size() != m_)
+			throw std::invalid_argument("UnscentedKalmanFilter::update: measurement size mismatch");
+
+		auto sigma = generate_sigma_points(x_, P_);
+
+		std::size_t num_pts = 2 * n_ + 1;
+		std::vector<vector_t> gamma(num_pts);
+		std::vector<vector_t> chi(num_pts);
+		for (std::size_t i = 0; i < num_pts; ++i) {
+			chi[i] = column(sigma, i);
+			gamma[i] = h_(chi[i]);
+		}
+
+		vector_t z_pred = weighted_mean(gamma);
+
+		// Innovation covariance P_zz + R.
+		matrix_t P_zz = weighted_covariance(gamma, z_pred, gamma, z_pred);
+		P_zz = P_zz + R_;
+
+		// Cross-covariance P_xz.
+		matrix_t P_xz = weighted_covariance(chi, x_, gamma, z_pred);
+
+		// Kalman gain.
+		using mtl::inv;
+		matrix_t K = P_xz * inv(P_zz);
+
+		// Update state and covariance.
+		using mtl::trans;
+		vector_t innovation = z - z_pred;
+		x_ = x_ + K * innovation;
+		P_ = P_ - K * P_zz * trans(K);
+	}
+
+	// Accessors
+	matrix_t& Q() { return Q_; }
+	matrix_t& R() { return R_; }
+	matrix_t& P() { return P_; }
+	vector_t& state() { return x_; }
+
+	const matrix_t& Q() const { return Q_; }
+	const matrix_t& R() const { return R_; }
+	const matrix_t& P() const { return P_; }
+	const vector_t& state() const { return x_; }
+
+	std::size_t state_dim() const { return n_; }
+	std::size_t meas_dim() const { return m_; }
+
+private:
+	// --- Weight computation (Julier/Merwe) ---
+	void compute_weights() {
+		T n = static_cast<T>(n_);
+		lambda_ = alpha_ * alpha_ * (n + kappa_) - n;
+		T denom = n + lambda_;
+
+		std::size_t num_pts = 2 * n_ + 1;
+		Wm_.resize(num_pts);
+		Wc_.resize(num_pts);
+
+		Wm_[0] = lambda_ / denom;
+		Wc_[0] = lambda_ / denom + (T{1} - alpha_ * alpha_ + beta_);
+		for (std::size_t i = 1; i < num_pts; ++i) {
+			Wm_[i] = T{1} / (T{2} * denom);
+			Wc_[i] = Wm_[i];
+		}
+	}
+
+	// --- Sigma-point generation via LDL^T ---
+	// Returns an n × (2n+1) matrix whose columns are the sigma points.
+	matrix_t generate_sigma_points(const vector_t& x, const matrix_t& P) const {
+		std::size_t num_pts = 2 * n_ + 1;
+		matrix_t sigma(n_, num_pts);
+
+		// Compute S = L * sqrt(D) from LDL^T of (n + lambda) * P.
+		T scale = static_cast<T>(n_) + lambda_;
+		matrix_t A(n_, n_);
+		for (std::size_t i = 0; i < n_; ++i)
+			for (std::size_t j = 0; j < n_; ++j)
+				A(i, j) = scale * P(i, j);
+
+		int info = mtl::ldlt_factor(A);
+		if (info != 0)
+			throw std::runtime_error(
+				"UnscentedKalmanFilter: LDL^T failed — covariance not positive definite "
+				"(pivot " + std::to_string(info - 1) + " is zero)");
+
+		// A now has: diagonal = D, strict lower triangle = L (unit diagonal).
+		// Compute S = L * sqrt(D): column j of S = L[:,j] * sqrt(D[j]).
+		using std::sqrt;
+		matrix_t S(n_, n_);
+		for (std::size_t j = 0; j < n_; ++j) {
+			T sj = sqrt(A(j, j));  // sqrt(D[j])
+			S(j, j) = sj;          // L has unit diagonal
+			for (std::size_t i = j + 1; i < n_; ++i) {
+				S(i, j) = A(i, j) * sj;  // L(i,j) * sqrt(D[j])
+			}
+			for (std::size_t i = 0; i < j; ++i) {
+				S(i, j) = T{};  // upper triangle = 0
+			}
+		}
+
+		// chi[0] = x
+		for (std::size_t i = 0; i < n_; ++i) sigma(i, 0) = x[i];
+
+		// chi[1..n] = x + S[:,i-1],  chi[n+1..2n] = x - S[:,i-1]
+		for (std::size_t j = 0; j < n_; ++j) {
+			for (std::size_t i = 0; i < n_; ++i) {
+				sigma(i, j + 1)      = x[i] + S(i, j);
+				sigma(i, j + 1 + n_) = x[i] - S(i, j);
+			}
+		}
+		return sigma;
+	}
+
+	// Extract column j from a matrix as a vector.
+	static vector_t column(const matrix_t& M, std::size_t j) {
+		std::size_t rows = M.num_rows();
+		vector_t v(rows);
+		for (std::size_t i = 0; i < rows; ++i) v[i] = M(i, j);
+		return v;
+	}
+
+	// Weighted mean of a set of vectors.
+	vector_t weighted_mean(const std::vector<vector_t>& pts) const {
+		std::size_t dim = pts[0].size();
+		vector_t mu(dim, T{});
+		for (std::size_t i = 0; i < pts.size(); ++i) {
+			for (std::size_t d = 0; d < dim; ++d) {
+				mu[d] = mu[d] + Wm_[i] * pts[i][d];
+			}
+		}
+		return mu;
+	}
+
+	// Weighted cross-covariance: sum_i W_c[i] * (a[i]-mu_a) * (b[i]-mu_b)^T
+	matrix_t weighted_covariance(const std::vector<vector_t>& a, const vector_t& mu_a,
+	                             const std::vector<vector_t>& b, const vector_t& mu_b) const {
+		std::size_t da = mu_a.size(), db = mu_b.size();
+		matrix_t C(da, db);
+		for (std::size_t i = 0; i < da; ++i)
+			for (std::size_t j = 0; j < db; ++j)
+				C(i, j) = T{};
+
+		for (std::size_t k = 0; k < a.size(); ++k) {
+			for (std::size_t i = 0; i < da; ++i) {
+				T diff_a = a[k][i] - mu_a[i];
+				for (std::size_t j = 0; j < db; ++j) {
+					C(i, j) = C(i, j) + Wc_[k] * diff_a * (b[k][j] - mu_b[j]);
+				}
+			}
+		}
+		return C;
+	}
+
+	static void identity_matrix(matrix_t& m) {
+		std::size_t r = m.num_rows(), c = m.num_cols();
+		for (std::size_t i = 0; i < r; ++i)
+			for (std::size_t j = 0; j < c; ++j)
+				m(i, j) = (i == j) ? T{1} : T{};
+	}
+
+	std::size_t n_;   // state dimension
+	std::size_t m_;   // measurement dimension
+	T alpha_, beta_, kappa_, lambda_;
+	std::vector<T> Wm_, Wc_;  // mean and covariance weights
+	vector_t    x_;
+	matrix_t    P_, Q_, R_;
+	state_func  f_;
+	obs_func    h_;
+};
+
+} // namespace sw::dsp

--- a/include/sw/dsp/estimation/ukf.hpp
+++ b/include/sw/dsp/estimation/ukf.hpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <cstddef>
 #include <functional>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 #include <mtl/mat/dense2D.hpp>
@@ -46,10 +47,12 @@ public:
 
 	// alpha: spread of sigma points around the mean (0 < alpha <= 1).
 	// beta:  prior knowledge of distribution (2 is optimal for Gaussian).
-	// kappa: secondary scaling parameter (3-n is the Julier convention).
+	// kappa: secondary scaling parameter. Default (nullopt) uses 3-n
+	//        (Julier convention). Passing 0 explicitly is valid and gives
+	//        the original non-scaled unscented transform.
 	UnscentedKalmanFilter(std::size_t state_dim, std::size_t meas_dim,
 	                      T alpha = T{0.5}, T beta = T{2},
-	                      T kappa = T{})
+	                      std::optional<T> kappa = std::nullopt)
 		: n_(state_dim), m_(meas_dim),
 		  alpha_(alpha), beta_(beta),
 		  x_(state_dim, T{}),
@@ -62,11 +65,7 @@ public:
 		if (meas_dim == 0)
 			throw std::invalid_argument("UnscentedKalmanFilter: meas_dim must be > 0");
 
-		// Default kappa = 3 - n (Julier convention)
-		if (kappa == T{})
-			kappa_ = T{3} - static_cast<T>(state_dim);
-		else
-			kappa_ = kappa;
+		kappa_ = kappa.value_or(T{3} - static_cast<T>(state_dim));
 
 		compute_weights();
 		identity_matrix(P_);
@@ -195,6 +194,11 @@ private:
 		using std::sqrt;
 		matrix_t S(n_, n_);
 		for (std::size_t j = 0; j < n_; ++j) {
+			if (!(A(j, j) > T{}))
+				throw std::runtime_error(
+					"UnscentedKalmanFilter: non-positive diagonal D["
+					+ std::to_string(j) + "] in LDL^T "
+					"-- covariance not positive definite");
 			T sj = sqrt(A(j, j));  // sqrt(D[j])
 			S(j, j) = sj;          // L has unit diagonal
 			for (std::size_t i = j + 1; i < n_; ++i) {

--- a/tests/test_kalman.cpp
+++ b/tests/test_kalman.cpp
@@ -305,6 +305,137 @@ void test_ekf_validation() {
 	std::cout << "  ekf_validation: passed\n";
 }
 
+// ========== UKF Tests ==========
+
+void test_ukf_construction() {
+	UnscentedKalmanFilter<double> ukf(4, 2);
+	if (!(ukf.state_dim() == 4)) throw std::runtime_error("test failed: ukf state_dim");
+	if (!(ukf.meas_dim() == 2))  throw std::runtime_error("test failed: ukf meas_dim");
+	if (!(ukf.state().size() == 4)) throw std::runtime_error("test failed: ukf state size");
+
+	std::cout << "  ukf_construction: passed\n";
+}
+
+void test_ukf_sigma_identity() {
+	// For the identity function f(x) = x, predict should leave
+	// mean unchanged and covariance = P + Q.
+	UnscentedKalmanFilter<double> ukf(2, 1);
+
+	using vec = mtl::vec::dense_vector<double>;
+	ukf.set_state_function([](const vec& x) -> vec { return x; });
+	ukf.set_observation_function([](const vec& x) -> vec {
+		vec z(1); z[0] = x[0]; return z;
+	});
+
+	ukf.state()[0] = 5.0;
+	ukf.state()[1] = -3.0;
+	ukf.P()(0, 0) = 4.0; ukf.P()(0, 1) = 0.0;
+	ukf.P()(1, 0) = 0.0; ukf.P()(1, 1) = 9.0;
+	ukf.Q()(0, 0) = 0.01; ukf.Q()(0, 1) = 0.0;
+	ukf.Q()(1, 0) = 0.0;  ukf.Q()(1, 1) = 0.01;
+
+	ukf.predict();
+
+	if (!near(ukf.state()[0], 5.0, 1e-10))
+		throw std::runtime_error("test failed: ukf identity mean[0]");
+	if (!near(ukf.state()[1], -3.0, 1e-10))
+		throw std::runtime_error("test failed: ukf identity mean[1]");
+	// P should be original P + Q
+	if (!near(ukf.P()(0, 0), 4.01, 0.05))
+		throw std::runtime_error("test failed: ukf identity P(0,0)");
+	if (!near(ukf.P()(1, 1), 9.01, 0.05))
+		throw std::runtime_error("test failed: ukf identity P(1,1)");
+
+	std::cout << "  ukf_sigma_identity: passed\n";
+}
+
+void test_ukf_bearing_range_tracking() {
+	// Same 2D bearing-range tracking as the EKF test, for comparison.
+	using vec = mtl::vec::dense_vector<double>;
+	constexpr double dt = 1.0;
+
+	UnscentedKalmanFilter<double> ukf(4, 2);
+
+	ukf.set_state_function([](const vec& s) -> vec {
+		constexpr double dt = 1.0;
+		vec s_new(4);
+		s_new[0] = s[0] + dt * s[2];
+		s_new[1] = s[1] + dt * s[3];
+		s_new[2] = s[2];
+		s_new[3] = s[3];
+		return s_new;
+	});
+
+	ukf.set_observation_function([](const vec& s) -> vec {
+		vec z(2);
+		z[0] = std::sqrt(s[0] * s[0] + s[1] * s[1]);
+		z[1] = std::atan2(s[1], s[0]);
+		return z;
+	});
+
+	ukf.Q()(0, 0) = 0.1;  ukf.Q()(1, 1) = 0.1;
+	ukf.Q()(2, 2) = 0.01; ukf.Q()(3, 3) = 0.01;
+	ukf.R()(0, 0) = 1.0;
+	ukf.R()(1, 1) = 0.001;
+
+	ukf.state()[0] = 95.0;
+	ukf.state()[1] = 5.0;
+	ukf.state()[2] = 0.0;
+	ukf.state()[3] = 0.0;
+	ukf.P()(0, 0) = 100.0; ukf.P()(1, 1) = 100.0;
+	ukf.P()(2, 2) = 10.0;  ukf.P()(3, 3) = 10.0;
+
+	std::mt19937 gen(123);
+	std::normal_distribution<double> range_noise(0.0, 1.0);
+	std::normal_distribution<double> bearing_noise(0.0, std::sqrt(0.001));
+
+	double true_x = 100.0, true_y = 0.0;
+	double true_vx = 0.0,  true_vy = 10.0;
+
+	vec z(2);
+	for (int t = 0; t < 50; ++t) {
+		true_x += true_vx * dt;
+		true_y += true_vy * dt;
+		z[0] = std::sqrt(true_x * true_x + true_y * true_y) + range_noise(gen);
+		z[1] = std::atan2(true_y, true_x) + bearing_noise(gen);
+		ukf.predict();
+		ukf.update(z);
+	}
+
+	double est_x = ukf.state()[0], est_y = ukf.state()[1];
+	double est_vx = ukf.state()[2], est_vy = ukf.state()[3];
+
+	if (!near(est_x, true_x, 5.0))
+		throw std::runtime_error("test failed: UKF bearing-range x off by "
+			+ std::to_string(std::abs(est_x - true_x)));
+	if (!near(est_y, true_y, 5.0))
+		throw std::runtime_error("test failed: UKF bearing-range y off by "
+			+ std::to_string(std::abs(est_y - true_y)));
+	if (!near(est_vx, true_vx, 2.0))
+		throw std::runtime_error("test failed: UKF bearing-range vx");
+	if (!near(est_vy, true_vy, 2.0))
+		throw std::runtime_error("test failed: UKF bearing-range vy");
+
+	std::cout << "  ukf_bearing_range_tracking: passed (pos=[" << est_x << ", " << est_y
+	          << "], vel=[" << est_vx << ", " << est_vy << "])\n";
+}
+
+void test_ukf_validation() {
+	bool caught = false;
+	try { UnscentedKalmanFilter<double> ukf(0, 1); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: ukf should reject state_dim=0");
+
+	caught = false;
+	try {
+		UnscentedKalmanFilter<double> ukf(2, 1);
+		ukf.predict();
+	} catch (const std::logic_error&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: ukf predict without function should throw");
+
+	std::cout << "  ukf_validation: passed\n";
+}
+
 // ========== LMS Tests ==========
 
 void test_lms_converges_to_known_filter() {
@@ -430,6 +561,10 @@ int main() {
 		test_ekf_linear_equivalence();
 		test_ekf_bearing_range_tracking();
 		test_ekf_validation();
+		test_ukf_construction();
+		test_ukf_sigma_identity();
+		test_ukf_bearing_range_tracking();
+		test_ukf_validation();
 		test_lms_converges_to_known_filter();
 		test_lms_reset();
 		test_nlms();


### PR DESCRIPTION
## Summary
- `UnscentedKalmanFilter<T>` for Jacobian-free nonlinear state estimation via sigma-point sampling.
- Uses **LDL^T decomposition** (`mtl::ldlt_factor`) for sigma-point generation — avoids intermediate square roots, giving better numerical stability for ill-conditioned covariances vs. standard Cholesky. Matrix square root computed as L·sqrt(D) at the final step.
- Julier/Merwe scaling with recommended defaults: alpha=0.5, beta=2, kappa=3-n (per Wan & van der Merwe 2001).
- On the same bearing-range tracking scenario, UKF achieves slightly better accuracy than EKF (0.07m vs 0.10m position error) as expected for nonlinear observations.

## Changes
- `include/sw/dsp/estimation/ukf.hpp` — **NEW**: `UnscentedKalmanFilter<T>` with sigma-point generation, weighted mean/covariance reconstruction, predict/update via unscented transform
- `include/sw/dsp/estimation/estimation.hpp` — include ukf.hpp (removes last `// Future:` comment)
- `tests/test_kalman.cpp` — 4 new tests: construction, sigma-point identity recovery, 2D bearing-range tracking, validation
- `applications/estimation_demo/ukf_tracking.cpp` — **NEW**: 80-step 2D target tracking demo
- `applications/estimation_demo/CMakeLists.txt` — add ukf_tracking target

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_kalman (16 tests) | OK | 16/16 PASS | OK | 16/16 PASS |
| ukf_tracking demo | OK | runs, converges | OK | runs |
| full ctest | OK | 21/21 PASS | OK | 21/21 PASS |

### UKF vs EKF comparison (same bearing-range scenario)
```
EKF: pos=[99.99, 500.10], vel=[-0.02, 10.03]  (error ~0.10m)
UKF: pos=[100.00, 500.07], vel=[-0.02, 10.02]  (error ~0.07m)
```

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready: `gh pr ready <N>`

Resolves #39

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Unscented Kalman Filter to the estimation library.
  * Added a demo showcasing 2D bearing–range target tracking with the new filter.

* **Tests**
  * Added UKF unit tests covering construction, predict/update behavior, nonlinear tracking convergence, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->