### PR TITLE
feat(acquisition): CIC decimation and interpolation filters

### DIFF
--- a/docs-site/src/content/docs/acquisition/cic.md
+++ b/docs-site/src/content/docs/acquisition/cic.md
@@ -22,7 +22,7 @@ high-speed data acquisition systems.
 A typical high-rate acquisition chain processes an ADC output through several
 stages of decimation before the signal reaches the application:
 
-```
+```text
 ┌─────────┐    ┌─────────────┐    ┌───────────┐    ┌──────────────┐    ┌────────┐
 │ ADC     │───>│ CIC         │───>│ CIC Comp  │───>│ Half-Band    │───>│ Final  │
 │ 1 GSPS  │    │ Decimator   │    │ Filter    │    │ Decimator    │    │ FIR    │

--- a/docs-site/src/content/docs/acquisition/cic.md
+++ b/docs-site/src/content/docs/acquisition/cic.md
@@ -1,0 +1,237 @@
+---
+title: CIC Filters
+description: Cascaded Integrator-Comb decimation and interpolation filters for high-rate data acquisition
+---
+
+## History and Motivation
+
+The Cascaded Integrator-Comb (CIC) filter was introduced by Eugene Hogenauer
+in 1981 to address a fundamental problem in digital receiver design: how to
+decimate a high-speed ADC stream by a large factor without multiplications.
+
+At GHz sampling rates, even a single multiplier per clock cycle is expensive
+in silicon area and power. Hogenauer showed that a cascade of integrators
+(accumulators) followed by a cascade of combs (differentiators) — separated
+by a rate change — implements a decimation or interpolation filter using
+**only additions and subtractions**. This made CIC filters the universal
+first stage in digital down-converters, software-defined radios, and
+high-speed data acquisition systems.
+
+## Where CIC Fits in the Pipeline
+
+A typical high-rate acquisition chain processes an ADC output through several
+stages of decimation before the signal reaches the application:
+
+```
+┌─────────┐    ┌─────────────┐    ┌───────────┐    ┌──────────────┐    ┌────────┐
+│ ADC     │───>│ CIC         │───>│ CIC Comp  │───>│ Half-Band    │───>│ Final  │
+│ 1 GSPS  │    │ Decimator   │    │ Filter    │    │ Decimator    │    │ FIR    │
+│ 12-bit  │    │ ÷64         │    │ (droop)   │    │ ÷2           │    │ ÷4     │
+└─────────┘    └─────────────┘    └───────────┘    └──────────────┘    └────────┘
+  SampleT          StateT            CoeffT            CoeffT           CoeffT
+  (narrow)         (wide)            /StateT           /StateT          /StateT
+```
+
+The CIC decimator handles the bulk of the rate reduction (often 16× to 256×)
+at the full ADC clock rate. Subsequent stages operate at the reduced rate
+where multipliers are affordable.
+
+## Theory
+
+### Structure
+
+A CIC decimation filter of order $M$ with decimation ratio $R$ and
+differential delay $D$ consists of:
+
+1. **$M$ integrator stages** running at the input (high) rate:
+
+$$
+H_I(z) = \frac{1}{1 - z^{-1}}
+$$
+
+2. **Downsampling by $R$**: keep every $R$-th sample
+
+3. **$M$ comb stages** running at the output (decimated) rate:
+
+$$
+H_C(z) = 1 - z^{-D}
+$$
+
+The combined transfer function is:
+
+$$
+H(z) = \left(\frac{1 - z^{-RD}}{1 - z^{-1}}\right)^M
+$$
+
+### DC Gain
+
+At DC ($z = 1$), the transfer function evaluates to:
+
+$$
+H(1) = (RD)^M
+$$
+
+For example, with $R=8$, $M=3$, $D=1$: DC gain $= 8^3 = 512$.
+
+### Bit Growth
+
+The CIC filter's DC gain determines the required accumulator width.
+To prevent overflow, the state registers must accommodate:
+
+$$
+B_{\text{out}} = B_{\text{in}} + M \cdot \lceil\log_2(RD)\rceil
+$$
+
+additional bits beyond the input sample width. This formula directly
+drives the `StateScalar` selection in the three-scalar model.
+
+| Configuration | Bit Growth | DC Gain | Min StateScalar |
+|--------------|-----------|---------|----------------|
+| $R=4, M=1, D=1$ | 2 bits | 4 | 14-bit for 12-bit ADC |
+| $R=8, M=3, D=1$ | 9 bits | 512 | 21-bit for 12-bit ADC |
+| $R=16, M=4, D=1$ | 16 bits | 65536 | 28-bit for 12-bit ADC |
+| $R=64, M=5, D=1$ | 30 bits | ~10⁹ | 42-bit for 12-bit ADC |
+
+### Frequency Response
+
+The magnitude response of a CIC filter is:
+
+$$
+|H(f)| = \left|\frac{\sin(\pi R D f)}{\sin(\pi f)}\right|^M
+$$
+
+This is a **sinc-like lowpass** with:
+- Main lobe width proportional to $1/(RD)$
+- Side lobes that decrease with $M$
+- **Passband droop** that increases toward the band edge
+
+The passband droop is the CIC's main limitation — it must be compensated
+by a subsequent FIR filter (the "CIC compensation filter") whose response
+is the inverse of the CIC's passband rolloff.
+
+### Interpolation
+
+A CIC interpolator reverses the structure:
+
+1. **$M$ comb stages** at the low (input) rate
+2. **Upsampling by $R$**: insert $R-1$ zeros between samples
+3. **$M$ integrator stages** at the high (output) rate
+
+The transfer function is identical. For each low-rate input sample,
+$R$ high-rate output samples are produced.
+
+## API
+
+### CIC Decimator
+
+```cpp
+#include <sw/dsp/acquisition/cic.hpp>
+
+using namespace sw::dsp;
+
+// CICDecimator<StateScalar, SampleScalar>
+// R=8 decimation, M=3 stages, D=1 differential delay
+CICDecimator<double> cic(8, 3, 1);
+
+// Process one sample at a time
+bool ready = cic.push(sample);
+if (ready) {
+    double output = cic.output();
+}
+
+// Or process a block
+std::vector<double> input = /* ... */;
+std::vector<double> output;
+cic.process_block(std::span<const double>(input), output);
+```
+
+### CIC Interpolator
+
+```cpp
+// CICInterpolator<StateScalar, SampleScalar>
+CICInterpolator<double> interp(8, 3, 1);
+
+// Feed one low-rate sample, get R high-rate samples
+interp.push(sample);
+for (int r = 0; r < 8; ++r) {
+    double y = interp.output();
+}
+
+// Or process a block (produces input.size() * R outputs)
+std::vector<double> input = /* ... */;
+std::vector<double> output;
+interp.process_block(std::span<const double>(input), output);
+```
+
+### Utility Functions
+
+```cpp
+// Compute required bit growth
+int growth = cic_bit_growth(3, 8, 1);  // M=3, R=8, D=1 → 9
+
+// Query filter properties
+cic.decimation_ratio();    // R
+cic.num_stages();          // M
+cic.differential_delay();  // D
+cic.dc_gain();             // (R*D)^M
+cic.bit_growth();          // M * ceil(log2(R*D))
+cic.reset();               // Clear all state
+```
+
+## Example: 12-bit ADC Decimation
+
+```cpp
+#include <sw/dsp/acquisition/cic.hpp>
+#include <sw/universal/number/fixpnt/fixpnt.hpp>
+#include <sw/universal/number/posit/posit.hpp>
+
+using namespace sw::dsp;
+using namespace sw::universal;
+
+// 12-bit ADC → CIC decimate by 64, 4 stages
+// Bit growth = 4 * ceil(log2(64)) = 24
+// Need 12 + 24 = 36-bit accumulator minimum
+
+// Fixed-point: 40-bit state, 12-bit samples (classic approach)
+using state_fx = fixpnt<40, 36>;
+using sample_fx = fixpnt<12, 11>;
+CICDecimator<state_fx, sample_fx> cic_fixed(64, 4, 1);
+
+// Posit: 32-bit state may suffice due to tapered precision
+using state_p = posit<32, 2>;
+using sample_p = posit<16, 2>;
+CICDecimator<state_p, sample_p> cic_posit(64, 4, 1);
+
+// Double: reference (no overflow concerns)
+CICDecimator<double> cic_ref(64, 4, 1);
+```
+
+## Precision Considerations
+
+The CIC filter is a natural showcase for the three-scalar model:
+
+- **SampleScalar** matches the ADC bit depth (8-16 bits). Narrow types
+  minimize memory bandwidth at the full sampling rate.
+
+- **StateScalar** must accommodate the full bit growth. For a 5-stage
+  CIC with $R=64$, this is 30 extra bits — a 12-bit ADC needs a 42-bit
+  accumulator. Fixed-point types must be sized precisely; posit types
+  may tolerate fewer bits due to tapered precision near zero.
+
+- The CIC requires **no coefficients** (no `CoeffScalar`), since all
+  operations are unit additions and subtractions. This is unique among
+  DSP filter structures.
+
+### Overflow Behavior
+
+When `StateScalar` is too narrow, the integrators overflow. Unlike FIR
+filters where coefficient errors cause gradual degradation, CIC overflow
+is **catastrophic** — the output becomes meaningless. This makes the
+bit-growth formula critical for correct design.
+
+With wrapping arithmetic (as in hardware fixed-point), CIC filters can
+exploit modular arithmetic: if the final output fits in the output word
+width, intermediate overflow in the integrators is harmless because the
+comb stages recover the correct result via modular subtraction. This
+property holds for two's-complement integers and `fixpnt` types but
+**not** for floating-point, posit, or other non-wrapping types.

--- a/include/sw/dsp/acquisition/acquisition.hpp
+++ b/include/sw/dsp/acquisition/acquisition.hpp
@@ -1,0 +1,7 @@
+#pragma once
+// acquisition.hpp: umbrella header for high-rate data acquisition module
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/acquisition/cic.hpp>

--- a/include/sw/dsp/acquisition/cic.hpp
+++ b/include/sw/dsp/acquisition/cic.hpp
@@ -1,0 +1,245 @@
+#pragma once
+// cic.hpp: Cascaded Integrator-Comb (CIC) decimation and interpolation filters
+//
+// CIC filters perform sample-rate conversion using only additions and
+// subtractions — no multiplications. This makes them ideal for the first
+// decimation stage after a high-speed ADC where the input rate can exceed
+// GHz and multiplier resources are scarce.
+//
+// Two-scalar parameterization:
+//   StateScalar  — integrator/comb accumulators (must accommodate bit growth)
+//   SampleScalar — input/output samples
+//
+// Bit growth: B_out = B_in + M * ceil(log2(R * D))
+// where R = decimation ratio, D = differential delay, M = number of stages.
+// StateScalar must be at least B_out bits wide to avoid overflow.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <vector>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp {
+
+// Compute the bit growth for a CIC filter: M * ceil(log2(R * D))
+inline int cic_bit_growth(int stages, int decimation, int delay = 1) {
+	if (stages <= 0 || decimation <= 0 || delay <= 0) return 0;
+	return stages * static_cast<int>(std::ceil(
+		std::log2(static_cast<double>(decimation) * static_cast<double>(delay))));
+}
+
+// CIC decimation filter
+//
+// Structure: M integrator stages (full rate) -> downsample by R -> M comb stages (decimated rate)
+//
+// The integrator sections run at the input sample rate, accumulating
+// every sample. After R input samples, one output is produced by
+// passing the integrator output through M comb (differencing) stages.
+template <DspScalar StateScalar = double,
+          DspScalar SampleScalar = StateScalar>
+class CICDecimator {
+public:
+	using state_scalar  = StateScalar;
+	using sample_scalar = SampleScalar;
+
+	CICDecimator(int decimation_ratio, int num_stages, int differential_delay = 1)
+		: R_(decimation_ratio), M_(num_stages), D_(differential_delay),
+		  integrators_(static_cast<std::size_t>(num_stages), StateScalar{}),
+		  comb_state_(static_cast<std::size_t>(num_stages), StateScalar{}),
+		  comb_delay_(static_cast<std::size_t>(num_stages) *
+		              static_cast<std::size_t>(differential_delay), StateScalar{}),
+		  comb_write_(static_cast<std::size_t>(num_stages), 0),
+		  count_(0) {
+		if (decimation_ratio < 1)
+			throw std::invalid_argument("CICDecimator: decimation ratio must be >= 1");
+		if (num_stages < 1)
+			throw std::invalid_argument("CICDecimator: number of stages must be >= 1");
+		if (differential_delay < 1)
+			throw std::invalid_argument("CICDecimator: differential delay must be >= 1");
+	}
+
+	// Feed one input sample. Returns true when an output is ready.
+	bool push(SampleScalar in) {
+		StateScalar x = static_cast<StateScalar>(in);
+
+		// Integrator cascade (runs at full rate)
+		for (std::size_t i = 0; i < static_cast<std::size_t>(M_); ++i) {
+			integrators_[i] = integrators_[i] + x;
+			x = integrators_[i];
+		}
+
+		++count_;
+		if (count_ < R_) return false;
+		count_ = 0;
+
+		// Comb cascade (runs at decimated rate)
+		for (std::size_t i = 0; i < static_cast<std::size_t>(M_); ++i) {
+			std::size_t base = i * static_cast<std::size_t>(D_);
+			std::size_t wi = comb_write_[i];
+			StateScalar delayed = comb_delay_[base + wi];
+			comb_delay_[base + wi] = x;
+			comb_write_[i] = (wi + 1) % static_cast<std::size_t>(D_);
+			x = x - delayed;
+		}
+
+		last_output_ = x;
+		return true;
+	}
+
+	// Retrieve the most recent output (valid after push() returns true)
+	SampleScalar output() const {
+		return static_cast<SampleScalar>(last_output_);
+	}
+
+	// Process a block of input samples, appending decimated output
+	void process_block(std::span<const SampleScalar> input,
+	                   std::vector<SampleScalar>& output) {
+		for (auto s : input) {
+			if (push(s)) {
+				output.push_back(this->output());
+			}
+		}
+	}
+
+	// Reset all internal state
+	void reset() {
+		for (auto& v : integrators_) v = StateScalar{};
+		for (auto& v : comb_state_)  v = StateScalar{};
+		for (auto& v : comb_delay_)  v = StateScalar{};
+		for (auto& v : comb_write_)  v = 0;
+		count_ = 0;
+		last_output_ = StateScalar{};
+	}
+
+	int decimation_ratio()    const { return R_; }
+	int num_stages()          const { return M_; }
+	int differential_delay()  const { return D_; }
+	int bit_growth()          const { return cic_bit_growth(M_, R_, D_); }
+
+	// DC gain = (R * D)^M
+	double dc_gain() const {
+		return std::pow(static_cast<double>(R_) * static_cast<double>(D_),
+		                static_cast<double>(M_));
+	}
+
+private:
+	int R_;  // decimation ratio
+	int M_;  // number of stages
+	int D_;  // differential delay
+
+	std::vector<StateScalar> integrators_;
+	std::vector<StateScalar> comb_state_;
+	std::vector<StateScalar> comb_delay_;
+	std::vector<std::size_t> comb_write_;
+	int count_;
+	StateScalar last_output_{};
+};
+
+// CIC interpolation filter
+//
+// Structure: M comb stages (low rate) -> upsample by R -> M integrator stages (high rate)
+//
+// For each low-rate input sample, R output samples are produced.
+// The comb stages run at the low rate, then R-1 zeros are inserted,
+// and the integrator cascade smooths the result at the high output rate.
+template <DspScalar StateScalar = double,
+          DspScalar SampleScalar = StateScalar>
+class CICInterpolator {
+public:
+	using state_scalar  = StateScalar;
+	using sample_scalar = SampleScalar;
+
+	CICInterpolator(int interpolation_ratio, int num_stages, int differential_delay = 1)
+		: R_(interpolation_ratio), M_(num_stages), D_(differential_delay),
+		  integrators_(static_cast<std::size_t>(num_stages), StateScalar{}),
+		  comb_delay_(static_cast<std::size_t>(num_stages) *
+		              static_cast<std::size_t>(differential_delay), StateScalar{}),
+		  comb_write_(static_cast<std::size_t>(num_stages), 0),
+		  phase_(0) {
+		if (interpolation_ratio < 1)
+			throw std::invalid_argument("CICInterpolator: interpolation ratio must be >= 1");
+		if (num_stages < 1)
+			throw std::invalid_argument("CICInterpolator: number of stages must be >= 1");
+		if (differential_delay < 1)
+			throw std::invalid_argument("CICInterpolator: differential delay must be >= 1");
+	}
+
+	// Feed one low-rate input sample. Call output() R times to get interpolated samples.
+	void push(SampleScalar in) {
+		// Comb cascade (runs at low rate)
+		StateScalar x = static_cast<StateScalar>(in);
+		for (std::size_t i = 0; i < static_cast<std::size_t>(M_); ++i) {
+			std::size_t base = i * static_cast<std::size_t>(D_);
+			std::size_t wi = comb_write_[i];
+			StateScalar delayed = comb_delay_[base + wi];
+			comb_delay_[base + wi] = x;
+			comb_write_[i] = (wi + 1) % static_cast<std::size_t>(D_);
+			x = x - delayed;
+		}
+		comb_output_ = x;
+		phase_ = 0;
+	}
+
+	// Get next interpolated output sample. Call R times per push().
+	SampleScalar output() {
+		StateScalar x = (phase_ == 0) ? comb_output_ : StateScalar{};
+
+		// Integrator cascade (runs at high rate)
+		for (std::size_t i = 0; i < static_cast<std::size_t>(M_); ++i) {
+			integrators_[i] = integrators_[i] + x;
+			x = integrators_[i];
+		}
+
+		++phase_;
+		return static_cast<SampleScalar>(x);
+	}
+
+	// Process a block: for each input sample, produce R output samples
+	void process_block(std::span<const SampleScalar> input,
+	                   std::vector<SampleScalar>& out) {
+		for (auto s : input) {
+			push(s);
+			for (int r = 0; r < R_; ++r) {
+				out.push_back(output());
+			}
+		}
+	}
+
+	void reset() {
+		for (auto& v : integrators_) v = StateScalar{};
+		for (auto& v : comb_delay_)  v = StateScalar{};
+		for (auto& v : comb_write_)  v = 0;
+		phase_ = 0;
+		comb_output_ = StateScalar{};
+	}
+
+	int interpolation_ratio()  const { return R_; }
+	int num_stages()           const { return M_; }
+	int differential_delay()   const { return D_; }
+	int bit_growth()           const { return cic_bit_growth(M_, R_, D_); }
+
+	// The z-transform DC gain is (R*D)^M, same as the decimator.
+	// To normalize interpolator output, divide by (R*D)^M.
+	double dc_gain() const {
+		return std::pow(static_cast<double>(R_) * static_cast<double>(D_),
+		                static_cast<double>(M_));
+	}
+
+private:
+	int R_;
+	int M_;
+	int D_;
+
+	std::vector<StateScalar> integrators_;
+	std::vector<StateScalar> comb_delay_;
+	std::vector<std::size_t> comb_write_;
+	int phase_;
+	StateScalar comb_output_{};
+};
+
+} // namespace sw::dsp

--- a/include/sw/dsp/acquisition/cic.hpp
+++ b/include/sw/dsp/acquisition/cic.hpp
@@ -21,7 +21,9 @@
 #include <cstddef>
 #include <span>
 #include <stdexcept>
+#include <string>
 #include <vector>
+#include <mtl/vec/dense_vector.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
 
 namespace sw::dsp {
@@ -32,6 +34,17 @@ inline int cic_bit_growth(int stages, int decimation, int delay = 1) {
 	return stages * static_cast<int>(std::ceil(
 		std::log2(static_cast<double>(decimation) * static_cast<double>(delay))));
 }
+
+namespace detail {
+inline void validate_cic_params(int ratio, int stages, int delay, const char* name) {
+	if (ratio < 1)
+		throw std::invalid_argument(std::string(name) + ": ratio must be >= 1");
+	if (stages < 1)
+		throw std::invalid_argument(std::string(name) + ": number of stages must be >= 1");
+	if (delay < 1)
+		throw std::invalid_argument(std::string(name) + ": differential delay must be >= 1");
+}
+} // namespace detail
 
 // CIC decimation filter
 //
@@ -48,19 +61,15 @@ public:
 	using sample_scalar = SampleScalar;
 
 	CICDecimator(int decimation_ratio, int num_stages, int differential_delay = 1)
-		: R_(decimation_ratio), M_(num_stages), D_(differential_delay),
+		: R_((detail::validate_cic_params(decimation_ratio, num_stages,
+		       differential_delay, "CICDecimator"), decimation_ratio)),
+		  M_(num_stages), D_(differential_delay),
 		  integrators_(static_cast<std::size_t>(num_stages), StateScalar{}),
 		  comb_state_(static_cast<std::size_t>(num_stages), StateScalar{}),
 		  comb_delay_(static_cast<std::size_t>(num_stages) *
 		              static_cast<std::size_t>(differential_delay), StateScalar{}),
 		  comb_write_(static_cast<std::size_t>(num_stages), 0),
 		  count_(0) {
-		if (decimation_ratio < 1)
-			throw std::invalid_argument("CICDecimator: decimation ratio must be >= 1");
-		if (num_stages < 1)
-			throw std::invalid_argument("CICDecimator: number of stages must be >= 1");
-		if (differential_delay < 1)
-			throw std::invalid_argument("CICDecimator: differential delay must be >= 1");
 	}
 
 	// Feed one input sample. Returns true when an output is ready.
@@ -104,6 +113,19 @@ public:
 				output.push_back(this->output());
 			}
 		}
+	}
+
+	// Dense-vector overload for signal containers
+	mtl::vec::dense_vector<SampleScalar> process_block(
+			const mtl::vec::dense_vector<SampleScalar>& input) {
+		std::vector<SampleScalar> tmp;
+		tmp.reserve(input.size() / static_cast<std::size_t>(R_) + 1);
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			if (push(input[i])) tmp.push_back(this->output());
+		}
+		mtl::vec::dense_vector<SampleScalar> result(tmp.size());
+		for (std::size_t i = 0; i < tmp.size(); ++i) result[i] = tmp[i];
+		return result;
 	}
 
 	// Reset all internal state
@@ -155,18 +177,14 @@ public:
 	using sample_scalar = SampleScalar;
 
 	CICInterpolator(int interpolation_ratio, int num_stages, int differential_delay = 1)
-		: R_(interpolation_ratio), M_(num_stages), D_(differential_delay),
+		: R_((detail::validate_cic_params(interpolation_ratio, num_stages,
+		       differential_delay, "CICInterpolator"), interpolation_ratio)),
+		  M_(num_stages), D_(differential_delay),
 		  integrators_(static_cast<std::size_t>(num_stages), StateScalar{}),
 		  comb_delay_(static_cast<std::size_t>(num_stages) *
 		              static_cast<std::size_t>(differential_delay), StateScalar{}),
 		  comb_write_(static_cast<std::size_t>(num_stages), 0),
 		  phase_(0) {
-		if (interpolation_ratio < 1)
-			throw std::invalid_argument("CICInterpolator: interpolation ratio must be >= 1");
-		if (num_stages < 1)
-			throw std::invalid_argument("CICInterpolator: number of stages must be >= 1");
-		if (differential_delay < 1)
-			throw std::invalid_argument("CICInterpolator: differential delay must be >= 1");
 	}
 
 	// Feed one low-rate input sample. Call output() R times to get interpolated samples.
@@ -208,6 +226,19 @@ public:
 				out.push_back(output());
 			}
 		}
+	}
+
+	// Dense-vector overload for signal containers
+	mtl::vec::dense_vector<SampleScalar> process_block(
+			const mtl::vec::dense_vector<SampleScalar>& input) {
+		std::size_t out_size = input.size() * static_cast<std::size_t>(R_);
+		mtl::vec::dense_vector<SampleScalar> result(out_size);
+		std::size_t idx = 0;
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			push(input[i]);
+			for (int r = 0; r < R_; ++r) result[idx++] = output();
+		}
+		return result;
 	}
 
 	void reset() {

--- a/include/sw/dsp/dsp.hpp
+++ b/include/sw/dsp/dsp.hpp
@@ -58,6 +58,9 @@
 // Image processing
 #include <sw/dsp/image/image.hpp>
 
+// High-rate data acquisition
+#include <sw/dsp/acquisition/acquisition.hpp>
+
 // Numerical analysis
 #include <sw/dsp/analysis/analysis.hpp>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,3 +84,6 @@ dsp_add_test(test_src)
 
 # Type projection/embedding
 dsp_add_test(test_projection)
+
+# CIC decimation/interpolation (Issue #86)
+dsp_add_test(test_cic)

--- a/tests/test_cic.cpp
+++ b/tests/test_cic.cpp
@@ -1,0 +1,394 @@
+// test_cic.cpp: test CIC decimation and interpolation filters
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/acquisition/cic.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace sw::dsp;
+
+bool near(double a, double b, double eps = 1e-6) {
+	return std::abs(a - b) < eps;
+}
+
+// ============================================================================
+// Bit growth calculation
+// ============================================================================
+
+void test_bit_growth() {
+	// Single stage, R=4, D=1: ceil(log2(4)) = 2
+	if (cic_bit_growth(1, 4, 1) != 2)
+		throw std::runtime_error("test failed: bit_growth M=1 R=4 D=1");
+
+	// 3 stages, R=8, D=1: 3 * ceil(log2(8)) = 3 * 3 = 9
+	if (cic_bit_growth(3, 8, 1) != 9)
+		throw std::runtime_error("test failed: bit_growth M=3 R=8 D=1");
+
+	// 4 stages, R=16, D=2: 4 * ceil(log2(32)) = 4 * 5 = 20
+	if (cic_bit_growth(4, 16, 2) != 20)
+		throw std::runtime_error("test failed: bit_growth M=4 R=16 D=2");
+
+	// 5 stages, R=64, D=1: 5 * ceil(log2(64)) = 5 * 6 = 30
+	if (cic_bit_growth(5, 64, 1) != 30)
+		throw std::runtime_error("test failed: bit_growth M=5 R=64 D=1");
+
+	// Edge: R=1 => log2(1)=0, growth=0
+	if (cic_bit_growth(3, 1, 1) != 0)
+		throw std::runtime_error("test failed: bit_growth M=3 R=1 D=1");
+
+	std::cout << "  bit_growth: passed\n";
+}
+
+// ============================================================================
+// DC gain
+// ============================================================================
+
+void test_dc_gain() {
+	CICDecimator<double> cic(4, 3, 1);
+	// DC gain = (R*D)^M = 4^3 = 64
+	if (!near(cic.dc_gain(), 64.0))
+		throw std::runtime_error("test failed: dc_gain R=4 M=3");
+
+	CICDecimator<double> cic2(8, 2, 2);
+	// DC gain = (8*2)^2 = 256
+	if (!near(cic2.dc_gain(), 256.0))
+		throw std::runtime_error("test failed: dc_gain R=8 M=2 D=2");
+
+	std::cout << "  dc_gain: passed\n";
+}
+
+// ============================================================================
+// Single-stage decimation impulse response
+// ============================================================================
+
+void test_single_stage_impulse() {
+	// CIC with M=1, R=4, D=1 is a moving-average of length R=4
+	// Impulse response: feed 1 followed by zeros
+	// The integrator accumulates the running sum.
+	// After R=4 samples, the comb differences current - delayed (D=1 samples ago at decimated rate).
+	CICDecimator<double> cic(4, 1, 1);
+
+	// Feed impulse: x = {1, 0, 0, 0, 0, 0, 0, 0, ...}
+	std::vector<double> input(16, 0.0);
+	input[0] = 1.0;
+	std::vector<double> output;
+	cic.process_block(std::span<const double>(input), output);
+
+	// Expected: 4 output samples (16/4)
+	if (output.size() != 4)
+		throw std::runtime_error("test failed: impulse output size = " +
+			std::to_string(output.size()));
+
+	// First output: integrator sees {1,0,0,0}, sum=1, comb: 1-0 = 1
+	if (!near(output[0], 1.0))
+		throw std::runtime_error("test failed: impulse y[0] = " +
+			std::to_string(output[0]));
+
+	// Subsequent outputs: integrator still at 1 (no new input), comb: 1-1 = 0
+	for (std::size_t i = 1; i < output.size(); ++i) {
+		if (!near(output[i], 0.0))
+			throw std::runtime_error("test failed: impulse y[" +
+				std::to_string(i) + "] = " + std::to_string(output[i]));
+	}
+
+	std::cout << "  single_stage_impulse: passed\n";
+}
+
+// ============================================================================
+// DC input: output should equal DC * gain
+// ============================================================================
+
+void test_dc_response() {
+	// M=2, R=4, D=1: DC gain = 4^2 = 16
+	CICDecimator<double> cic(4, 2, 1);
+	double dc_in = 1.0;
+
+	// Feed enough samples for the filter to settle
+	// After settling, each output should be dc_in * (R*D)^M = 16
+	std::vector<double> input(100, dc_in);
+	std::vector<double> output;
+	cic.process_block(std::span<const double>(input), output);
+
+	// Check last few outputs (after settling)
+	double expected = cic.dc_gain() * dc_in;
+	for (std::size_t i = output.size() - 5; i < output.size(); ++i) {
+		if (!near(output[i], expected, 1e-9))
+			throw std::runtime_error("test failed: dc_response y[" +
+				std::to_string(i) + "] = " + std::to_string(output[i]) +
+				", expected " + std::to_string(expected));
+	}
+
+	std::cout << "  dc_response: passed\n";
+}
+
+// ============================================================================
+// Multi-stage with D>1
+// ============================================================================
+
+void test_differential_delay() {
+	// M=1, R=2, D=2: effectively a moving sum over R*D=4 samples, decimated by 2
+	CICDecimator<double> cic(2, 1, 2);
+
+	// DC gain = (2*2)^1 = 4
+	if (!near(cic.dc_gain(), 4.0))
+		throw std::runtime_error("test failed: D=2 dc_gain");
+
+	// Feed DC=1.0 and check settled output
+	std::vector<double> input(40, 1.0);
+	std::vector<double> output;
+	cic.process_block(std::span<const double>(input), output);
+
+	double expected = 4.0;
+	for (std::size_t i = output.size() - 3; i < output.size(); ++i) {
+		if (!near(output[i], expected, 1e-9))
+			throw std::runtime_error("test failed: D=2 settled output");
+	}
+
+	std::cout << "  differential_delay: passed\n";
+}
+
+// ============================================================================
+// Interpolator: DC gain and round-trip
+// ============================================================================
+
+void test_interpolator_impulse() {
+	// M=1, R=4, D=1: impulse response is a rectangular pulse of length R
+	CICInterpolator<double> interp(4, 1, 1);
+
+	std::vector<double> input = {1.0, 0.0, 0.0, 0.0};
+	std::vector<double> output;
+	interp.process_block(std::span<const double>(input), output);
+
+	// 4 inputs * R=4 = 16 outputs
+	if (output.size() != 16)
+		throw std::runtime_error("test failed: interp impulse size = " +
+			std::to_string(output.size()));
+
+	// First R=4 samples should be 1, rest should be 0
+	for (int i = 0; i < 4; ++i) {
+		if (!near(output[static_cast<std::size_t>(i)], 1.0))
+			throw std::runtime_error("test failed: interp impulse y[" +
+				std::to_string(i) + "] = " + std::to_string(output[static_cast<std::size_t>(i)]));
+	}
+	for (std::size_t i = 4; i < output.size(); ++i) {
+		if (!near(output[i], 0.0))
+			throw std::runtime_error("test failed: interp impulse tail y[" +
+				std::to_string(i) + "] = " + std::to_string(output[i]));
+	}
+
+	std::cout << "  interpolator_impulse: passed\n";
+}
+
+void test_interpolator_output_count() {
+	CICInterpolator<double> interp(4, 2, 1);
+
+	std::vector<double> input(20, 1.0);
+	std::vector<double> output;
+	interp.process_block(std::span<const double>(input), output);
+
+	// 20 inputs * R=4 = 80 outputs
+	if (output.size() != 80)
+		throw std::runtime_error("test failed: interp output size = " +
+			std::to_string(output.size()));
+
+	// After settling, output should be constant (all samples equal)
+	double settled = output.back();
+	for (std::size_t i = output.size() - 10; i < output.size(); ++i) {
+		if (!near(output[i], settled, 1e-9))
+			throw std::runtime_error("test failed: interp not settled at " +
+				std::to_string(i));
+	}
+
+	std::cout << "  interpolator_output_count: settled at " << settled << ", passed\n";
+}
+
+// ============================================================================
+// Decimation + interpolation round-trip preserves DC
+// ============================================================================
+
+void test_round_trip() {
+	// Decimation followed by interpolation should preserve DC (up to gain factors)
+	int R = 4, M = 2, D = 1;
+	CICDecimator<double>    dec(R, M, D);
+	CICInterpolator<double> interp(R, M, D);
+
+	double dc = 0.5;
+	std::vector<double> input(200, dc);
+	std::vector<double> decimated;
+	dec.process_block(std::span<const double>(input), decimated);
+
+	// Decimated output settles to dc * (R*D)^M = 0.5 * 16 = 8
+	double dec_settled = decimated.back();
+
+	std::vector<double> reconstructed;
+	interp.process_block(std::span<const double>(decimated), reconstructed);
+
+	// The reconstructed output should settle to a constant
+	double recon_settled = reconstructed.back();
+
+	// Verify the round-trip output is constant (settled)
+	for (std::size_t i = reconstructed.size() - 10; i < reconstructed.size(); ++i) {
+		if (!near(reconstructed[i], recon_settled, 1e-9))
+			throw std::runtime_error("test failed: round-trip not settled");
+	}
+
+	std::cout << "  round_trip: dec_settled=" << dec_settled
+	          << " recon_settled=" << recon_settled << ", passed\n";
+}
+
+// ============================================================================
+// Reset clears state
+// ============================================================================
+
+void test_reset() {
+	CICDecimator<double> cic(4, 2, 1);
+
+	std::vector<double> input(16, 1.0);
+	std::vector<double> out1;
+	cic.process_block(std::span<const double>(input), out1);
+
+	cic.reset();
+
+	std::vector<double> out2;
+	cic.process_block(std::span<const double>(input), out2);
+
+	if (out1.size() != out2.size())
+		throw std::runtime_error("test failed: reset output size mismatch");
+
+	for (std::size_t i = 0; i < out1.size(); ++i) {
+		if (!near(out1[i], out2[i]))
+			throw std::runtime_error("test failed: reset output mismatch at " +
+				std::to_string(i));
+	}
+
+	std::cout << "  reset: passed\n";
+}
+
+// ============================================================================
+// Mixed-precision: float state with double samples
+// ============================================================================
+
+void test_mixed_precision() {
+	// Use float for state (limited precision) to show quality degradation
+	CICDecimator<float, double> cic_float(8, 3, 1);
+	CICDecimator<double, double> cic_double(8, 3, 1);
+
+	// Generate a signal with small amplitude to stress precision
+	std::vector<double> input(800);
+	for (std::size_t i = 0; i < input.size(); ++i) {
+		input[i] = 1e-4 * std::sin(2.0 * M_PI * 7.0 *
+			static_cast<double>(i) / static_cast<double>(input.size()));
+	}
+
+	std::vector<double> out_float, out_double;
+	cic_float.process_block(std::span<const double>(input), out_float);
+	cic_double.process_block(std::span<const double>(input), out_double);
+
+	if (out_float.size() != out_double.size())
+		throw std::runtime_error("test failed: mixed-precision size mismatch");
+
+	// Compute error between float and double state
+	double max_err = 0.0;
+	double max_val = 0.0;
+	for (std::size_t i = 0; i < out_float.size(); ++i) {
+		max_err = std::max(max_err, std::abs(out_float[i] - out_double[i]));
+		max_val = std::max(max_val, std::abs(out_double[i]));
+	}
+
+	// Float should introduce measurable error but not catastrophic
+	double relative_err = (max_val > 0.0) ? max_err / max_val : 0.0;
+	std::cout << "  mixed_precision: float vs double relative error = "
+	          << relative_err << "\n";
+
+	// Float has ~7 decimal digits; CIC gain = 8^3 = 512, and integrators
+	// accumulate rounding errors over many samples, so relative error
+	// can reach ~1e-2 for long sequences
+	if (relative_err > 0.05)
+		throw std::runtime_error("test failed: float state error too large: " +
+			std::to_string(relative_err));
+
+	std::cout << "  mixed_precision: passed\n";
+}
+
+// ============================================================================
+// Overflow demonstration: narrow integer-like type
+// ============================================================================
+
+void test_bit_growth_verification() {
+	// With M=3, R=8, D=1: bit growth = 9, DC gain = 512
+	// An input of 1.0 through the filter settles to 512
+	CICDecimator<double> cic(8, 3, 1);
+	if (cic.bit_growth() != 9)
+		throw std::runtime_error("test failed: bit_growth() accessor");
+
+	std::vector<double> input(80, 1.0);
+	std::vector<double> output;
+	cic.process_block(std::span<const double>(input), output);
+
+	double settled = output.back();
+	if (!near(settled, 512.0, 1e-9))
+		throw std::runtime_error("test failed: settled value = " +
+			std::to_string(settled) + ", expected 512");
+
+	std::cout << "  bit_growth_verification: passed\n";
+}
+
+// ============================================================================
+// Parameter validation
+// ============================================================================
+
+void test_parameter_validation() {
+	bool caught = false;
+
+	try { CICDecimator<double>(0, 1, 1); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: R=0 should throw");
+
+	caught = false;
+	try { CICDecimator<double>(4, 0, 1); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: M=0 should throw");
+
+	caught = false;
+	try { CICDecimator<double>(4, 1, 0); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: D=0 should throw");
+
+	caught = false;
+	try { CICInterpolator<double>(0, 1, 1); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: interp R=0 should throw");
+
+	std::cout << "  parameter_validation: passed\n";
+}
+
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "CIC filter tests\n";
+		test_bit_growth();
+		test_dc_gain();
+		test_single_stage_impulse();
+		test_dc_response();
+		test_differential_delay();
+		test_interpolator_impulse();
+		test_interpolator_output_count();
+		test_round_trip();
+		test_reset();
+		test_mixed_precision();
+		test_bit_growth_verification();
+		test_parameter_validation();
+		std::cout << "All CIC tests passed.\n";
+		return 0;
+	} catch (const std::exception& e) {
+		std::cerr << "FAIL: " << e.what() << '\n';
+		return 1;
+	}
+}

--- a/tests/test_cic.cpp
+++ b/tests/test_cic.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <sw/dsp/acquisition/cic.hpp>
+#include <sw/dsp/math/constants.hpp>
 
 #include <cmath>
 #include <iostream>
@@ -282,7 +283,7 @@ void test_mixed_precision() {
 	// Generate a signal with small amplitude to stress precision
 	std::vector<double> input(800);
 	for (std::size_t i = 0; i < input.size(); ++i) {
-		input[i] = 1e-4 * std::sin(2.0 * M_PI * 7.0 *
+		input[i] = 1e-4 * std::sin(sw::dsp::two_pi * 7.0 *
 			static_cast<double>(i) / static_cast<double>(input.size()));
 	}
 


### PR DESCRIPTION
## Summary
- Adds CIC (Cascaded Integrator-Comb) filter as the first component of the `acquisition` module
- Multiplication-free decimation/interpolation using only additions and subtractions
- Two-scalar parameterization: StateScalar (accumulators) + SampleScalar (I/O)
- Bit-growth formula drives StateScalar sizing: `B_out = B_in + M*ceil(log2(R*D))`
- Documentation page with Hogenauer history, pipeline diagram, theory, and precision guidance

## Changes
- `include/sw/dsp/acquisition/cic.hpp` — CICDecimator and CICInterpolator classes
- `include/sw/dsp/acquisition/acquisition.hpp` — module umbrella header
- `include/sw/dsp/dsp.hpp` — wire acquisition module into library umbrella
- `tests/test_cic.cpp` — 12 unit tests (bit-growth, DC response, impulse, round-trip, mixed-precision, validation)
- `tests/CMakeLists.txt` — register test_cic
- `docs-site/src/content/docs/acquisition/cic.md` — full documentation page

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_cic | OK | PASS (12 tests) | OK | PASS (12 tests) |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CIC (Cascaded Integrator–Comb) filters for sample-rate conversion: streaming decimator and interpolator with configurable ratio, stages, and delay.

* **Documentation**
  * Added a comprehensive CIC guide covering theory, usage patterns, API examples, precision and overflow considerations.

* **Tests**
  * Added extensive tests validating bit-growth, DC gain, impulse/settled responses, round-trip behavior, reset semantics, mixed-precision accuracy, and parameter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->