### PR TITLE
feat(spectral): Bluestein chirp-z arbitrary-length DFT

### DIFF
--- a/include/sw/dsp/spectral/bluestein.hpp
+++ b/include/sw/dsp/spectral/bluestein.hpp
@@ -10,6 +10,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <limits>
 #include <stdexcept>
 #include <mtl/vec/dense_vector.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
@@ -21,6 +22,11 @@ namespace sw::dsp::spectral {
 namespace detail {
 
 inline std::size_t next_power_of_2(std::size_t n) {
+	if (n <= 1) return 1;
+	constexpr std::size_t max_pow2 =
+		std::size_t{1} << (std::numeric_limits<std::size_t>::digits - 1);
+	if (n > max_pow2)
+		throw std::length_error("bluestein: convolution length too large");
 	std::size_t m = 1;
 	while (m < n) m <<= 1;
 	return m;
@@ -35,34 +41,36 @@ template <DspField T>
 mtl::vec::dense_vector<complex_for_t<T>> bluestein_forward(
 		const mtl::vec::dense_vector<complex_for_t<T>>& x) {
 	using complex_t = complex_for_t<T>;
+	using std::conj;
+	using std::cos;
+	using std::sin;
 	const std::size_t N = x.size();
 	if (N == 0) return {};
 	if (N == 1) return mtl::vec::dense_vector<complex_t>({x[0]});
 
+	if (N > (std::numeric_limits<std::size_t>::max() - 1) / 2)
+		throw std::length_error("bluestein: input length too large");
 	const std::size_t M = detail::next_power_of_2(2 * N - 1);
 
 	// Chirp sequence: w[n] = exp(-j * pi * n^2 / N)
 	mtl::vec::dense_vector<complex_t> chirp(N);
 	for (std::size_t n = 0; n < N; ++n) {
-		double angle = -pi * static_cast<double>(n) * static_cast<double>(n)
-		               / static_cast<double>(N);
-		chirp[n] = complex_t(static_cast<T>(std::cos(angle)),
-		                     static_cast<T>(std::sin(angle)));
+		T angle = -pi_v<T> * static_cast<T>(n) * static_cast<T>(n)
+		          / static_cast<T>(N);
+		chirp[n] = complex_t(cos(angle), sin(angle));
 	}
 
 	// a[n] = x[n] * chirp[n], zero-padded to length M
 	mtl::vec::dense_vector<complex_t> a(M, complex_t{});
 	for (std::size_t n = 0; n < N; ++n) {
-		a[n] = complex_t(
-			x[n].real() * chirp[n].real() - x[n].imag() * chirp[n].imag(),
-			x[n].real() * chirp[n].imag() + x[n].imag() * chirp[n].real());
+		a[n] = x[n] * chirp[n];
 	}
 
 	// b[n] = conj(chirp[n]) with wrap-around for circular convolution
 	mtl::vec::dense_vector<complex_t> b(M, complex_t{});
-	b[0] = complex_t(chirp[0].real(), T{} - chirp[0].imag());
+	b[0] = conj(chirp[0]);
 	for (std::size_t n = 1; n < N; ++n) {
-		complex_t cj(chirp[n].real(), T{} - chirp[n].imag());
+		complex_t cj = conj(chirp[n]);
 		b[n] = cj;
 		b[M - n] = cj;
 	}
@@ -72,10 +80,7 @@ mtl::vec::dense_vector<complex_for_t<T>> bluestein_forward(
 	fft_forward<T>(b);
 
 	for (std::size_t i = 0; i < M; ++i) {
-		complex_t prod(
-			a[i].real() * b[i].real() - a[i].imag() * b[i].imag(),
-			a[i].real() * b[i].imag() + a[i].imag() * b[i].real());
-		a[i] = prod;
+		a[i] = a[i] * b[i];
 	}
 
 	fft_inverse<T>(a);
@@ -83,9 +88,7 @@ mtl::vec::dense_vector<complex_for_t<T>> bluestein_forward(
 	// X[k] = chirp[k] * C[k]
 	mtl::vec::dense_vector<complex_t> X(N);
 	for (std::size_t k = 0; k < N; ++k) {
-		X[k] = complex_t(
-			a[k].real() * chirp[k].real() - a[k].imag() * chirp[k].imag(),
-			a[k].real() * chirp[k].imag() + a[k].imag() * chirp[k].real());
+		X[k] = chirp[k] * a[k];
 	}
 	return X;
 }
@@ -96,22 +99,20 @@ template <DspField T>
 mtl::vec::dense_vector<complex_for_t<T>> bluestein_inverse(
 		const mtl::vec::dense_vector<complex_for_t<T>>& X) {
 	using complex_t = complex_for_t<T>;
+	using std::conj;
 	const std::size_t N = X.size();
 	if (N == 0) return {};
 
-	// Conjugate input
 	mtl::vec::dense_vector<complex_t> conj_X(N);
 	for (std::size_t i = 0; i < N; ++i) {
-		conj_X[i] = complex_t(X[i].real(), T{} - X[i].imag());
+		conj_X[i] = conj(X[i]);
 	}
 
 	auto result = bluestein_forward<T>(conj_X);
 
-	// Conjugate and scale by 1/N
 	T inv_N = T{1} / static_cast<T>(N);
 	for (std::size_t i = 0; i < N; ++i) {
-		result[i] = complex_t(result[i].real() * inv_N,
-		                      (T{} - result[i].imag()) * inv_N);
+		result[i] = conj(result[i]) * inv_N;
 	}
 	return result;
 }

--- a/include/sw/dsp/spectral/bluestein.hpp
+++ b/include/sw/dsp/spectral/bluestein.hpp
@@ -1,0 +1,145 @@
+#pragma once
+// bluestein.hpp: Bluestein's chirp-z algorithm for arbitrary-length DFT
+//
+// Converts an N-point DFT into circular convolution of length M
+// (next power-of-2 >= 2N-1), computed via three radix-2 FFTs.
+// Total complexity: O(N log N) for any N, not just powers of 2.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/math/constants.hpp>
+#include <sw/dsp/spectral/fft.hpp>
+
+namespace sw::dsp::spectral {
+
+namespace detail {
+
+inline std::size_t next_power_of_2(std::size_t n) {
+	std::size_t m = 1;
+	while (m < n) m <<= 1;
+	return m;
+}
+
+} // namespace detail
+
+// Bluestein forward DFT for arbitrary length N.
+// Input: complex vector of length N.
+// Output: complex vector of length N (the DFT).
+template <DspField T>
+mtl::vec::dense_vector<complex_for_t<T>> bluestein_forward(
+		const mtl::vec::dense_vector<complex_for_t<T>>& x) {
+	using complex_t = complex_for_t<T>;
+	const std::size_t N = x.size();
+	if (N == 0) return {};
+	if (N == 1) return mtl::vec::dense_vector<complex_t>({x[0]});
+
+	const std::size_t M = detail::next_power_of_2(2 * N - 1);
+
+	// Chirp sequence: w[n] = exp(-j * pi * n^2 / N)
+	mtl::vec::dense_vector<complex_t> chirp(N);
+	for (std::size_t n = 0; n < N; ++n) {
+		double angle = -pi * static_cast<double>(n) * static_cast<double>(n)
+		               / static_cast<double>(N);
+		chirp[n] = complex_t(static_cast<T>(std::cos(angle)),
+		                     static_cast<T>(std::sin(angle)));
+	}
+
+	// a[n] = x[n] * chirp[n], zero-padded to length M
+	mtl::vec::dense_vector<complex_t> a(M, complex_t{});
+	for (std::size_t n = 0; n < N; ++n) {
+		a[n] = complex_t(
+			x[n].real() * chirp[n].real() - x[n].imag() * chirp[n].imag(),
+			x[n].real() * chirp[n].imag() + x[n].imag() * chirp[n].real());
+	}
+
+	// b[n] = conj(chirp[n]) with wrap-around for circular convolution
+	mtl::vec::dense_vector<complex_t> b(M, complex_t{});
+	b[0] = complex_t(chirp[0].real(), T{} - chirp[0].imag());
+	for (std::size_t n = 1; n < N; ++n) {
+		complex_t cj(chirp[n].real(), T{} - chirp[n].imag());
+		b[n] = cj;
+		b[M - n] = cj;
+	}
+
+	// Circular convolution via FFT: C = IFFT(FFT(a) .* FFT(b))
+	fft_forward<T>(a);
+	fft_forward<T>(b);
+
+	for (std::size_t i = 0; i < M; ++i) {
+		complex_t prod(
+			a[i].real() * b[i].real() - a[i].imag() * b[i].imag(),
+			a[i].real() * b[i].imag() + a[i].imag() * b[i].real());
+		a[i] = prod;
+	}
+
+	fft_inverse<T>(a);
+
+	// X[k] = chirp[k] * C[k]
+	mtl::vec::dense_vector<complex_t> X(N);
+	for (std::size_t k = 0; k < N; ++k) {
+		X[k] = complex_t(
+			a[k].real() * chirp[k].real() - a[k].imag() * chirp[k].imag(),
+			a[k].real() * chirp[k].imag() + a[k].imag() * chirp[k].real());
+	}
+	return X;
+}
+
+// Bluestein inverse DFT for arbitrary length N.
+// Conjugate-transform-conjugate-scale approach.
+template <DspField T>
+mtl::vec::dense_vector<complex_for_t<T>> bluestein_inverse(
+		const mtl::vec::dense_vector<complex_for_t<T>>& X) {
+	using complex_t = complex_for_t<T>;
+	const std::size_t N = X.size();
+	if (N == 0) return {};
+
+	// Conjugate input
+	mtl::vec::dense_vector<complex_t> conj_X(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		conj_X[i] = complex_t(X[i].real(), T{} - X[i].imag());
+	}
+
+	auto result = bluestein_forward<T>(conj_X);
+
+	// Conjugate and scale by 1/N
+	T inv_N = T{1} / static_cast<T>(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		result[i] = complex_t(result[i].real() * inv_N,
+		                      (T{} - result[i].imag()) * inv_N);
+	}
+	return result;
+}
+
+// Auto-dispatching forward DFT: uses radix-2 FFT for power-of-2,
+// Bluestein for arbitrary lengths.
+template <DspField T>
+mtl::vec::dense_vector<complex_for_t<T>> dft_forward(
+		const mtl::vec::dense_vector<complex_for_t<T>>& x) {
+	if (detail::is_power_of_2(x.size())) {
+		auto data = x;
+		fft_forward<T>(data);
+		return data;
+	}
+	return bluestein_forward<T>(x);
+}
+
+// Auto-dispatching inverse DFT: uses radix-2 FFT for power-of-2,
+// Bluestein for arbitrary lengths.
+template <DspField T>
+mtl::vec::dense_vector<complex_for_t<T>> dft_inverse(
+		const mtl::vec::dense_vector<complex_for_t<T>>& x) {
+	if (detail::is_power_of_2(x.size())) {
+		auto data = x;
+		fft_inverse<T>(data);
+		return data;
+	}
+	return bluestein_inverse<T>(x);
+}
+
+} // namespace sw::dsp::spectral

--- a/include/sw/dsp/spectral/bluestein.hpp
+++ b/include/sw/dsp/spectral/bluestein.hpp
@@ -9,6 +9,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <cmath>
+#include <concepts>
 #include <cstddef>
 #include <limits>
 #include <stdexcept>
@@ -38,6 +39,7 @@ inline std::size_t next_power_of_2(std::size_t n) {
 // Input: complex vector of length N.
 // Output: complex vector of length N (the DFT).
 template <DspField T>
+requires (!std::integral<T>)
 mtl::vec::dense_vector<complex_for_t<T>> bluestein_forward(
 		const mtl::vec::dense_vector<complex_for_t<T>>& x) {
 	using complex_t = complex_for_t<T>;
@@ -96,6 +98,7 @@ mtl::vec::dense_vector<complex_for_t<T>> bluestein_forward(
 // Bluestein inverse DFT for arbitrary length N.
 // Conjugate-transform-conjugate-scale approach.
 template <DspField T>
+requires (!std::integral<T>)
 mtl::vec::dense_vector<complex_for_t<T>> bluestein_inverse(
 		const mtl::vec::dense_vector<complex_for_t<T>>& X) {
 	using complex_t = complex_for_t<T>;
@@ -120,6 +123,7 @@ mtl::vec::dense_vector<complex_for_t<T>> bluestein_inverse(
 // Auto-dispatching forward DFT: uses radix-2 FFT for power-of-2,
 // Bluestein for arbitrary lengths.
 template <DspField T>
+requires (!std::integral<T>)
 mtl::vec::dense_vector<complex_for_t<T>> dft_forward(
 		const mtl::vec::dense_vector<complex_for_t<T>>& x) {
 	if (detail::is_power_of_2(x.size())) {
@@ -133,6 +137,7 @@ mtl::vec::dense_vector<complex_for_t<T>> dft_forward(
 // Auto-dispatching inverse DFT: uses radix-2 FFT for power-of-2,
 // Bluestein for arbitrary lengths.
 template <DspField T>
+requires (!std::integral<T>)
 mtl::vec::dense_vector<complex_for_t<T>> dft_inverse(
 		const mtl::vec::dense_vector<complex_for_t<T>>& x) {
 	if (detail::is_power_of_2(x.size())) {

--- a/include/sw/dsp/spectral/spectral.hpp
+++ b/include/sw/dsp/spectral/spectral.hpp
@@ -6,6 +6,7 @@
 
 #include <sw/dsp/spectral/dft.hpp>
 #include <sw/dsp/spectral/fft.hpp>
+#include <sw/dsp/spectral/bluestein.hpp>
 #include <sw/dsp/spectral/ztransform.hpp>
 #include <sw/dsp/spectral/laplace.hpp>
 #include <sw/dsp/spectral/psd.hpp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,5 +73,8 @@ dsp_add_test(test_filtfilt)
 # Parks-McClellan equiripple FIR design (Issue #67)
 dsp_add_test(test_remez)
 
+# Bluestein chirp-z arbitrary-length DFT (Issue #68)
+dsp_add_test(test_bluestein)
+
 # Type projection/embedding
 dsp_add_test(test_projection)

--- a/tests/test_bluestein.cpp
+++ b/tests/test_bluestein.cpp
@@ -232,6 +232,8 @@ void test_auto_dispatch() {
 		for (std::size_t i = 0; i < N; ++i) {
 			check(near(y[i].real(), x[i].real(), 1e-10),
 			      "dispatch_pow2 real[" + std::to_string(i) + "]");
+			check(near(y[i].imag(), x[i].imag(), 1e-10),
+			      "dispatch_pow2 imag[" + std::to_string(i) + "]");
 		}
 	}
 
@@ -248,6 +250,8 @@ void test_auto_dispatch() {
 		for (std::size_t i = 0; i < N; ++i) {
 			check(near(y[i].real(), x[i].real(), 1e-8),
 			      "dispatch_prime real[" + std::to_string(i) + "]");
+			check(near(y[i].imag(), x[i].imag(), 1e-8),
+			      "dispatch_prime imag[" + std::to_string(i) + "]");
 		}
 	}
 

--- a/tests/test_bluestein.cpp
+++ b/tests/test_bluestein.cpp
@@ -1,0 +1,339 @@
+// test_bluestein.cpp: Bluestein chirp-z arbitrary-length DFT tests
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/spectral/bluestein.hpp>
+#include <sw/dsp/spectral/dft.hpp>
+#include <sw/dsp/math/constants.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+using namespace sw::dsp;
+using namespace sw::dsp::spectral;
+
+constexpr double tolerance = 1e-8;
+
+bool near(double a, double b, double eps = tolerance) {
+	return std::abs(a - b) < eps;
+}
+
+void check(bool condition, const std::string& msg) {
+	if (!condition) throw std::runtime_error("test failed: " + msg);
+}
+
+// Test 1: Bluestein matches naive DFT for prime length 7
+void test_prime_7() {
+	constexpr std::size_t N = 7;
+	using complex_t = std::complex<double>;
+
+	mtl::vec::dense_vector<complex_t> x(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		double t = static_cast<double>(i) / static_cast<double>(N);
+		x[i] = complex_t(std::cos(two_pi * 2.0 * t), std::sin(two_pi * 3.0 * t));
+	}
+
+	auto X_blue = bluestein_forward<double>(x);
+
+	mtl::vec::dense_vector<double> xr(N);
+	for (std::size_t i = 0; i < N; ++i) xr[i] = x[i].real();
+	auto X_ref = dft(xr);
+
+	// Compare against complex DFT computed manually
+	for (std::size_t k = 0; k < N; ++k) {
+		complex_t ref{};
+		for (std::size_t n = 0; n < N; ++n) {
+			double angle = -two_pi * static_cast<double>(k) * static_cast<double>(n)
+			               / static_cast<double>(N);
+			complex_t tw(std::cos(angle), std::sin(angle));
+			ref += x[n] * tw;
+		}
+		check(near(X_blue[k].real(), ref.real(), 1e-6),
+		      "prime_7 real[" + std::to_string(k) + "]=" +
+		      std::to_string(X_blue[k].real()) + " vs " + std::to_string(ref.real()));
+		check(near(X_blue[k].imag(), ref.imag(), 1e-6),
+		      "prime_7 imag[" + std::to_string(k) + "]");
+	}
+
+	std::cout << "  prime_7: passed\n";
+}
+
+// Test 2: Bluestein matches naive DFT for prime length 13
+void test_prime_13() {
+	constexpr std::size_t N = 13;
+	using complex_t = std::complex<double>;
+
+	mtl::vec::dense_vector<double> xr(N);
+	for (std::size_t i = 0; i < N; ++i)
+		xr[i] = std::sin(two_pi * 3.0 * static_cast<double>(i) / static_cast<double>(N));
+
+	auto X_ref = dft(xr);
+
+	mtl::vec::dense_vector<complex_t> xc(N);
+	for (std::size_t i = 0; i < N; ++i) xc[i] = complex_t(xr[i], 0.0);
+	auto X_blue = bluestein_forward<double>(xc);
+
+	for (std::size_t k = 0; k < N; ++k) {
+		check(near(X_blue[k].real(), X_ref[k].real(), 1e-6),
+		      "prime_13 real[" + std::to_string(k) + "]");
+		check(near(X_blue[k].imag(), X_ref[k].imag(), 1e-6),
+		      "prime_13 imag[" + std::to_string(k) + "]");
+	}
+
+	std::cout << "  prime_13: passed\n";
+}
+
+// Test 3: Large prime 127
+void test_prime_127() {
+	constexpr std::size_t N = 127;
+	using complex_t = std::complex<double>;
+
+	mtl::vec::dense_vector<double> xr(N);
+	for (std::size_t i = 0; i < N; ++i)
+		xr[i] = std::cos(two_pi * 5.0 * static_cast<double>(i) / static_cast<double>(N));
+
+	auto X_ref = dft(xr);
+
+	mtl::vec::dense_vector<complex_t> xc(N);
+	for (std::size_t i = 0; i < N; ++i) xc[i] = complex_t(xr[i], 0.0);
+	auto X_blue = bluestein_forward<double>(xc);
+
+	for (std::size_t k = 0; k < N; ++k) {
+		check(near(X_blue[k].real(), X_ref[k].real(), 1e-5),
+		      "prime_127 real[" + std::to_string(k) + "]");
+		check(near(X_blue[k].imag(), X_ref[k].imag(), 1e-5),
+		      "prime_127 imag[" + std::to_string(k) + "]");
+	}
+
+	std::cout << "  prime_127: passed\n";
+}
+
+// Test 4: Large prime 251
+void test_prime_251() {
+	constexpr std::size_t N = 251;
+	using complex_t = std::complex<double>;
+
+	mtl::vec::dense_vector<double> xr(N);
+	for (std::size_t i = 0; i < N; ++i)
+		xr[i] = std::sin(two_pi * 7.0 * static_cast<double>(i) / static_cast<double>(N))
+		       + 0.5 * std::cos(two_pi * 23.0 * static_cast<double>(i) / static_cast<double>(N));
+
+	auto X_ref = dft(xr);
+
+	mtl::vec::dense_vector<complex_t> xc(N);
+	for (std::size_t i = 0; i < N; ++i) xc[i] = complex_t(xr[i], 0.0);
+	auto X_blue = bluestein_forward<double>(xc);
+
+	for (std::size_t k = 0; k < N; ++k) {
+		check(near(X_blue[k].real(), X_ref[k].real(), 1e-4),
+		      "prime_251 real[" + std::to_string(k) + "]");
+		check(near(X_blue[k].imag(), X_ref[k].imag(), 1e-4),
+		      "prime_251 imag[" + std::to_string(k) + "]");
+	}
+
+	std::cout << "  prime_251: passed\n";
+}
+
+// Test 5: Parseval's theorem — energy conservation
+void test_parseval() {
+	constexpr std::size_t N = 17;
+	using complex_t = std::complex<double>;
+
+	mtl::vec::dense_vector<complex_t> x(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		double t = static_cast<double>(i) / static_cast<double>(N);
+		x[i] = complex_t(std::sin(two_pi * 3.0 * t), 0.0);
+	}
+
+	auto X = bluestein_forward<double>(x);
+
+	double time_energy = 0.0, freq_energy = 0.0;
+	for (std::size_t i = 0; i < N; ++i) {
+		time_energy += x[i].real() * x[i].real() + x[i].imag() * x[i].imag();
+	}
+	for (std::size_t k = 0; k < N; ++k) {
+		freq_energy += X[k].real() * X[k].real() + X[k].imag() * X[k].imag();
+	}
+	freq_energy /= static_cast<double>(N);
+
+	check(near(time_energy, freq_energy, 1e-6),
+	      "Parseval: time=" + std::to_string(time_energy) +
+	      " freq=" + std::to_string(freq_energy));
+
+	std::cout << "  parseval: passed\n";
+}
+
+// Test 6: Forward-inverse roundtrip
+void test_roundtrip() {
+	constexpr std::size_t N = 23;
+	using complex_t = std::complex<double>;
+
+	mtl::vec::dense_vector<complex_t> x(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		double t = static_cast<double>(i) / static_cast<double>(N);
+		x[i] = complex_t(std::cos(two_pi * 5.0 * t), std::sin(two_pi * 2.0 * t));
+	}
+
+	auto X = bluestein_forward<double>(x);
+	auto y = bluestein_inverse<double>(X);
+
+	for (std::size_t i = 0; i < N; ++i) {
+		check(near(y[i].real(), x[i].real(), 1e-8),
+		      "roundtrip real[" + std::to_string(i) + "]");
+		check(near(y[i].imag(), x[i].imag(), 1e-8),
+		      "roundtrip imag[" + std::to_string(i) + "]");
+	}
+
+	std::cout << "  roundtrip: passed (N=23)\n";
+}
+
+// Test 7: Power-of-2 should match radix-2 FFT
+void test_power_of_2_match() {
+	constexpr std::size_t N = 16;
+	using complex_t = std::complex<double>;
+
+	mtl::vec::dense_vector<complex_t> x(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		x[i] = complex_t(static_cast<double>(i) * 0.1, 0.0);
+	}
+
+	auto X_blue = bluestein_forward<double>(x);
+
+	auto x_copy = x;
+	fft_forward<double>(x_copy);
+
+	for (std::size_t k = 0; k < N; ++k) {
+		check(near(X_blue[k].real(), x_copy[k].real(), 1e-8),
+		      "pow2_match real[" + std::to_string(k) + "]");
+		check(near(X_blue[k].imag(), x_copy[k].imag(), 1e-8),
+		      "pow2_match imag[" + std::to_string(k) + "]");
+	}
+
+	std::cout << "  power_of_2_match: passed\n";
+}
+
+// Test 8: Auto-dispatching dft_forward/dft_inverse
+void test_auto_dispatch() {
+	using complex_t = std::complex<double>;
+
+	// Power-of-2: should use radix-2 path
+	{
+		constexpr std::size_t N = 8;
+		mtl::vec::dense_vector<complex_t> x(N);
+		for (std::size_t i = 0; i < N; ++i)
+			x[i] = complex_t(static_cast<double>(i), 0.0);
+
+		auto X = dft_forward<double>(x);
+		auto y = dft_inverse<double>(X);
+
+		for (std::size_t i = 0; i < N; ++i) {
+			check(near(y[i].real(), x[i].real(), 1e-10),
+			      "dispatch_pow2 real[" + std::to_string(i) + "]");
+		}
+	}
+
+	// Non-power-of-2: should use Bluestein path
+	{
+		constexpr std::size_t N = 11;
+		mtl::vec::dense_vector<complex_t> x(N);
+		for (std::size_t i = 0; i < N; ++i)
+			x[i] = complex_t(std::sin(two_pi * static_cast<double>(i) / static_cast<double>(N)), 0.0);
+
+		auto X = dft_forward<double>(x);
+		auto y = dft_inverse<double>(X);
+
+		for (std::size_t i = 0; i < N; ++i) {
+			check(near(y[i].real(), x[i].real(), 1e-8),
+			      "dispatch_prime real[" + std::to_string(i) + "]");
+		}
+	}
+
+	std::cout << "  auto_dispatch: passed\n";
+}
+
+// Test 9: Edge cases — N=1, N=2, N=3
+void test_edge_cases() {
+	using complex_t = std::complex<double>;
+
+	// N=0
+	{
+		mtl::vec::dense_vector<complex_t> x;
+		auto X = bluestein_forward<double>(x);
+		check(X.size() == 0, "edge N=0 size");
+	}
+
+	// N=1
+	{
+		mtl::vec::dense_vector<complex_t> x({complex_t(3.14, 0.0)});
+		auto X = bluestein_forward<double>(x);
+		check(X.size() == 1, "edge N=1 size");
+		check(near(X[0].real(), 3.14, 1e-10), "edge N=1 value");
+	}
+
+	// N=2
+	{
+		mtl::vec::dense_vector<complex_t> x({complex_t(1.0, 0.0), complex_t(2.0, 0.0)});
+		auto X = bluestein_forward<double>(x);
+		check(X.size() == 2, "edge N=2 size");
+		check(near(X[0].real(), 3.0, 1e-8), "edge N=2 DC");
+		check(near(X[1].real(), -1.0, 1e-8), "edge N=2 Nyquist");
+	}
+
+	// N=3
+	{
+		mtl::vec::dense_vector<complex_t> x({complex_t(1.0, 0.0), complex_t(1.0, 0.0), complex_t(1.0, 0.0)});
+		auto X = bluestein_forward<double>(x);
+		check(X.size() == 3, "edge N=3 size");
+		check(near(X[0].real(), 3.0, 1e-8), "edge N=3 DC");
+		check(near(std::abs(X[1]), 0.0, 1e-8), "edge N=3 bin1");
+		check(near(std::abs(X[2]), 0.0, 1e-8), "edge N=3 bin2");
+	}
+
+	std::cout << "  edge_cases: passed\n";
+}
+
+// Test 10: Impulse response — DFT of [1, 0, ..., 0] = flat spectrum
+void test_impulse() {
+	constexpr std::size_t N = 19;
+	using complex_t = std::complex<double>;
+
+	mtl::vec::dense_vector<complex_t> x(N, complex_t{});
+	x[0] = complex_t(1.0, 0.0);
+
+	auto X = bluestein_forward<double>(x);
+
+	for (std::size_t k = 0; k < N; ++k) {
+		check(near(X[k].real(), 1.0, 1e-8),
+		      "impulse real[" + std::to_string(k) + "]=" + std::to_string(X[k].real()));
+		check(near(X[k].imag(), 0.0, 1e-8),
+		      "impulse imag[" + std::to_string(k) + "]");
+	}
+
+	std::cout << "  impulse: passed (N=19)\n";
+}
+
+int main() {
+	try {
+		std::cout << "Bluestein chirp-z arbitrary-length DFT tests\n";
+
+		test_prime_7();
+		test_prime_13();
+		test_prime_127();
+		test_prime_251();
+		test_parseval();
+		test_roundtrip();
+		test_power_of_2_match();
+		test_auto_dispatch();
+		test_edge_cases();
+		test_impulse();
+
+		std::cout << "All Bluestein tests passed.\n";
+		return 0;
+	} catch (const std::exception& e) {
+		std::cerr << "FAILED: " << e.what() << '\n';
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary
- Implements Bluestein's chirp-z algorithm for O(N log N) DFT at arbitrary lengths (not just power-of-2)
- Adds auto-dispatching `dft_forward<T>()` / `dft_inverse<T>()` wrappers that select radix-2 FFT or Bluestein based on input length
- 10 tests verifying against naive DFT for prime lengths (7, 13, 127, 251), Parseval's theorem, forward-inverse roundtrip, power-of-2 match, and edge cases

## Changes
- `include/sw/dsp/spectral/bluestein.hpp` — Bluestein forward/inverse and auto-dispatching wrappers
- `include/sw/dsp/spectral/spectral.hpp` — added bluestein to umbrella
- `tests/test_bluestein.cpp` — 10 test cases
- `tests/CMakeLists.txt` — added test_bluestein target

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_bluestein | OK | PASS (10/10) | OK | PASS (10/10) |
| test_fft | OK | PASS (no regressions) | — | — |

## Test plan
- [x] Local gcc build and test
- [x] Local clang build and test
- [x] Existing FFT tests pass (no regressions)
- [x] Fast CI passes
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added arbitrary-length DFT support using Bluestein’s chirp‑Z method for non‑power‑of‑two inputs.
  * Added auto‑dispatching DFT routines that select the optimal algorithm based on input size.
  * Public spectral headers updated to expose the new DFT routines.

* **Tests**
  * Added a comprehensive test suite covering many lengths (including primes), edge cases, energy conservation, roundtrip behavior, and FFT consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->