### PR TITLE
feat(filter): zero-phase forward-backward filtering (filtfilt)

### DIFF
--- a/include/sw/dsp/dsp.hpp
+++ b/include/sw/dsp/dsp.hpp
@@ -42,6 +42,7 @@
 
 // Filters (IIR + FIR)
 #include <sw/dsp/filter/filter.hpp>
+#include <sw/dsp/filter/filtfilt.hpp>
 #include <sw/dsp/filter/iir/iir.hpp>
 #include <sw/dsp/filter/fir/fir.hpp>
 

--- a/include/sw/dsp/filter/filtfilt.hpp
+++ b/include/sw/dsp/filter/filtfilt.hpp
@@ -1,0 +1,117 @@
+#pragma once
+// filtfilt.hpp: zero-phase forward-backward filtering
+//
+// Applies a biquad cascade forward then backward, cancelling phase
+// distortion. The magnitude response is squared relative to a
+// single pass. Signal edges are reflected to reduce transients.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cstddef>
+#include <algorithm>
+#include <vector>
+#include <sw/dsp/filter/biquad/cascade.hpp>
+#include <sw/dsp/filter/biquad/state.hpp>
+
+namespace sw::dsp {
+
+// filtfilt: zero-phase filtering via forward-backward cascade processing.
+//
+// Template parameters:
+//   StateForm   — biquad state realization (DirectFormI, DirectFormII, etc.)
+//   CoeffScalar — coefficient precision
+//   MaxStages   — maximum biquad stages in the cascade
+//   SampleScalar — sample I/O precision
+//
+// The algorithm:
+//   1. Reflect the signal at both ends to reduce edge transients
+//   2. Filter forward through the cascade
+//   3. Reverse the result and filter forward again (= backward pass)
+//   4. Reverse and extract the central N samples
+template <typename StateForm,
+          DspField CoeffScalar, int MaxStages,
+          DspScalar SampleScalar>
+std::vector<SampleScalar> filtfilt(
+    const Cascade<CoeffScalar, MaxStages>& cascade,
+    const std::vector<SampleScalar>& input) {
+
+	const std::size_t N = input.size();
+	if (N == 0) return {};
+
+	const int ns = cascade.num_stages();
+	if (ns == 0) return std::vector<SampleScalar>(input.begin(), input.end());
+
+	// Reflection length: 3 * (2 * num_stages + 1) - 1
+	// Clamped to N-1 if input is shorter than the reflection length
+	std::size_t nrefl = static_cast<std::size_t>(3 * (2 * ns + 1) - 1);
+	if (nrefl >= N) nrefl = N - 1;
+
+	if (nrefl == 0) {
+		// Signal too short to reflect — just do forward-backward without extension
+		std::vector<SampleScalar> out(input.begin(), input.end());
+
+		std::array<StateForm, MaxStages> state{};
+		for (std::size_t i = 0; i < N; ++i)
+			out[i] = cascade.process(out[i], state);
+
+		std::reverse(out.begin(), out.end());
+		for (auto& s : state) s.reset();
+		for (std::size_t i = 0; i < N; ++i)
+			out[i] = cascade.process(out[i], state);
+
+		std::reverse(out.begin(), out.end());
+		return out;
+	}
+
+	// Build extended signal: [reflected_front | original | reflected_back]
+	// Front reflection: 2*x[0] - x[nrefl], ..., 2*x[0] - x[1]
+	// Back reflection:  2*x[N-1] - x[N-2], ..., 2*x[N-1] - x[N-1-nrefl]
+	const std::size_t ext_len = nrefl + N + nrefl;
+	std::vector<SampleScalar> ext(ext_len);
+
+	SampleScalar x0 = input[0];
+	SampleScalar xN = input[N - 1];
+	SampleScalar two{2};
+
+	for (std::size_t i = 0; i < nrefl; ++i)
+		ext[i] = two * x0 - input[nrefl - i];
+
+	for (std::size_t i = 0; i < N; ++i)
+		ext[nrefl + i] = input[i];
+
+	for (std::size_t i = 0; i < nrefl; ++i)
+		ext[nrefl + N + i] = two * xN - input[N - 2 - i];
+
+	// Forward pass
+	std::array<StateForm, MaxStages> state{};
+	for (std::size_t i = 0; i < ext_len; ++i)
+		ext[i] = cascade.process(ext[i], state);
+
+	// Reverse
+	std::reverse(ext.begin(), ext.end());
+
+	// Backward pass (forward on reversed signal)
+	for (auto& s : state) s.reset();
+	for (std::size_t i = 0; i < ext_len; ++i)
+		ext[i] = cascade.process(ext[i], state);
+
+	// Reverse back and extract central N samples
+	std::reverse(ext.begin(), ext.end());
+
+	return std::vector<SampleScalar>(ext.begin() + static_cast<std::ptrdiff_t>(nrefl),
+	                                 ext.begin() + static_cast<std::ptrdiff_t>(nrefl + N));
+}
+
+// Convenience overload defaulting to DirectFormII
+template <DspField CoeffScalar, int MaxStages,
+          DspScalar SampleScalar>
+std::vector<SampleScalar> filtfilt(
+    const Cascade<CoeffScalar, MaxStages>& cascade,
+    const std::vector<SampleScalar>& input) {
+	return filtfilt<DirectFormII<CoeffScalar>, CoeffScalar, MaxStages, SampleScalar>(
+	    cascade, input);
+}
+
+} // namespace sw::dsp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,5 +67,8 @@ dsp_add_test(test_image_generators)
 # Image file I/O (Issue #13)
 dsp_add_test(test_image_io)
 
+# Zero-phase filtering (Issue #66)
+dsp_add_test(test_filtfilt)
+
 # Type projection/embedding
 dsp_add_test(test_projection)

--- a/tests/test_filtfilt.cpp
+++ b/tests/test_filtfilt.cpp
@@ -1,0 +1,259 @@
+// test_filtfilt.cpp: zero-phase forward-backward filtering tests
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/filter/iir/butterworth.hpp>
+#include <sw/dsp/filter/filtfilt.hpp>
+#include <sw/dsp/math/constants.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace sw::dsp;
+
+constexpr double tolerance = 1e-6;
+
+bool near(double a, double b, double eps = tolerance) {
+	return std::abs(a - b) < eps;
+}
+
+void check(bool condition, const std::string& msg) {
+	if (!condition) throw std::runtime_error("test failed: " + msg);
+}
+
+// Test 1: filtfilt output should have zero phase shift.
+// A symmetric signal filtered with filtfilt should remain symmetric.
+void test_zero_phase() {
+	iir::ButterworthLowPass<4> filter;
+	filter.setup(4, 1000.0, 100.0);
+	const auto& cascade = filter.cascade();
+
+	// Symmetric signal: triangle pulse centered at N/2
+	constexpr int N = 200;
+	std::vector<double> input(N, 0.0);
+	int center = N / 2;
+	int half_width = 20;
+	for (int i = -half_width; i <= half_width; ++i) {
+		input[center + i] = 1.0 - std::abs(static_cast<double>(i)) / half_width;
+	}
+
+	auto output = filtfilt(cascade, input);
+	check(output.size() == static_cast<std::size_t>(N), "output size matches input");
+
+	// Output should be symmetric around center
+	for (int i = 1; i < N / 2; ++i) {
+		double left  = output[static_cast<std::size_t>(center - i)];
+		double right = output[static_cast<std::size_t>(center + i)];
+		check(near(left, right, 1e-10),
+		      "symmetry at offset " + std::to_string(i) +
+		      " left=" + std::to_string(left) + " right=" + std::to_string(right));
+	}
+
+	std::cout << "  zero_phase: passed\n";
+}
+
+// Test 2: filtfilt magnitude should be the square of single-pass magnitude.
+// At the cutoff frequency, single-pass is -3 dB, filtfilt should be -6 dB.
+void test_squared_magnitude() {
+	iir::ButterworthLowPass<4> filter;
+	filter.setup(4, 44100.0, 1000.0);
+	const auto& cascade = filter.cascade();
+
+	// Single-pass magnitude at cutoff
+	double fc = 1000.0 / 44100.0;
+	auto r_single = cascade.response(fc);
+	double mag_single = std::abs(r_single);
+	double db_single = 20.0 * std::log10(mag_single);
+
+	// filtfilt effective magnitude is |H(f)|^2, so dB doubles
+	double db_filtfilt_expected = 2.0 * db_single;
+
+	// Generate a sinusoid at the cutoff frequency
+	constexpr int N = 8820;  // ~200ms at 44100 Hz
+	std::vector<double> input(N);
+	for (int n = 0; n < N; ++n) {
+		input[n] = std::sin(2.0 * pi * fc * n);
+	}
+
+	auto output = filtfilt(cascade, input);
+
+	// Measure output amplitude in the steady-state region (middle)
+	double max_out = 0.0;
+	for (int n = N / 3; n < 2 * N / 3; ++n) {
+		max_out = std::max(max_out, std::abs(output[n]));
+	}
+	double db_measured = 20.0 * std::log10(max_out);
+
+	check(near(db_measured, db_filtfilt_expected, 1.0),
+	      "squared magnitude: expected " + std::to_string(db_filtfilt_expected) +
+	      " dB, got " + std::to_string(db_measured) + " dB");
+
+	std::cout << "  squared_magnitude: passed (single=" << db_single
+	          << " dB, filtfilt=" << db_measured << " dB)\n";
+}
+
+// Test 3: all three state forms should produce the same result
+void test_state_forms_agree() {
+	iir::ButterworthLowPass<4> filter;
+	filter.setup(4, 1000.0, 100.0);
+	const auto& cascade = filter.cascade();
+
+	constexpr int N = 200;
+	std::vector<double> input(N);
+	for (int n = 0; n < N; ++n) {
+		input[n] = std::sin(2.0 * pi * 50.0 / 1000.0 * n)
+		         + 0.5 * std::sin(2.0 * pi * 300.0 / 1000.0 * n);
+	}
+
+	using DFI  = DirectFormI<double>;
+	using DFII = DirectFormII<double>;
+	using TDFII = TransposedDirectFormII<double>;
+	auto out_df1  = sw::dsp::filtfilt<DFI>(cascade, input);
+	auto out_df2  = sw::dsp::filtfilt<DFII>(cascade, input);
+	auto out_tdf2 = sw::dsp::filtfilt<TDFII>(cascade, input);
+
+	for (int n = 0; n < N; ++n) {
+		check(near(out_df1[n], out_df2[n], 1e-10),
+		      "DFI vs DFII at sample " + std::to_string(n));
+		check(near(out_df2[n], out_tdf2[n], 1e-10),
+		      "DFII vs TDFII at sample " + std::to_string(n));
+	}
+
+	std::cout << "  state_forms_agree: passed\n";
+}
+
+// Test 4: filtfilt of a DC signal should return the same DC level
+void test_dc_passthrough() {
+	iir::ButterworthLowPass<4> filter;
+	filter.setup(4, 1000.0, 100.0);
+	const auto& cascade = filter.cascade();
+
+	constexpr int N = 500;
+	double dc_level = 0.42;
+	std::vector<double> input(N, dc_level);
+
+	auto output = filtfilt(cascade, input);
+
+	// Interior samples should be near-perfect; edges have small transient artifacts
+	for (int n = N / 10; n < 9 * N / 10; ++n) {
+		check(near(output[n], dc_level, 1e-6),
+		      "DC passthrough at sample " + std::to_string(n) +
+		      " got " + std::to_string(output[n]));
+	}
+	// Edge samples should still be within 2%
+	for (int n = 0; n < N; ++n) {
+		check(near(output[n], dc_level, 0.02),
+		      "DC edge tolerance at sample " + std::to_string(n) +
+		      " got " + std::to_string(output[n]));
+	}
+
+	std::cout << "  dc_passthrough: passed\n";
+}
+
+// Test 5: filtfilt should reject frequencies above the cutoff
+void test_stopband_rejection() {
+	iir::ButterworthLowPass<4> filter;
+	filter.setup(4, 1000.0, 50.0);  // 50 Hz cutoff at 1000 Hz sample rate
+	const auto& cascade = filter.cascade();
+
+	// Pure high-frequency signal at 400 Hz (well into stopband)
+	constexpr int N = 1000;
+	std::vector<double> input(N);
+	for (int n = 0; n < N; ++n) {
+		input[n] = std::sin(2.0 * pi * 400.0 / 1000.0 * n);
+	}
+
+	auto output = filtfilt(cascade, input);
+
+	// Output energy should be tiny relative to input
+	double input_energy = 0.0, output_energy = 0.0;
+	for (int n = N / 4; n < 3 * N / 4; ++n) {
+		input_energy  += input[n] * input[n];
+		output_energy += output[n] * output[n];
+	}
+
+	double attenuation_db = 10.0 * std::log10(output_energy / input_energy);
+	check(attenuation_db < -80.0,
+	      "stopband rejection: " + std::to_string(attenuation_db) + " dB (expected < -80 dB)");
+
+	std::cout << "  stopband_rejection: passed (" << attenuation_db << " dB)\n";
+}
+
+// Test 6: empty and short input edge cases
+void test_edge_cases() {
+	iir::ButterworthLowPass<4> filter;
+	filter.setup(4, 1000.0, 100.0);
+	const auto& cascade = filter.cascade();
+
+	// Empty input
+	std::vector<double> empty;
+	auto out_empty = filtfilt(cascade, empty);
+	check(out_empty.empty(), "empty input returns empty output");
+
+	// Single sample
+	std::vector<double> single = {1.0};
+	auto out_single = filtfilt(cascade, single);
+	check(out_single.size() == 1, "single sample returns single sample");
+	check(std::isfinite(out_single[0]), "single sample output is finite");
+
+	// Two samples
+	std::vector<double> two = {1.0, 0.5};
+	auto out_two = filtfilt(cascade, two);
+	check(out_two.size() == 2, "two samples returns two samples");
+	check(std::isfinite(out_two[0]) && std::isfinite(out_two[1]),
+	      "two sample outputs are finite");
+
+	std::cout << "  edge_cases: passed\n";
+}
+
+// Test 7: convenience overload (no explicit StateForm) works
+void test_default_state_form() {
+	iir::ButterworthLowPass<2> filter;
+	filter.setup(2, 1000.0, 100.0);
+	const auto& cascade = filter.cascade();
+
+	constexpr int N = 100;
+	std::vector<double> input(N);
+	for (int n = 0; n < N; ++n) {
+		input[n] = std::sin(2.0 * pi * 50.0 / 1000.0 * n);
+	}
+
+	// This calls the convenience overload (no StateForm template argument)
+	auto output = filtfilt(cascade, input);
+	check(output.size() == static_cast<std::size_t>(N), "default overload returns correct size");
+
+	// Compare with explicit DFII
+	using DFII = DirectFormII<double>;
+	auto output_explicit = sw::dsp::filtfilt<DFII>(cascade, input);
+	for (int n = 0; n < N; ++n) {
+		check(near(output[n], output_explicit[n], 1e-15),
+		      "default matches explicit DFII at sample " + std::to_string(n));
+	}
+
+	std::cout << "  default_state_form: passed\n";
+}
+
+int main() {
+	try {
+		std::cout << "filtfilt (zero-phase filtering) tests\n";
+
+		test_zero_phase();
+		test_squared_magnitude();
+		test_state_forms_agree();
+		test_dc_passthrough();
+		test_stopband_rejection();
+		test_edge_cases();
+		test_default_state_form();
+
+		std::cout << "All filtfilt tests passed.\n";
+		return 0;
+	}
+	catch (const std::exception& e) {
+		std::cerr << "FAILED: " << e.what() << "\n";
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary
- Implements `filtfilt` — zero-phase forward-backward filtering via biquad cascade
- Signal edges are reflected to reduce transients (reflection length = `3 * (2 * num_stages + 1) - 1`)
- Supports all three state forms (DirectFormI, DirectFormII, TransposedDirectFormII)
- Convenience overload defaults to DirectFormII when no state form is specified

## Changes
- `include/sw/dsp/filter/filtfilt.hpp` — new `filtfilt()` function template
- `include/sw/dsp/dsp.hpp` — added filtfilt to umbrella header
- `tests/test_filtfilt.cpp` — 7 tests: zero phase, squared magnitude, state form agreement, DC passthrough, stopband rejection, edge cases, default overload
- `tests/CMakeLists.txt` — registered test_filtfilt

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_filtfilt | OK | PASS (7/7) | OK | PASS (7/7) |
| full suite | OK | PASS (22/22) | — | — |

## Test plan
- [x] Zero phase shift verified (symmetric signal remains symmetric)
- [x] Magnitude response is squared vs single-pass (-3 dB → -6 dB at cutoff)
- [x] All three state forms produce identical results
- [x] DC signal passes through with < 1e-6 interior error
- [x] Stopband rejection reaches -206 dB (squared 4th-order Butterworth)
- [x] Edge cases: empty, single-sample, two-sample inputs
- [x] Fast CI passes (gcc + clang)
- [x] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #66

Generated with [Claude Code](https://claude.com/claude-code)