### PR TITLE
fix(estimation): add missing const overload for KalmanFilter::B()

### DIFF
--- a/include/sw/dsp/estimation/kalman.hpp
+++ b/include/sw/dsp/estimation/kalman.hpp
@@ -77,6 +77,7 @@ public:
 	const matrix_t& H() const { return H_; }
 	const matrix_t& Q() const { return Q_; }
 	const matrix_t& R() const { return R_; }
+	const matrix_t& B() const { return B_; }
 	const matrix_t& P() const { return P_; }
 	const vector_t& state() const { return x_; }
 


### PR DESCRIPTION
## Summary
- Add `const matrix_t& B() const { return B_; }` to `KalmanFilter<T>`
- All other five matrix accessors (F, H, Q, R, P) and `state()` already have paired const overloads; `B()` was the only one missing

## Changes
- `include/sw/dsp/estimation/kalman.hpp` — one-line addition alongside the other const accessors

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_kalman | OK | PASS (17/17) | OK | PASS (17/17) |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #61

Generated with [Claude Code](https://claude.com/claude-code)