### PR TITLE
feat(quantization): higher-order noise shaping (2nd/3rd order)

### DIFF
--- a/include/sw/dsp/quantization/noise_shaping.hpp
+++ b/include/sw/dsp/quantization/noise_shaping.hpp
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <mtl/vec/dense_vector.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/math/denormal.hpp>
 
 namespace sw::dsp {
 
@@ -29,7 +30,7 @@ public:
 		LowPrecT quantized = static_cast<LowPrecT>(shaped);
 		HighPrecT reconstructed = static_cast<HighPrecT>(quantized);
 		HighPrecT error = shaped - reconstructed;
-		error_feedback_ = error;
+		error_feedback_ = error + denormal_.ac();
 		return quantized;
 	}
 
@@ -45,6 +46,7 @@ public:
 
 private:
 	HighPrecT error_feedback_{};
+	DenormalPrevention<HighPrecT> denormal_;
 };
 
 // Second-order error-feedback noise shaper.
@@ -60,7 +62,7 @@ public:
 		HighPrecT reconstructed = static_cast<HighPrecT>(quantized);
 		HighPrecT error = shaped - reconstructed;
 		e2_ = e1_;
-		e1_ = error;
+		e1_ = error + denormal_.ac();
 		return quantized;
 	}
 
@@ -77,6 +79,7 @@ public:
 private:
 	HighPrecT e1_{};
 	HighPrecT e2_{};
+	DenormalPrevention<HighPrecT> denormal_;
 };
 
 // Third-order error-feedback noise shaper.
@@ -94,7 +97,7 @@ public:
 		HighPrecT error = shaped - reconstructed;
 		e3_ = e2_;
 		e2_ = e1_;
-		e1_ = error;
+		e1_ = error + denormal_.ac();
 		return quantized;
 	}
 
@@ -112,6 +115,7 @@ private:
 	HighPrecT e1_{};
 	HighPrecT e2_{};
 	HighPrecT e3_{};
+	DenormalPrevention<HighPrecT> denormal_;
 };
 
 } // namespace sw::dsp

--- a/include/sw/dsp/quantization/noise_shaping.hpp
+++ b/include/sw/dsp/quantization/noise_shaping.hpp
@@ -3,7 +3,12 @@
 //
 // Feeds the quantization error back through a filter to reshape
 // the noise spectrum, pushing noise energy out of the band of
-// interest. First-order noise shaping is the simplest form.
+// interest.
+//
+// NTF designs:
+//   1st order: (1 - z⁻¹)        → -e[n-1]
+//   2nd order: (1 - z⁻¹)²       → -2e[n-1] + e[n-2]
+//   3rd order: (1 - z⁻¹)³       → -3e[n-1] + 3e[n-2] - e[n-3]
 //
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -15,15 +20,7 @@
 namespace sw::dsp {
 
 // First-order error-feedback noise shaper.
-//
-// For each sample:
-//   shaped = input + error_feedback
-//   quantized = quantize(shaped)    // conversion to OutputT
-//   error = shaped - quantized      // quantization error
-//   error_feedback = -error         // feed back for next sample
-//
-// This pushes noise energy to higher frequencies (first-order
-// high-pass shaping of the noise floor).
+// NTF = (1 - z⁻¹)
 template <DspField HighPrecT, DspField LowPrecT>
 class FirstOrderNoiseShaper {
 public:
@@ -32,7 +29,7 @@ public:
 		LowPrecT quantized = static_cast<LowPrecT>(shaped);
 		HighPrecT reconstructed = static_cast<HighPrecT>(quantized);
 		HighPrecT error = shaped - reconstructed;
-		error_feedback_ = HighPrecT{} - error;  // negative feedback
+		error_feedback_ = error;
 		return quantized;
 	}
 
@@ -48,6 +45,73 @@ public:
 
 private:
 	HighPrecT error_feedback_{};
+};
+
+// Second-order error-feedback noise shaper.
+// NTF = (1 - z⁻¹)²
+// Feedback: -2·e[n-1] + e[n-2]
+template <DspField HighPrecT, DspField LowPrecT>
+class SecondOrderNoiseShaper {
+public:
+	LowPrecT process(HighPrecT input) {
+		HighPrecT feedback = HighPrecT(2) * e1_ - e2_;
+		HighPrecT shaped = input + feedback;
+		LowPrecT quantized = static_cast<LowPrecT>(shaped);
+		HighPrecT reconstructed = static_cast<HighPrecT>(quantized);
+		HighPrecT error = shaped - reconstructed;
+		e2_ = e1_;
+		e1_ = error;
+		return quantized;
+	}
+
+	mtl::vec::dense_vector<LowPrecT> process(const mtl::vec::dense_vector<HighPrecT>& input) {
+		mtl::vec::dense_vector<LowPrecT> output(input.size());
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			output[i] = process(input[i]);
+		}
+		return output;
+	}
+
+	void reset() { e1_ = HighPrecT{}; e2_ = HighPrecT{}; }
+
+private:
+	HighPrecT e1_{};
+	HighPrecT e2_{};
+};
+
+// Third-order error-feedback noise shaper.
+// NTF = (1 - z⁻¹)³
+// Feedback: -3·e[n-1] + 3·e[n-2] - e[n-3]
+template <DspField HighPrecT, DspField LowPrecT>
+class ThirdOrderNoiseShaper {
+public:
+	LowPrecT process(HighPrecT input) {
+		HighPrecT feedback = HighPrecT(3) * e1_
+		                   - HighPrecT(3) * e2_ + e3_;
+		HighPrecT shaped = input + feedback;
+		LowPrecT quantized = static_cast<LowPrecT>(shaped);
+		HighPrecT reconstructed = static_cast<HighPrecT>(quantized);
+		HighPrecT error = shaped - reconstructed;
+		e3_ = e2_;
+		e2_ = e1_;
+		e1_ = error;
+		return quantized;
+	}
+
+	mtl::vec::dense_vector<LowPrecT> process(const mtl::vec::dense_vector<HighPrecT>& input) {
+		mtl::vec::dense_vector<LowPrecT> output(input.size());
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			output[i] = process(input[i]);
+		}
+		return output;
+	}
+
+	void reset() { e1_ = HighPrecT{}; e2_ = HighPrecT{}; e3_ = HighPrecT{}; }
+
+private:
+	HighPrecT e1_{};
+	HighPrecT e2_{};
+	HighPrecT e3_{};
 };
 
 } // namespace sw::dsp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,5 +76,8 @@ dsp_add_test(test_remez)
 # Bluestein chirp-z arbitrary-length DFT (Issue #68)
 dsp_add_test(test_bluestein)
 
+# Higher-order noise shaping (Issue #70)
+dsp_add_test(test_noise_shaping)
+
 # Type projection/embedding
 dsp_add_test(test_projection)

--- a/tests/test_noise_shaping.cpp
+++ b/tests/test_noise_shaping.cpp
@@ -1,0 +1,321 @@
+// test_noise_shaping.cpp: tests for higher-order noise shaping
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/quantization/quantization.hpp>
+#include <sw/dsp/signals/generators.hpp>
+#include <sw/dsp/spectral/fft.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+#include <universal/number/posit/posit.hpp>
+#include <universal/number/fixpnt/fixpnt.hpp>
+
+using namespace sw::dsp;
+
+// Measure noise spectral tilt in dB/octave from magnitude spectrum.
+// Fits a line to log2(frequency) vs noise magnitude in dB.
+// Returns the slope (dB/octave). Positive = rising with frequency.
+double noise_spectral_tilt(const mtl::vec::dense_vector<double>& reference,
+                           const mtl::vec::dense_vector<double>& quantized,
+                           double sample_rate) {
+	std::size_t N = reference.size();
+	mtl::vec::dense_vector<double> noise(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		noise[i] = static_cast<double>(reference[i]) - static_cast<double>(quantized[i]);
+	}
+
+	// Convert to complex and compute FFT
+	mtl::vec::dense_vector<std::complex<double>> noise_c(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		noise_c[i] = std::complex<double>(noise[i], 0.0);
+	}
+	spectral::fft_forward<double>(noise_c);
+	auto noise_spectrum = spectral::magnitude_spectrum_db<double>(noise_c);
+	std::size_t num_bins = noise_spectrum.size();
+
+	// Linear regression on log2(f) vs dB, skipping DC and very low bins
+	std::size_t start = num_bins / 16;
+	std::size_t end = num_bins / 2;
+	double sum_x = 0, sum_y = 0, sum_xx = 0, sum_xy = 0;
+	double count = 0;
+	for (std::size_t k = start; k < end; ++k) {
+		double freq = static_cast<double>(k) * sample_rate / static_cast<double>(N);
+		if (freq <= 0) continue;
+		double x = std::log2(freq);
+		double y = static_cast<double>(noise_spectrum[k]);
+		sum_x += x;
+		sum_y += y;
+		sum_xx += x * x;
+		sum_xy += x * y;
+		count += 1.0;
+	}
+	double slope = (count * sum_xy - sum_x * sum_y) / (count * sum_xx - sum_x * sum_x);
+	return slope;
+}
+
+void test_first_order_tilt() {
+	auto sig = sine<double>(8192, 100.0, 44100.0);
+	FirstOrderNoiseShaper<double, float> shaper;
+	auto shaped = shaper.process(sig);
+
+	mtl::vec::dense_vector<double> shaped_d(shaped.size());
+	for (std::size_t i = 0; i < shaped.size(); ++i)
+		shaped_d[i] = static_cast<double>(shaped[i]);
+
+	double tilt = noise_spectral_tilt(sig, shaped_d, 44100.0);
+
+	// 1st order: ~+3 dB/octave noise tilt (20 dB/decade ≈ 6 dB/octave theoretical)
+	if (!(tilt > 1.0))
+		throw std::runtime_error("test failed: 1st order tilt should be positive, got " + std::to_string(tilt));
+
+	std::cout << "  first_order_tilt: passed (tilt=" << tilt << " dB/oct)\n";
+}
+
+void test_second_order_tilt() {
+	auto sig = sine<double>(8192, 100.0, 44100.0);
+	SecondOrderNoiseShaper<double, float> shaper;
+	auto shaped = shaper.process(sig);
+
+	mtl::vec::dense_vector<double> shaped_d(shaped.size());
+	for (std::size_t i = 0; i < shaped.size(); ++i)
+		shaped_d[i] = static_cast<double>(shaped[i]);
+
+	double tilt = noise_spectral_tilt(sig, shaped_d, 44100.0);
+
+	// 2nd order: steeper tilt than 1st order (~+6 dB/octave)
+	if (!(tilt > 3.0))
+		throw std::runtime_error("test failed: 2nd order tilt should be > 3 dB/oct, got " + std::to_string(tilt));
+
+	std::cout << "  second_order_tilt: passed (tilt=" << tilt << " dB/oct)\n";
+}
+
+void test_third_order_tilt() {
+	auto sig = sine<double>(8192, 100.0, 44100.0);
+	ThirdOrderNoiseShaper<double, float> shaper;
+	auto shaped = shaper.process(sig);
+
+	mtl::vec::dense_vector<double> shaped_d(shaped.size());
+	for (std::size_t i = 0; i < shaped.size(); ++i)
+		shaped_d[i] = static_cast<double>(shaped[i]);
+
+	double tilt = noise_spectral_tilt(sig, shaped_d, 44100.0);
+
+	// 3rd order: steeper tilt than 2nd order (~+9 dB/octave)
+	if (!(tilt > 5.0))
+		throw std::runtime_error("test failed: 3rd order tilt should be > 5 dB/oct, got " + std::to_string(tilt));
+
+	std::cout << "  third_order_tilt: passed (tilt=" << tilt << " dB/oct)\n";
+}
+
+void test_increasing_tilt_with_order() {
+	auto sig = sine<double>(8192, 100.0, 44100.0);
+
+	FirstOrderNoiseShaper<double, float> shaper1;
+	SecondOrderNoiseShaper<double, float> shaper2;
+	ThirdOrderNoiseShaper<double, float> shaper3;
+
+	auto s1 = shaper1.process(sig);
+	auto s2 = shaper2.process(sig);
+	auto s3 = shaper3.process(sig);
+
+	mtl::vec::dense_vector<double> s1d(s1.size()), s2d(s2.size()), s3d(s3.size());
+	for (std::size_t i = 0; i < sig.size(); ++i) {
+		s1d[i] = static_cast<double>(s1[i]);
+		s2d[i] = static_cast<double>(s2[i]);
+		s3d[i] = static_cast<double>(s3[i]);
+	}
+
+	double tilt1 = noise_spectral_tilt(sig, s1d, 44100.0);
+	double tilt2 = noise_spectral_tilt(sig, s2d, 44100.0);
+	double tilt3 = noise_spectral_tilt(sig, s3d, 44100.0);
+
+	if (!(tilt2 > tilt1))
+		throw std::runtime_error("test failed: 2nd order tilt (" + std::to_string(tilt2) +
+		                         ") should exceed 1st order (" + std::to_string(tilt1) + ")");
+	if (!(tilt3 > tilt2))
+		throw std::runtime_error("test failed: 3rd order tilt (" + std::to_string(tilt3) +
+		                         ") should exceed 2nd order (" + std::to_string(tilt2) + ")");
+
+	std::cout << "  increasing_tilt: passed (1st=" << tilt1 << ", 2nd=" << tilt2 << ", 3rd=" << tilt3 << " dB/oct)\n";
+}
+
+void test_inband_sqnr_improvement() {
+	// Higher-order shaping should improve in-band SQNR for oversampled signals.
+	// Use a low-frequency tone at high sample rate (oversampled scenario).
+	auto sig = sine<double>(8192, 100.0, 44100.0);
+
+	FirstOrderNoiseShaper<double, float> shaper1;
+	SecondOrderNoiseShaper<double, float> shaper2;
+	ThirdOrderNoiseShaper<double, float> shaper3;
+
+	auto s1 = shaper1.process(sig);
+	auto s2 = shaper2.process(sig);
+	auto s3 = shaper3.process(sig);
+
+	double sqnr1 = sqnr_db(sig, s1);
+	double sqnr2 = sqnr_db(sig, s2);
+	double sqnr3 = sqnr_db(sig, s3);
+
+	if (!(std::isfinite(sqnr1) && std::isfinite(sqnr2) && std::isfinite(sqnr3)))
+		throw std::runtime_error("test failed: all SQNR values should be finite");
+
+	std::cout << "  inband_sqnr: passed (1st=" << sqnr1 << ", 2nd=" << sqnr2 << ", 3rd=" << sqnr3 << " dB)\n";
+}
+
+void test_reset() {
+	SecondOrderNoiseShaper<double, float> shaper;
+	ThirdOrderNoiseShaper<double, float> shaper3;
+
+	// Process some samples to build up state
+	for (int i = 0; i < 100; ++i) {
+		shaper.process(static_cast<double>(i) * 0.01);
+		shaper3.process(static_cast<double>(i) * 0.01);
+	}
+
+	// Reset should clear state
+	shaper.reset();
+	shaper3.reset();
+
+	// After reset, first sample should behave identically to fresh instance
+	SecondOrderNoiseShaper<double, float> fresh2;
+	ThirdOrderNoiseShaper<double, float> fresh3;
+
+	double input = 0.5;
+	float out_reset2 = shaper.process(input);
+	float out_fresh2 = fresh2.process(input);
+	float out_reset3 = shaper3.process(input);
+	float out_fresh3 = fresh3.process(input);
+
+	if (out_reset2 != out_fresh2)
+		throw std::runtime_error("test failed: 2nd order reset should match fresh instance");
+	if (out_reset3 != out_fresh3)
+		throw std::runtime_error("test failed: 3rd order reset should match fresh instance");
+
+	std::cout << "  reset: passed\n";
+}
+
+void test_stability_aggressive_quantization() {
+	// Aggressive quantization: double -> half-precision cfloat
+	// Use posit<8,2> as a very coarse target to stress the shapers.
+	using LowPrec = sw::universal::posit<8, 2>;
+
+	auto sig = sine<double>(1024, 440.0, 44100.0);
+
+	FirstOrderNoiseShaper<double, LowPrec> shaper1;
+	SecondOrderNoiseShaper<double, LowPrec> shaper2;
+	ThirdOrderNoiseShaper<double, LowPrec> shaper3;
+
+	auto s1 = shaper1.process(sig);
+	auto s2 = shaper2.process(sig);
+	auto s3 = shaper3.process(sig);
+
+	// All outputs should be finite (no overflow/NaN)
+	for (std::size_t i = 0; i < sig.size(); ++i) {
+		double v1 = static_cast<double>(s1[i]);
+		double v2 = static_cast<double>(s2[i]);
+		double v3 = static_cast<double>(s3[i]);
+		if (!std::isfinite(v1) || !std::isfinite(v2) || !std::isfinite(v3))
+			throw std::runtime_error("test failed: output not finite at sample " + std::to_string(i));
+	}
+
+	double sqnr1 = sqnr_db(sig, s1);
+	double sqnr2 = sqnr_db(sig, s2);
+	double sqnr3 = sqnr_db(sig, s3);
+
+	std::cout << "  stability_aggressive: passed (posit<8,2> SQNR: 1st=" << sqnr1
+	          << ", 2nd=" << sqnr2 << ", 3rd=" << sqnr3 << " dB)\n";
+}
+
+void test_posit_combination() {
+	// posit<32,2> -> posit<16,2>
+	using HighPrec = sw::universal::posit<32, 2>;
+	using LowPrec = sw::universal::posit<16, 2>;
+
+	std::size_t N = 512;
+	mtl::vec::dense_vector<HighPrec> sig(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		sig[i] = HighPrec(std::sin(2.0 * M_PI * 440.0 * static_cast<double>(i) / 44100.0));
+	}
+
+	FirstOrderNoiseShaper<HighPrec, LowPrec> shaper1;
+	SecondOrderNoiseShaper<HighPrec, LowPrec> shaper2;
+	ThirdOrderNoiseShaper<HighPrec, LowPrec> shaper3;
+
+	auto s1 = shaper1.process(sig);
+	auto s2 = shaper2.process(sig);
+	auto s3 = shaper3.process(sig);
+
+	if (s1.size() != N || s2.size() != N || s3.size() != N)
+		throw std::runtime_error("test failed: posit output size mismatch");
+
+	std::cout << "  posit_combination: passed (posit<32,2> -> posit<16,2>)\n";
+}
+
+void test_fixpnt_combination() {
+	// double -> fixpnt<8,4> (cross-fixpnt cast not supported, use double as bridge)
+	using LowPrec = sw::universal::fixpnt<8, 4, sw::universal::Saturate, uint8_t>;
+
+	std::size_t N = 512;
+	mtl::vec::dense_vector<double> sig(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		sig[i] = 0.5 * std::sin(2.0 * M_PI * 440.0 * static_cast<double>(i) / 44100.0);
+	}
+
+	FirstOrderNoiseShaper<double, LowPrec> shaper1;
+	SecondOrderNoiseShaper<double, LowPrec> shaper2;
+	ThirdOrderNoiseShaper<double, LowPrec> shaper3;
+
+	auto s1 = shaper1.process(sig);
+	auto s2 = shaper2.process(sig);
+	auto s3 = shaper3.process(sig);
+
+	if (s1.size() != N || s2.size() != N || s3.size() != N)
+		throw std::runtime_error("test failed: fixpnt output size mismatch");
+
+	std::cout << "  fixpnt_combination: passed (double -> fixpnt<8,4>)\n";
+}
+
+void test_vector_vs_scalar_consistency() {
+	auto sig = sine<double>(256, 440.0, 44100.0);
+
+	SecondOrderNoiseShaper<double, float> vec_shaper;
+	SecondOrderNoiseShaper<double, float> scalar_shaper;
+
+	auto vec_result = vec_shaper.process(sig);
+
+	for (std::size_t i = 0; i < sig.size(); ++i) {
+		float scalar_result = scalar_shaper.process(sig[i]);
+		if (vec_result[i] != scalar_result)
+			throw std::runtime_error("test failed: vector/scalar mismatch at sample " + std::to_string(i));
+	}
+
+	std::cout << "  vector_scalar_consistency: passed\n";
+}
+
+int main() {
+	try {
+		std::cout << "Noise Shaping Tests\n";
+
+		test_first_order_tilt();
+		test_second_order_tilt();
+		test_third_order_tilt();
+		test_increasing_tilt_with_order();
+		test_inband_sqnr_improvement();
+		test_reset();
+		test_stability_aggressive_quantization();
+		test_posit_combination();
+		test_fixpnt_combination();
+		test_vector_vs_scalar_consistency();
+
+		std::cout << "All noise shaping tests passed.\n";
+		return 0;
+	} catch (const std::exception& e) {
+		std::cerr << "FAILED: " << e.what() << '\n';
+		return 1;
+	}
+}

--- a/tests/test_noise_shaping.cpp
+++ b/tests/test_noise_shaping.cpp
@@ -55,7 +55,10 @@ double noise_spectral_tilt(const mtl::vec::dense_vector<double>& reference,
 		sum_xy += x * y;
 		count += 1.0;
 	}
-	double slope = (count * sum_xy - sum_x * sum_y) / (count * sum_xx - sum_x * sum_x);
+	double denom = count * sum_xx - sum_x * sum_x;
+	if (count < 2.0 || std::abs(denom) < 1e-12)
+		throw std::runtime_error("test failed: insufficient data for spectral-tilt regression");
+	double slope = (count * sum_xy - sum_x * sum_y) / denom;
 	return slope;
 }
 
@@ -145,10 +148,15 @@ void test_increasing_tilt_with_order() {
 	std::cout << "  increasing_tilt: passed (1st=" << tilt1 << ", 2nd=" << tilt2 << ", 3rd=" << tilt3 << " dB/oct)\n";
 }
 
-void test_inband_sqnr_improvement() {
-	// Higher-order shaping should improve in-band SQNR for oversampled signals.
-	// Use a low-frequency tone at high sample rate (oversampled scenario).
+void test_broadband_sqnr() {
+	// Noise shaping redistributes noise spectrally — broadband SQNR may
+	// decrease with higher order because more energy is pushed to high
+	// frequencies. Verify all values are finite and compare against plain
+	// quantization baseline.
 	auto sig = sine<double>(8192, 100.0, 44100.0);
+
+	ADC<double, float> adc;
+	auto plain = adc.convert(sig);
 
 	FirstOrderNoiseShaper<double, float> shaper1;
 	SecondOrderNoiseShaper<double, float> shaper2;
@@ -158,14 +166,21 @@ void test_inband_sqnr_improvement() {
 	auto s2 = shaper2.process(sig);
 	auto s3 = shaper3.process(sig);
 
+	double sqnr_plain = sqnr_db(sig, plain);
 	double sqnr1 = sqnr_db(sig, s1);
 	double sqnr2 = sqnr_db(sig, s2);
 	double sqnr3 = sqnr_db(sig, s3);
 
-	if (!(std::isfinite(sqnr1) && std::isfinite(sqnr2) && std::isfinite(sqnr3)))
+	if (!(std::isfinite(sqnr_plain) && std::isfinite(sqnr1) &&
+	      std::isfinite(sqnr2) && std::isfinite(sqnr3)))
 		throw std::runtime_error("test failed: all SQNR values should be finite");
 
-	std::cout << "  inband_sqnr: passed (1st=" << sqnr1 << ", 2nd=" << sqnr2 << ", 3rd=" << sqnr3 << " dB)\n";
+	// All shaped outputs should have reasonable SQNR (> 100 dB for double->float)
+	if (!(sqnr1 > 100.0 && sqnr2 > 100.0 && sqnr3 > 100.0))
+		throw std::runtime_error("test failed: shaped SQNR too low");
+
+	std::cout << "  broadband_sqnr: passed (plain=" << sqnr_plain
+	          << ", 1st=" << sqnr1 << ", 2nd=" << sqnr2 << ", 3rd=" << sqnr3 << " dB)\n";
 }
 
 void test_reset() {
@@ -306,7 +321,7 @@ int main() {
 		test_second_order_tilt();
 		test_third_order_tilt();
 		test_increasing_tilt_with_order();
-		test_inband_sqnr_improvement();
+		test_broadband_sqnr();
 		test_reset();
 		test_stability_aggressive_quantization();
 		test_posit_combination();

--- a/tests/test_noise_shaping.cpp
+++ b/tests/test_noise_shaping.cpp
@@ -9,6 +9,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <numbers>
 #include <stdexcept>
 #include <vector>
 
@@ -239,7 +240,7 @@ void test_posit_combination() {
 	std::size_t N = 512;
 	mtl::vec::dense_vector<HighPrec> sig(N);
 	for (std::size_t i = 0; i < N; ++i) {
-		sig[i] = HighPrec(std::sin(2.0 * M_PI * 440.0 * static_cast<double>(i) / 44100.0));
+		sig[i] = HighPrec(std::sin(2.0 * std::numbers::pi * 440.0 * static_cast<double>(i) / 44100.0));
 	}
 
 	FirstOrderNoiseShaper<HighPrec, LowPrec> shaper1;
@@ -263,7 +264,7 @@ void test_fixpnt_combination() {
 	std::size_t N = 512;
 	mtl::vec::dense_vector<double> sig(N);
 	for (std::size_t i = 0; i < N; ++i) {
-		sig[i] = 0.5 * std::sin(2.0 * M_PI * 440.0 * static_cast<double>(i) / 44100.0);
+		sig[i] = 0.5 * std::sin(2.0 * std::numbers::pi * 440.0 * static_cast<double>(i) / 44100.0);
 	}
 
 	FirstOrderNoiseShaper<double, LowPrec> shaper1;


### PR DESCRIPTION
## Summary
- Add `SecondOrderNoiseShaper` and `ThirdOrderNoiseShaper` with NTF = (1-z⁻¹)² and (1-z⁻¹)³
- Fix error feedback sign bug in existing `FirstOrderNoiseShaper`: was producing lowpass NTF = (1+z⁻¹) instead of highpass NTF = (1-z⁻¹)
- Verified spectral tilt progression: ~4.3, ~9.2, ~14.3 dB/octave for 1st/2nd/3rd order

## Changes
- `include/sw/dsp/quantization/noise_shaping.hpp` — fix 1st order feedback sign, add 2nd/3rd order classes
- `tests/test_noise_shaping.cpp` — 10 dedicated tests (spectral tilt, SQNR, reset, stability, posit/fixpnt combos)
- `tests/CMakeLists.txt` — register test_noise_shaping

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_noise_shaping | OK | PASS (10/10) | OK | PASS (10/10) |
| test_quantization | OK | PASS (regression) | OK | PASS (regression) |

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected first-order noise shaper feedback behavior and added denormal prevention.

* **New Features**
  * Added second- and third-order noise shapers with scalar/vector processing and state reset.

* **Tests**
  * Added comprehensive tests validating spectral tilt, SQNR improvements, numerical stability, reset behavior, and scalar/vector consistency.

* **Documentation**
  * Updated comments with explicit NTF design equations for 1st–3rd order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->