### PR TITLE
feat(windows): add Tukey, Gaussian, Dolph-Chebyshev, Bartlett-Hann windows

### DIFF
--- a/include/sw/dsp/windows/bartlett_hann.hpp
+++ b/include/sw/dsp/windows/bartlett_hann.hpp
@@ -1,0 +1,29 @@
+#pragma once
+// bartlett_hann.hpp: Bartlett-Hann window
+//
+// w[n] = 0.62 - 0.48 * |n/(N-1) - 0.5| + 0.38 * cos(2*pi * (n/(N-1) - 0.5))
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/math/constants.hpp>
+
+namespace sw::dsp {
+
+template <DspField T>
+mtl::vec::dense_vector<T> bartlett_hann_window(std::size_t length) {
+	mtl::vec::dense_vector<T> w(length);
+	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
+	double N = static_cast<double>(length - 1);
+	for (std::size_t n = 0; n < length; ++n) {
+		double x = static_cast<double>(n) / N - 0.5;
+		w[n] = static_cast<T>(0.62 - 0.48 * std::abs(x) + 0.38 * std::cos(two_pi * x));
+	}
+	return w;
+}
+
+} // namespace sw::dsp

--- a/include/sw/dsp/windows/dolph_chebyshev.hpp
+++ b/include/sw/dsp/windows/dolph_chebyshev.hpp
@@ -1,0 +1,82 @@
+#pragma once
+// dolph_chebyshev.hpp: Dolph-Chebyshev window
+//
+// Equiripple sidelobes at a specified attenuation level. Optimal in the
+// sense of narrowest main lobe for a given sidelobe level.
+//
+// Uses the DFT-based construction:
+//   W[k] = T_{N-1}(x0 * cos(pi*k/N)) / T_{N-1}(x0)
+// where T_n is the Chebyshev polynomial, x0 = cosh(acosh(10^(atten/20))/(N-1))
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/math/constants.hpp>
+
+namespace sw::dsp {
+
+namespace detail {
+
+inline double chebyshev_poly(int n, double x) {
+	if (std::abs(x) <= 1.0)
+		return std::cos(static_cast<double>(n) * std::acos(x));
+	return std::cosh(static_cast<double>(n) * std::acosh(std::abs(x)));
+}
+
+} // namespace detail
+
+template <DspField T>
+mtl::vec::dense_vector<T> dolph_chebyshev_window(std::size_t length,
+                                                  double attenuation_db = 100.0) {
+	mtl::vec::dense_vector<T> w(length);
+	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
+
+	int N = static_cast<int>(length);
+	int order = N - 1;
+	double atten_linear = std::pow(10.0, attenuation_db / 20.0);
+	double x0 = std::cosh(std::acosh(atten_linear) / static_cast<double>(order));
+
+	// Compute frequency-domain window W[k] via Chebyshev polynomial
+	// (-1)^k factor ensures the IDFT produces a real, symmetric result
+	std::vector<double> W(N);
+	for (int k = 0; k < N; ++k) {
+		double sign = (k % 2 == 0) ? 1.0 : -1.0;
+		double arg = x0 * std::cos(pi * static_cast<double>(k) / static_cast<double>(N));
+		W[k] = sign * detail::chebyshev_poly(order, arg) / atten_linear;
+	}
+
+	// Inverse DFT to get time-domain window (real-valued, symmetric)
+	std::vector<double> wn(N);
+	double max_val = 0.0;
+	for (int n = 0; n < N; ++n) {
+		double sum = 0.0;
+		for (int k = 0; k < N; ++k) {
+			sum += W[k] * std::cos(two_pi * static_cast<double>(k) *
+			       static_cast<double>(n) / static_cast<double>(N));
+		}
+		wn[n] = sum;
+		if (std::abs(sum) > max_val) max_val = std::abs(sum);
+	}
+
+	// Enforce symmetry then normalize to unity peak
+	for (int n = 0; n < N / 2; ++n) {
+		double avg = 0.5 * (wn[n] + wn[N - 1 - n]);
+		wn[n] = avg;
+		wn[N - 1 - n] = avg;
+	}
+	max_val = 0.0;
+	for (int n = 0; n < N; ++n) {
+		if (std::abs(wn[n]) > max_val) max_val = std::abs(wn[n]);
+	}
+	for (int n = 0; n < N; ++n) {
+		w[n] = static_cast<T>(wn[n] / max_val);
+	}
+	return w;
+}
+
+} // namespace sw::dsp

--- a/include/sw/dsp/windows/dolph_chebyshev.hpp
+++ b/include/sw/dsp/windows/dolph_chebyshev.hpp
@@ -25,7 +25,8 @@ namespace detail {
 inline double chebyshev_poly(int n, double x) {
 	if (std::abs(x) <= 1.0)
 		return std::cos(static_cast<double>(n) * std::acos(x));
-	return std::cosh(static_cast<double>(n) * std::acosh(std::abs(x)));
+	double val = std::cosh(static_cast<double>(n) * std::acosh(std::abs(x)));
+	return (x < 0.0 && (n % 2 != 0)) ? -val : val;
 }
 
 } // namespace detail

--- a/include/sw/dsp/windows/gaussian.hpp
+++ b/include/sw/dsp/windows/gaussian.hpp
@@ -1,0 +1,29 @@
+#pragma once
+// gaussian.hpp: Gaussian window
+//
+// w[n] = exp(-0.5 * ((n - (N-1)/2) / (sigma * (N-1)/2))^2)
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+template <DspField T>
+mtl::vec::dense_vector<T> gaussian_window(std::size_t length, double sigma = 0.4) {
+	mtl::vec::dense_vector<T> w(length);
+	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
+	double half_N = static_cast<double>(length - 1) * 0.5;
+	double denom = sigma * half_N;
+	for (std::size_t n = 0; n < length; ++n) {
+		double x = (static_cast<double>(n) - half_N) / denom;
+		w[n] = static_cast<T>(std::exp(-0.5 * x * x));
+	}
+	return w;
+}
+
+} // namespace sw::dsp

--- a/include/sw/dsp/windows/gaussian.hpp
+++ b/include/sw/dsp/windows/gaussian.hpp
@@ -17,6 +17,7 @@ template <DspField T>
 mtl::vec::dense_vector<T> gaussian_window(std::size_t length, double sigma = 0.4) {
 	mtl::vec::dense_vector<T> w(length);
 	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
+	if (sigma <= 0.0) sigma = 0.4;
 	double half_N = static_cast<double>(length - 1) * 0.5;
 	double denom = sigma * half_N;
 	for (std::size_t n = 0; n < length; ++n) {

--- a/include/sw/dsp/windows/tukey.hpp
+++ b/include/sw/dsp/windows/tukey.hpp
@@ -1,0 +1,51 @@
+#pragma once
+// tukey.hpp: Tukey (cosine-tapered) window
+//
+// w[n] = { 0.5 * (1 - cos(2*pi*n / (alpha*(N-1))))                  for 0 <= n < alpha*(N-1)/2
+//        { 1                                                          for alpha*(N-1)/2 <= n <= (N-1)*(1-alpha/2)
+//        { 0.5 * (1 - cos(2*pi*(N-1-n) / (alpha*(N-1))))             for (N-1)*(1-alpha/2) < n <= N-1
+//
+// alpha=0 → rectangular, alpha=1 → Hanning
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/math/constants.hpp>
+
+namespace sw::dsp {
+
+template <DspField T>
+mtl::vec::dense_vector<T> tukey_window(std::size_t length, double alpha = 0.5) {
+	mtl::vec::dense_vector<T> w(length);
+	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
+	if (alpha <= 0.0) {
+		for (std::size_t n = 0; n < length; ++n) w[n] = T{1};
+		return w;
+	}
+	if (alpha >= 1.0) {
+		double N = static_cast<double>(length - 1);
+		for (std::size_t n = 0; n < length; ++n) {
+			w[n] = static_cast<T>(0.5 * (1.0 - std::cos(two_pi * static_cast<double>(n) / N)));
+		}
+		return w;
+	}
+	double N = static_cast<double>(length - 1);
+	double half_taper = alpha * N * 0.5;
+	for (std::size_t n = 0; n < length; ++n) {
+		double nd = static_cast<double>(n);
+		if (nd < half_taper) {
+			w[n] = static_cast<T>(0.5 * (1.0 - std::cos(two_pi * nd / (alpha * N))));
+		} else if (nd > N - half_taper) {
+			w[n] = static_cast<T>(0.5 * (1.0 - std::cos(two_pi * (N - nd) / (alpha * N))));
+		} else {
+			w[n] = T{1};
+		}
+	}
+	return w;
+}
+
+} // namespace sw::dsp

--- a/include/sw/dsp/windows/windows.hpp
+++ b/include/sw/dsp/windows/windows.hpp
@@ -11,3 +11,7 @@
 #include <sw/dsp/windows/blackman.hpp>
 #include <sw/dsp/windows/kaiser.hpp>
 #include <sw/dsp/windows/flat_top.hpp>
+#include <sw/dsp/windows/tukey.hpp>
+#include <sw/dsp/windows/gaussian.hpp>
+#include <sw/dsp/windows/dolph_chebyshev.hpp>
+#include <sw/dsp/windows/bartlett_hann.hpp>

--- a/tests/test_windows.cpp
+++ b/tests/test_windows.cpp
@@ -98,6 +98,79 @@ void test_flat_top() {
 	std::cout << "  flat_top: passed\n";
 }
 
+void test_tukey() {
+	auto w = tukey_window<double>(64, 0.5);
+	if (!(w.size() == 64)) throw std::runtime_error("test failed: tukey size");
+	// Symmetric
+	if (!(near(w[0], w[63], 1e-10))) throw std::runtime_error("test failed: tukey symmetry");
+	// Center should be 1.0 (flat region)
+	if (!(near(w[31], 1.0, 1e-10) || near(w[32], 1.0, 1e-10)))
+		throw std::runtime_error("test failed: tukey center should be 1.0");
+	// alpha=0 should give rectangular
+	auto w0 = tukey_window<double>(64, 0.0);
+	if (!(near(w0[0], 1.0, 1e-10))) throw std::runtime_error("test failed: tukey alpha=0");
+	// alpha=1 should match Hanning (endpoints near zero)
+	auto w1 = tukey_window<double>(64, 1.0);
+	if (!(near(w1[0], 0.0, 1e-10))) throw std::runtime_error("test failed: tukey alpha=1 endpoint");
+	std::cout << "  tukey: passed\n";
+}
+
+void test_gaussian() {
+	auto w = gaussian_window<double>(64, 0.4);
+	if (!(w.size() == 64)) throw std::runtime_error("test failed: gaussian size");
+	// Symmetric
+	if (!(near(w[0], w[63], 1e-10))) throw std::runtime_error("test failed: gaussian symmetry");
+	// Peak at center = 1.0
+	double center = static_cast<double>(w[31]);
+	double center2 = static_cast<double>(w[32]);
+	if (!(near(center, 1.0, 0.01) || near(center2, 1.0, 0.01)))
+		throw std::runtime_error("test failed: gaussian peak");
+	// Endpoints should be small for sigma=0.4
+	if (!(w[0] < 0.1)) throw std::runtime_error("test failed: gaussian endpoint");
+	// Larger sigma -> wider window (less attenuation at edges)
+	auto w_wide = gaussian_window<double>(64, 1.0);
+	if (!(w_wide[0] > w[0]))
+		throw std::runtime_error("test failed: gaussian sigma=1.0 should be wider");
+	std::cout << "  gaussian: passed\n";
+}
+
+void test_dolph_chebyshev() {
+	auto w = dolph_chebyshev_window<double>(64, 100.0);
+	if (!(w.size() == 64)) throw std::runtime_error("test failed: dolph_chebyshev size");
+	// Symmetric
+	if (!(near(w[0], w[63], 1e-6))) throw std::runtime_error("test failed: dolph_chebyshev symmetry");
+	// Peak = 1.0 (normalized)
+	double max_val = 0;
+	for (std::size_t i = 0; i < 64; ++i) {
+		if (static_cast<double>(w[i]) > max_val)
+			max_val = static_cast<double>(w[i]);
+	}
+	if (!(near(max_val, 1.0, 1e-6)))
+		throw std::runtime_error("test failed: dolph_chebyshev peak should be 1.0");
+	// All values should be positive for reasonable attenuation
+	for (std::size_t i = 0; i < 64; ++i) {
+		if (!(static_cast<double>(w[i]) > -0.01))
+			throw std::runtime_error("test failed: dolph_chebyshev negative value at " +
+			                         std::to_string(i));
+	}
+	std::cout << "  dolph_chebyshev: passed\n";
+}
+
+void test_bartlett_hann() {
+	auto w = bartlett_hann_window<double>(64);
+	if (!(w.size() == 64)) throw std::runtime_error("test failed: bartlett_hann size");
+	// Symmetric
+	if (!(near(w[0], w[63], 1e-10)))
+		throw std::runtime_error("test failed: bartlett_hann symmetry");
+	// Endpoints should be small (zero at n=0 for this formula)
+	if (!(w[0] >= 0.0 && w[0] < 0.2))
+		throw std::runtime_error("test failed: bartlett_hann endpoint");
+	// Peak near center
+	if (!(w[31] > 0.9 || w[32] > 0.9))
+		throw std::runtime_error("test failed: bartlett_hann peak");
+	std::cout << "  bartlett_hann: passed\n";
+}
+
 void test_apply_window() {
 	auto sig = sine<double>(64, 1.0, 64.0);
 	auto win = hamming_window<double>(64);
@@ -184,6 +257,10 @@ int main() {
 		test_blackman();
 		test_kaiser();
 		test_flat_top();
+		test_tukey();
+		test_gaussian();
+		test_dolph_chebyshev();
+		test_bartlett_hann();
 		test_apply_window();
 		test_window_float();
 


### PR DESCRIPTION
## Summary
- Adds four new window functions: Tukey (cosine-tapered), Gaussian, Dolph-Chebyshev (equiripple sidelobes), and Bartlett-Hann
- All windows are `DspField`-templated, symmetric, and normalized to unity peak
- Extended `test_windows.cpp` with tests for size, symmetry, peak, endpoints, and parameter variations

## Changes
- `include/sw/dsp/windows/tukey.hpp` — cosine-tapered window with alpha parameter
- `include/sw/dsp/windows/gaussian.hpp` — Gaussian window with sigma parameter
- `include/sw/dsp/windows/dolph_chebyshev.hpp` — equiripple sidelobe window via inverse DFT of Chebyshev polynomial
- `include/sw/dsp/windows/bartlett_hann.hpp` — triangular-cosine hybrid window
- `include/sw/dsp/windows/windows.hpp` — added includes for new windows
- `tests/test_windows.cpp` — added test_tukey, test_gaussian, test_dolph_chebyshev, test_bartlett_hann

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_windows | OK | PASS (16/16) | OK | PASS (16/16) |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Four new window functions added for signal processing: Bartlett–Hann, Dolph–Chebyshev, Gaussian, and Tukey. These provide varied tapering, attenuation and symmetry behaviors and are available through the central windows include.

* **Tests**
  * Added unit tests validating sizes, symmetry, peaks/centers and endpoint/attenuation properties for all new windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->