### PR TITLE
feat(conditioning): rational sample-rate conversion (L/M resampling)

### DIFF
--- a/include/sw/dsp/conditioning/conditioning.hpp
+++ b/include/sw/dsp/conditioning/conditioning.hpp
@@ -7,4 +7,5 @@
 #include <sw/dsp/conditioning/envelope.hpp>
 #include <sw/dsp/conditioning/compressor.hpp>
 #include <sw/dsp/conditioning/agc.hpp>
-// Future: interpolator.hpp, decimator.hpp, resampler.hpp (depends on #33)
+// Rational sample-rate conversion (Issue #71)
+#include <sw/dsp/conditioning/src.hpp>

--- a/include/sw/dsp/conditioning/src.hpp
+++ b/include/sw/dsp/conditioning/src.hpp
@@ -25,6 +25,7 @@
 #include <mtl/vec/dense_vector.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
 #include <sw/dsp/filter/fir/fir_design.hpp>
+#include <sw/dsp/math/denormal.hpp>
 #include <sw/dsp/windows/kaiser.hpp>
 
 namespace sw::dsp {
@@ -72,7 +73,7 @@ public:
 			}
 		}
 
-		delay_.resize(sub_len, SampleScalar{});
+		delay_ = mtl::vec::dense_vector<SampleScalar>(sub_len, SampleScalar{});
 		write_pos_ = 0;
 	}
 
@@ -103,7 +104,7 @@ public:
 	}
 
 	void reset() {
-		for (auto& d : delay_) d = SampleScalar{};
+		for (std::size_t i = 0; i < delay_.size(); ++i) delay_[i] = SampleScalar{};
 		write_pos_ = 0;
 		time_reg_ = 0;
 	}
@@ -122,7 +123,8 @@ private:
 		std::size_t pos = (write_pos_ == 0) ? delay_.size() - 1 : write_pos_ - 1;
 		for (std::size_t p = 0; p < taps.size(); ++p) {
 			acc = acc + static_cast<StateScalar>(taps[p])
-			          * static_cast<StateScalar>(delay_[pos]);
+			          * static_cast<StateScalar>(delay_[pos])
+			    + denormal_.ac();
 			pos = (pos == 0) ? delay_.size() - 1 : pos - 1;
 		}
 		return static_cast<SampleScalar>(acc);
@@ -132,8 +134,9 @@ private:
 	std::size_t M_;
 	std::size_t time_reg_;
 	std::vector<std::vector<CoeffScalar>> sub_taps_;
-	std::vector<SampleScalar> delay_;
+	mtl::vec::dense_vector<SampleScalar> delay_;
 	std::size_t write_pos_;
+	DenormalPrevention<StateScalar> denormal_;
 };
 
 } // namespace sw::dsp

--- a/include/sw/dsp/conditioning/src.hpp
+++ b/include/sw/dsp/conditioning/src.hpp
@@ -1,0 +1,139 @@
+#pragma once
+// src.hpp: rational sample-rate conversion (L/M resampling)
+//
+// Combines polyphase interpolation by L and decimation by M with an
+// auto-designed Kaiser-windowed sinc anti-alias filter. The polyphase
+// structure avoids computing samples that would be discarded.
+//
+// Algorithm (time-register approach):
+//   For each input sample pushed into the delay line:
+//     while (time_register < L):
+//       output = sub_filter[time_register] · delay_line
+//       emit output
+//       time_register += M
+//     time_register -= L   (consumed one input)
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <numeric>
+#include <stdexcept>
+#include <vector>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/filter/fir/fir_design.hpp>
+#include <sw/dsp/windows/kaiser.hpp>
+
+namespace sw::dsp {
+
+template <DspField CoeffScalar = double,
+          DspField StateScalar = CoeffScalar,
+          DspScalar SampleScalar = StateScalar>
+class RationalResampler {
+public:
+	// L: interpolation factor, M: decimation factor
+	// filter_half_length: half-length in periods of the slower rate
+	// beta: Kaiser window shape parameter
+	RationalResampler(std::size_t L, std::size_t M,
+	                  std::size_t filter_half_length = 10,
+	                  CoeffScalar beta = CoeffScalar{5})
+		: L_(L), M_(M), time_reg_(0) {
+		if (L == 0 || M == 0)
+			throw std::invalid_argument("RationalResampler: L and M must be > 0");
+
+		std::size_t g = std::gcd(L, M);
+		L_ = L / g;
+		M_ = M / g;
+
+		std::size_t max_factor = std::max(L_, M_);
+		std::size_t num_taps = 2 * filter_half_length * max_factor + 1;
+
+		auto win = kaiser_window<CoeffScalar>(num_taps, static_cast<double>(beta));
+
+		double cutoff = 0.5 / static_cast<double>(max_factor);
+		auto taps = design_fir_lowpass<CoeffScalar>(num_taps, CoeffScalar(cutoff), win);
+
+		// Scale by L for unity passband gain after interpolation
+		for (std::size_t i = 0; i < num_taps; ++i) {
+			taps[i] = taps[i] * CoeffScalar(static_cast<double>(L_));
+		}
+
+		// Decompose into L sub-filters
+		std::size_t sub_len = (num_taps + L_ - 1) / L_;
+		sub_taps_.resize(L_);
+		for (std::size_t q = 0; q < L_; ++q) {
+			sub_taps_[q].resize(sub_len, CoeffScalar{});
+			for (std::size_t p = 0; p < sub_len; ++p) {
+				std::size_t idx = p * L_ + q;
+				if (idx < num_taps) sub_taps_[q][p] = taps[idx];
+			}
+		}
+
+		delay_.resize(sub_len, SampleScalar{});
+		write_pos_ = 0;
+	}
+
+	mtl::vec::dense_vector<SampleScalar> process(
+	        const mtl::vec::dense_vector<SampleScalar>& input) {
+		std::size_t out_cap = static_cast<std::size_t>(
+			std::ceil(static_cast<double>(input.size()) *
+			          static_cast<double>(L_) / static_cast<double>(M_))) + L_;
+		std::vector<SampleScalar> out_buf;
+		out_buf.reserve(out_cap);
+
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			delay_[write_pos_] = input[i];
+			write_pos_ = (write_pos_ + 1) % delay_.size();
+
+			while (time_reg_ < L_) {
+				out_buf.push_back(compute_sub_filter(time_reg_));
+				time_reg_ += M_;
+			}
+			time_reg_ -= L_;
+		}
+
+		mtl::vec::dense_vector<SampleScalar> result(out_buf.size());
+		for (std::size_t i = 0; i < out_buf.size(); ++i) {
+			result[i] = out_buf[i];
+		}
+		return result;
+	}
+
+	void reset() {
+		for (auto& d : delay_) d = SampleScalar{};
+		write_pos_ = 0;
+		time_reg_ = 0;
+	}
+
+	double ratio() const {
+		return static_cast<double>(L_) / static_cast<double>(M_);
+	}
+
+	std::size_t interp_factor() const { return L_; }
+	std::size_t decim_factor() const { return M_; }
+
+private:
+	SampleScalar compute_sub_filter(std::size_t phase) {
+		const auto& taps = sub_taps_[phase];
+		StateScalar acc{};
+		std::size_t pos = (write_pos_ == 0) ? delay_.size() - 1 : write_pos_ - 1;
+		for (std::size_t p = 0; p < taps.size(); ++p) {
+			acc = acc + static_cast<StateScalar>(taps[p])
+			          * static_cast<StateScalar>(delay_[pos]);
+			pos = (pos == 0) ? delay_.size() - 1 : pos - 1;
+		}
+		return static_cast<SampleScalar>(acc);
+	}
+
+	std::size_t L_;
+	std::size_t M_;
+	std::size_t time_reg_;
+	std::vector<std::vector<CoeffScalar>> sub_taps_;
+	std::vector<SampleScalar> delay_;
+	std::size_t write_pos_;
+};
+
+} // namespace sw::dsp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,5 +79,8 @@ dsp_add_test(test_bluestein)
 # Higher-order noise shaping (Issue #70)
 dsp_add_test(test_noise_shaping)
 
+# Rational sample-rate conversion (Issue #71)
+dsp_add_test(test_src)
+
 # Type projection/embedding
 dsp_add_test(test_projection)

--- a/tests/test_src.cpp
+++ b/tests/test_src.cpp
@@ -1,0 +1,355 @@
+// test_src.cpp: tests for rational sample-rate conversion
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/conditioning/src.hpp>
+#include <sw/dsp/signals/generators.hpp>
+#include <sw/dsp/quantization/sqnr.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <numbers>
+#include <stdexcept>
+
+#include <universal/number/posit/posit.hpp>
+#include <universal/number/fixpnt/fixpnt.hpp>
+
+using namespace sw::dsp;
+
+void test_ratio_and_gcd() {
+	// 44100 -> 48000: L=160, M=147 reduced by GCD
+	RationalResampler<> r1(160, 147);
+	if (r1.interp_factor() != 160 || r1.decim_factor() != 147)
+		throw std::runtime_error("test failed: 160/147 should be coprime");
+
+	// 48000 -> 16000: L=1, M=3
+	RationalResampler<> r2(1, 3);
+	if (r2.interp_factor() != 1 || r2.decim_factor() != 3)
+		throw std::runtime_error("test failed: 1/3 ratio");
+
+	// GCD reduction: 2/4 -> 1/2
+	RationalResampler<> r3(2, 4);
+	if (r3.interp_factor() != 1 || r3.decim_factor() != 2)
+		throw std::runtime_error("test failed: 2/4 should reduce to 1/2");
+
+	double expected = 160.0 / 147.0;
+	if (std::abs(r1.ratio() - expected) > 1e-10)
+		throw std::runtime_error("test failed: ratio() incorrect");
+
+	std::cout << "  ratio_and_gcd: passed\n";
+}
+
+void test_identity_resampling() {
+	// L=1, M=1 should pass through unchanged (minus filter delay)
+	RationalResampler<> resampler(1, 1);
+	auto sig = sine<double>(256, 100.0, 44100.0);
+	auto out = resampler.process(sig);
+
+	if (out.size() != sig.size())
+		throw std::runtime_error("test failed: 1:1 output size mismatch, got " +
+		                         std::to_string(out.size()));
+
+	// After filter settles, output should match input (with delay)
+	// Find peak correlation to identify the delay
+	double best_corr = 0;
+	std::size_t best_d = 0;
+	for (std::size_t d = 0; d < 50; ++d) {
+		double corr = 0;
+		for (std::size_t i = d; i < sig.size(); ++i) {
+			corr += static_cast<double>(sig[i - d]) * static_cast<double>(out[i]);
+		}
+		if (corr > best_corr) { best_corr = corr; best_d = d; }
+	}
+
+	// Verify the delayed output matches
+	double max_err = 0;
+	std::size_t skip = best_d + 20; // skip transient
+	for (std::size_t i = skip; i < sig.size() - 10; ++i) {
+		double err = std::abs(static_cast<double>(sig[i - best_d]) -
+		                      static_cast<double>(out[i]));
+		if (err > max_err) max_err = err;
+	}
+	// L=M=1 filter has cutoff at Nyquist with finite taps, so some ripple expected
+	if (!(max_err < 0.1))
+		throw std::runtime_error("test failed: 1:1 resampling max error " +
+		                         std::to_string(max_err) + " (delay=" +
+		                         std::to_string(best_d) + ")");
+
+	std::cout << "  identity_resampling: passed (delay=" << best_d
+	          << ", max_err=" << max_err << ")\n";
+}
+
+void test_44100_to_48000() {
+	// 44100 → 48000 Hz: L=160, M=147
+	double f_tone = 1000.0;
+	double fs_in = 44100.0;
+	double fs_out = 48000.0;
+	std::size_t N_in = 4410; // 100ms at 44100
+
+	mtl::vec::dense_vector<double> sig(N_in);
+	for (std::size_t i = 0; i < N_in; ++i) {
+		sig[i] = std::sin(2.0 * std::numbers::pi * f_tone *
+		                  static_cast<double>(i) / fs_in);
+	}
+
+	RationalResampler<> resampler(160, 147, 10, 5.0);
+	auto out = resampler.process(sig);
+
+	// Expected output length: ~N_in * 160/147 = ~4800
+	std::size_t expected_len = static_cast<std::size_t>(
+		std::round(static_cast<double>(N_in) * 160.0 / 147.0));
+	if (out.size() < expected_len - 10 || out.size() > expected_len + 10)
+		throw std::runtime_error("test failed: 44100->48000 output length " +
+		                         std::to_string(out.size()) + " expected ~" +
+		                         std::to_string(expected_len));
+
+	// Verify the 1 kHz tone is preserved in the output by measuring
+	// the dominant frequency via zero-crossing rate
+	std::size_t skip = 500; // skip filter transient
+	std::size_t crossings = 0;
+	for (std::size_t i = skip + 1; i < out.size(); ++i) {
+		if ((static_cast<double>(out[i - 1]) < 0 && static_cast<double>(out[i]) >= 0) ||
+		    (static_cast<double>(out[i - 1]) >= 0 && static_cast<double>(out[i]) < 0))
+			++crossings;
+	}
+	double measured_freq = static_cast<double>(crossings) * fs_out /
+	                       (2.0 * static_cast<double>(out.size() - skip));
+	if (std::abs(measured_freq - f_tone) > 50.0)
+		throw std::runtime_error("test failed: frequency shifted to " +
+		                         std::to_string(measured_freq) + " Hz");
+
+	std::cout << "  44100_to_48000: passed (out_len=" << out.size()
+	          << ", measured_freq=" << measured_freq << " Hz)\n";
+}
+
+void test_48000_to_16000() {
+	// 48000 → 16000 Hz: L=1, M=3 (pure decimation)
+	double fs_in = 48000.0;
+	std::size_t N_in = 4800; // 100ms
+
+	// Signal: 1 kHz (should be preserved) + 10 kHz (should be attenuated)
+	mtl::vec::dense_vector<double> sig(N_in);
+	for (std::size_t i = 0; i < N_in; ++i) {
+		double t = static_cast<double>(i) / fs_in;
+		sig[i] = std::sin(2.0 * std::numbers::pi * 1000.0 * t)
+		       + std::sin(2.0 * std::numbers::pi * 10000.0 * t);
+	}
+
+	RationalResampler<> resampler(1, 3, 10, 5.0);
+	auto out = resampler.process(sig);
+
+	// Expected ~1600 samples
+	if (out.size() < 1500 || out.size() > 1700)
+		throw std::runtime_error("test failed: 48000->16000 output length " +
+		                         std::to_string(out.size()));
+
+	// The 10 kHz tone is above Nyquist (8 kHz) of the output rate and
+	// should be heavily attenuated. Measure RMS of output vs a pure
+	// 1 kHz reference at the output rate.
+	std::size_t skip = 200;
+	double rms_out = 0;
+	for (std::size_t i = skip; i < out.size(); ++i) {
+		double v = static_cast<double>(out[i]);
+		rms_out += v * v;
+	}
+	rms_out = std::sqrt(rms_out / static_cast<double>(out.size() - skip));
+
+	// Pure 1 kHz at unit amplitude has RMS = 1/sqrt(2) ≈ 0.707
+	// With the 10 kHz removed, output RMS should be close to this
+	if (!(rms_out > 0.4 && rms_out < 1.0))
+		throw std::runtime_error("test failed: output RMS " +
+		                         std::to_string(rms_out) + " not in expected range");
+
+	std::cout << "  48000_to_16000: passed (out_len=" << out.size()
+	          << ", rms=" << rms_out << ")\n";
+}
+
+void test_roundtrip_snr() {
+	// Resample 44100 → 48000 → 44100, measure SNR vs original.
+	// Use short filter (half_length=3) to keep delay manageable, and
+	// a long signal (1 second) so we have plenty of valid data.
+	double fs1 = 44100.0;
+	std::size_t N = 44100; // 1 second
+
+	mtl::vec::dense_vector<double> sig(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		sig[i] = std::sin(2.0 * std::numbers::pi * 440.0 *
+		                  static_cast<double>(i) / fs1);
+	}
+
+	RationalResampler<> up(160, 147, 3, 5.0);
+	RationalResampler<> down(147, 160, 3, 5.0);
+
+	auto upsampled = up.process(sig);
+	auto roundtrip = down.process(upsampled);
+
+	// Search for best delay alignment. roundtrip[d] ≈ sig[0].
+	// Each filter: ~2*3*160+1 = 961 taps, delay ~480 at 48kHz.
+	// Total roundtrip delay at 44.1kHz ≈ 2 * 480 * (147/160) ≈ 882.
+	double best_snr = -999;
+	std::size_t best_d = 0;
+	std::size_t skip = 1000; // skip transient at start of reference
+	std::size_t compare_len = 20000;
+	for (std::size_t d = 200; d < 2000 &&
+	     d + skip + compare_len < roundtrip.size(); d += 5) {
+		if (skip + compare_len > N) break;
+		mtl::vec::dense_vector<double> r(compare_len);
+		mtl::vec::dense_vector<double> a(compare_len);
+		for (std::size_t i = 0; i < compare_len; ++i) {
+			r[i] = sig[i + skip];
+			a[i] = static_cast<double>(roundtrip[i + d + skip]);
+		}
+		double snr = sqnr_db(r, a);
+		if (snr > best_snr) { best_snr = snr; best_d = d; }
+	}
+
+	// Refine around best_d
+	for (std::size_t d = (best_d > 5 ? best_d - 5 : 0);
+	     d < best_d + 5 && d + skip + compare_len < roundtrip.size(); ++d) {
+		mtl::vec::dense_vector<double> r(compare_len);
+		mtl::vec::dense_vector<double> a(compare_len);
+		for (std::size_t i = 0; i < compare_len; ++i) {
+			r[i] = sig[i + skip];
+			a[i] = static_cast<double>(roundtrip[i + d + skip]);
+		}
+		double snr = sqnr_db(r, a);
+		if (snr > best_snr) { best_snr = snr; best_d = d; }
+	}
+
+	if (!(best_snr > 40.0))
+		throw std::runtime_error("test failed: roundtrip SNR " +
+		                         std::to_string(best_snr) + " dB too low (delay=" +
+		                         std::to_string(best_d) + ")");
+
+	std::cout << "  roundtrip_snr: passed (" << best_snr << " dB, delay="
+	          << best_d << ")\n";
+}
+
+void test_integer_upsample() {
+	// L=4, M=1 should produce 4x as many samples
+	RationalResampler<> resampler(4, 1);
+	auto sig = sine<double>(100, 100.0, 1000.0);
+	auto out = resampler.process(sig);
+
+	if (out.size() != 400)
+		throw std::runtime_error("test failed: 4x upsample length " +
+		                         std::to_string(out.size()) + " expected 400");
+
+	std::cout << "  integer_upsample: passed (out_len=" << out.size() << ")\n";
+}
+
+void test_integer_downsample() {
+	// L=1, M=4 should produce 1/4 as many samples
+	RationalResampler<> resampler(1, 4);
+	auto sig = sine<double>(400, 10.0, 1000.0);
+	auto out = resampler.process(sig);
+
+	if (out.size() != 100)
+		throw std::runtime_error("test failed: 4x downsample length " +
+		                         std::to_string(out.size()) + " expected 100");
+
+	std::cout << "  integer_downsample: passed (out_len=" << out.size() << ")\n";
+}
+
+void test_reset() {
+	RationalResampler<> resampler(3, 2);
+	auto sig = sine<double>(100, 440.0, 44100.0);
+
+	auto out1 = resampler.process(sig);
+	resampler.reset();
+	auto out2 = resampler.process(sig);
+
+	if (out1.size() != out2.size())
+		throw std::runtime_error("test failed: reset output size mismatch");
+
+	for (std::size_t i = 0; i < out1.size(); ++i) {
+		if (out1[i] != out2[i])
+			throw std::runtime_error("test failed: reset output mismatch at " +
+			                         std::to_string(i));
+	}
+
+	std::cout << "  reset: passed\n";
+}
+
+void test_posit_types() {
+	using p32 = sw::universal::posit<32, 2>;
+	RationalResampler<double, double, p32> resampler(3, 2);
+
+	std::size_t N = 100;
+	mtl::vec::dense_vector<p32> sig(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		sig[i] = p32(std::sin(2.0 * std::numbers::pi * 440.0 *
+		                      static_cast<double>(i) / 44100.0));
+	}
+
+	auto out = resampler.process(sig);
+	if (out.size() < 140 || out.size() > 160)
+		throw std::runtime_error("test failed: posit output size " +
+		                         std::to_string(out.size()));
+
+	for (std::size_t i = 0; i < out.size(); ++i) {
+		if (!std::isfinite(static_cast<double>(out[i])))
+			throw std::runtime_error("test failed: posit output not finite at " +
+			                         std::to_string(i));
+	}
+
+	std::cout << "  posit_types: passed (posit<32,2>, out_len=" << out.size() << ")\n";
+}
+
+void test_fixpnt_types() {
+	using fxp = sw::universal::fixpnt<16, 8, sw::universal::Saturate, uint16_t>;
+	RationalResampler<double, double, fxp> resampler(2, 3);
+
+	std::size_t N = 150;
+	mtl::vec::dense_vector<fxp> sig(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		sig[i] = fxp(0.5 * std::sin(2.0 * std::numbers::pi * 440.0 *
+		                             static_cast<double>(i) / 44100.0));
+	}
+
+	auto out = resampler.process(sig);
+	if (out.size() < 90 || out.size() > 110)
+		throw std::runtime_error("test failed: fixpnt output size " +
+		                         std::to_string(out.size()));
+
+	std::cout << "  fixpnt_types: passed (fixpnt<16,8>, out_len=" << out.size() << ")\n";
+}
+
+void test_invalid_args() {
+	bool caught = false;
+	try { RationalResampler<>(0, 1); } catch (const std::invalid_argument&) { caught = true; }
+	if (!caught)
+		throw std::runtime_error("test failed: should reject L=0");
+
+	caught = false;
+	try { RationalResampler<>(1, 0); } catch (const std::invalid_argument&) { caught = true; }
+	if (!caught)
+		throw std::runtime_error("test failed: should reject M=0");
+
+	std::cout << "  invalid_args: passed\n";
+}
+
+int main() {
+	try {
+		std::cout << "Sample Rate Conversion Tests\n";
+
+		test_ratio_and_gcd();
+		test_identity_resampling();
+		test_44100_to_48000();
+		test_48000_to_16000();
+		test_roundtrip_snr();
+		test_integer_upsample();
+		test_integer_downsample();
+		test_reset();
+		test_posit_types();
+		test_fixpnt_types();
+		test_invalid_args();
+
+		std::cout << "All sample rate conversion tests passed.\n";
+		return 0;
+	} catch (const std::exception& e) {
+		std::cerr << "FAILED: " << e.what() << '\n';
+		return 1;
+	}
+}

--- a/tests/test_src.cpp
+++ b/tests/test_src.cpp
@@ -272,6 +272,45 @@ void test_reset() {
 	std::cout << "  reset: passed\n";
 }
 
+void test_chunked_streaming() {
+	// Verify that processing as one buffer matches processing as chunks
+	RationalResampler<> resampler(3, 2);
+	auto sig = sine<double>(300, 440.0, 44100.0);
+
+	auto out_single = resampler.process(sig);
+
+	resampler.reset();
+
+	// Process in 4 chunks of varying sizes
+	std::size_t chunks[] = {50, 100, 80, 70};
+	std::vector<double> out_chunked;
+	std::size_t offset = 0;
+	for (auto chunk_size : chunks) {
+		mtl::vec::dense_vector<double> chunk(chunk_size);
+		for (std::size_t i = 0; i < chunk_size; ++i) {
+			chunk[i] = sig[offset + i];
+		}
+		auto chunk_out = resampler.process(chunk);
+		for (std::size_t i = 0; i < chunk_out.size(); ++i) {
+			out_chunked.push_back(static_cast<double>(chunk_out[i]));
+		}
+		offset += chunk_size;
+	}
+
+	if (out_single.size() != out_chunked.size())
+		throw std::runtime_error("test failed: chunked size " +
+		                         std::to_string(out_chunked.size()) +
+		                         " vs single " + std::to_string(out_single.size()));
+
+	for (std::size_t i = 0; i < out_single.size(); ++i) {
+		if (static_cast<double>(out_single[i]) != out_chunked[i])
+			throw std::runtime_error("test failed: chunked mismatch at " +
+			                         std::to_string(i));
+	}
+
+	std::cout << "  chunked_streaming: passed\n";
+}
+
 void test_posit_types() {
 	using p32 = sw::universal::posit<32, 2>;
 	RationalResampler<double, double, p32> resampler(3, 2);
@@ -342,6 +381,7 @@ int main() {
 		test_integer_upsample();
 		test_integer_downsample();
 		test_reset();
+		test_chunked_streaming();
 		test_posit_types();
 		test_fixpnt_types();
 		test_invalid_args();


### PR DESCRIPTION
## Summary
- Implement `RationalResampler` with efficient polyphase time-register algorithm
- Auto-designs Kaiser-windowed sinc anti-alias filter, GCD-reduces L/M
- Three-scalar parameterization: CoeffScalar, StateScalar, SampleScalar

## Changes
- `include/sw/dsp/conditioning/src.hpp` — RationalResampler class with polyphase SRC
- `include/sw/dsp/conditioning/conditioning.hpp` — add src.hpp to umbrella
- `tests/test_src.cpp` — 11 tests: ratio/GCD, identity, 44100→48000, 48000→16000, roundtrip SNR, integer up/down, reset, posit, fixpnt, invalid args
- `tests/CMakeLists.txt` — register test_src

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_src | OK | PASS (11/11) | OK | PASS (11/11) |
| test_conditioning | OK | PASS (regression) | — | — |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rational sample-rate conversion with configurable interpolation/decimation ratios, automatic filter design, stable streaming/reset behavior, and accurate length/ratio reporting.

* **Tests**
  * Added comprehensive end-to-end tests validating multiple conversion ratios, accuracy (including up/down and round-trip), deterministic/reset behavior, chunked vs single-buffer consistency, and argument validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->