### PR TITLE
feat(acquisition): half-band FIR filter for efficient 2x decimation

### DIFF
--- a/docs-site/src/content/docs/acquisition/halfband.md
+++ b/docs-site/src/content/docs/acquisition/halfband.md
@@ -1,0 +1,199 @@
+---
+title: Half-Band FIR Filter
+description: Optimized half-band FIR filter for efficient 2x decimation in high-rate acquisition pipelines
+---
+
+## History and Motivation
+
+Half-band filters are a special case of FIR lowpass filters where the cutoff
+frequency is exactly one quarter of the sampling rate ($f_s/4$). This
+constraint yields a remarkable structural property: nearly half the filter
+coefficients are exactly zero, cutting the computational cost roughly in half.
+
+When combined with 2x decimation — where only every other output sample is
+computed — the total savings approaches **4x** compared to a general FIR
+filter followed by downsampling. This makes half-band filters the standard
+building block between CIC decimation and final-stage processing in high-rate
+data acquisition systems.
+
+## Where Half-Band Fits in the Pipeline
+
+```text
+┌─────────┐    ┌─────────────┐    ┌───────────┐    ┌──────────────┐    ┌────────┐
+│ ADC     │───>│ CIC         │───>│ CIC Comp  │───>│ Half-Band    │───>│ Final  │
+│ 1 GSPS  │    │ Decimator   │    │ Filter    │    │ Decimator    │    │ FIR    │
+│ 12-bit  │    │ ÷64         │    │ (droop)   │    │ ÷2           │    │ ÷4     │
+└─────────┘    └─────────────┘    └───────────┘    └──────────────┘    └────────┘
+  SampleT          StateT            CoeffT           CoeffT           CoeffT
+  (narrow)         (wide)            /StateT          /StateT          /StateT
+```
+
+The CIC handles the bulk rate reduction at full clock rate (no multipliers).
+The half-band filter then provides a clean 2x decimation stage with excellent
+stopband rejection at modest computational cost.
+
+## Theory
+
+### Half-Band Property
+
+A half-band filter satisfies the power complementary condition:
+
+$$
+H(\omega) + H(\pi - \omega) = 1
+$$
+
+This means the frequency response is symmetric about $\omega = \pi/2$
+(normalized frequency 0.25). The passband and stopband ripples are equal.
+
+### Coefficient Structure
+
+For a Type I FIR filter of length $N = 4K + 3$ (odd, with center at
+index $C = (N-1)/2$):
+
+- **Center tap**: $h[C] = 0.5$
+- **Even offsets from center**: $h[C \pm 2k] = 0$ for $k \geq 1$
+- **Odd offsets**: $h[C \pm (2k+1)]$ are the non-zero design coefficients
+- **Symmetry**: $h[C - j] = h[C + j]$ (linear phase)
+
+### Computational Savings
+
+| Property | General FIR | Half-Band | Half-Band + Decimate |
+|----------|------------|-----------|---------------------|
+| Multiplies per output | $N$ | $\sim N/2$ | $\sim N/4$ |
+| Adds per output | $N-1$ | $\sim N/2$ | $\sim N/4$ |
+
+The savings come from:
+1. Skipping zero-valued taps (~half are zero)
+2. Exploiting symmetry (fold left + right before multiply)
+3. Computing only every other output (decimation)
+
+### Valid Filter Lengths
+
+The filter length must be of the form $N = 4K + 3$:
+
+| K | N | Non-zero taps | Zero taps |
+|---|---|--------------|-----------|
+| 0 | 3 | 3 | 0 |
+| 1 | 7 | 5 | 2 |
+| 2 | 11 | 7 | 4 |
+| 3 | 15 | 9 | 6 |
+| 4 | 19 | 11 | 8 |
+| 5 | 23 | 13 | 10 |
+
+## API
+
+### Design Function
+
+```cpp
+#include <sw/dsp/acquisition/halfband.hpp>
+
+using namespace sw::dsp;
+
+// Design an 11-tap half-band filter with transition width 0.1 (normalized)
+// Passband: [0, 0.20], Stopband: [0.30, 0.50]
+auto taps = design_halfband<double>(11, 0.1);
+
+// Design a sharper 19-tap filter with narrower transition
+auto sharp_taps = design_halfband<double>(19, 0.05);
+```
+
+The `transition_width` parameter controls the trade-off between filter
+length and transition sharpness:
+- Passband edge = $0.25 - \text{tw}/2$
+- Stopband edge = $0.25 + \text{tw}/2$
+
+### Half-Band Filter
+
+```cpp
+// Three-scalar parameterization: CoeffScalar, StateScalar, SampleScalar
+HalfBandFilter<double> hb(taps);
+
+// Full-rate filtering (one output per input)
+double y = hb.process(x);
+
+// Block processing
+std::vector<double> output(input.size());
+hb.process_block(std::span<const double>(input),
+                 std::span<double>(output));
+```
+
+### Integrated 2x Decimation
+
+```cpp
+HalfBandFilter<double> hb(taps);
+
+// Sample-by-sample decimation
+auto [ready, y] = hb.process_decimate(x);
+if (ready) {
+    // Use decimated output y
+}
+
+// Block decimation (produces input.size()/2 outputs)
+std::vector<double> output;
+hb.process_block_decimate(std::span<const double>(input), output);
+```
+
+### Utility Methods
+
+```cpp
+hb.num_taps();           // Total tap count (including zeros)
+hb.num_nonzero_taps();   // Non-zero taps (actual multiplications)
+hb.order();              // Filter order (num_taps - 1)
+hb.taps();               // Full tap vector (const reference)
+hb.reset();              // Clear all delay-line state
+```
+
+## Example: CIC + Half-Band Cascade
+
+```cpp
+#include <sw/dsp/acquisition/cic.hpp>
+#include <sw/dsp/acquisition/halfband.hpp>
+
+using namespace sw::dsp;
+
+// Stage 1: CIC decimation by 64 (no multiplications)
+CICDecimator<double> cic(64, 4, 1);
+
+// Stage 2: Half-band decimation by 2
+auto hb_taps = design_halfband<double>(19, 0.08);
+HalfBandFilter<double> hb(hb_taps);
+
+// Process: 1 GSPS → 15.625 MSPS (CIC) → 7.8125 MSPS (half-band)
+std::vector<double> adc_samples = /* ... */;
+std::vector<double> cic_out;
+cic.process_block(std::span<const double>(adc_samples), cic_out);
+
+std::vector<double> hb_out;
+hb.process_block_decimate(std::span<const double>(cic_out), hb_out);
+```
+
+## Precision Considerations
+
+The half-band filter uses the three-scalar model:
+
+- **CoeffScalar** stores the designed tap values. Since half-band taps are
+  derived from Remez exchange, they are typically small fractions. Float
+  precision is often sufficient for the coefficients themselves.
+
+- **StateScalar** holds the delay-line accumulation. For high dynamic range
+  signals, double or extended-precision accumulators prevent rounding
+  error accumulation across the $\sim N/4$ multiply-accumulate operations.
+
+- **SampleScalar** matches the data stream precision. In a cascade after
+  CIC, this is the CIC output type (often wider than the original ADC samples).
+
+```cpp
+// Mixed precision: float coefficients, double state, float samples
+auto taps_f = /* design and project to float */;
+HalfBandFilter<float, double, float> hb(taps_f);
+```
+
+### Comparison with CIC
+
+| Property | CIC | Half-Band |
+|----------|-----|-----------|
+| Multiplications | None | ~N/4 per output |
+| Coefficients | None (unit) | Designed (Remez) |
+| Passband shape | sinc droop | Equiripple (flat) |
+| Typical decimation | 16x–256x | 2x |
+| Precision model | Two-scalar | Three-scalar |

--- a/include/sw/dsp/acquisition/acquisition.hpp
+++ b/include/sw/dsp/acquisition/acquisition.hpp
@@ -5,3 +5,4 @@
 // SPDX-License-Identifier: MIT
 
 #include <sw/dsp/acquisition/cic.hpp>
+#include <sw/dsp/acquisition/halfband.hpp>

--- a/include/sw/dsp/acquisition/halfband.hpp
+++ b/include/sw/dsp/acquisition/halfband.hpp
@@ -51,20 +51,23 @@ mtl::vec::dense_vector<T> design_halfband(
 			"design_halfband: num_taps must be of the form 4K+3 "
 			"(e.g., 3, 7, 11, 15, 19, ...)");
 
-	double tw = static_cast<double>(transition_width);
-	if (tw <= 0.0 || tw >= 0.5)
+	T tw = transition_width;
+	T half = T(0.5);
+	T quarter = T(0.25);
+	T two = T{1} + T{1};
+
+	if (!(tw > T{0}) || !(tw < half))
 		throw std::invalid_argument(
 			"design_halfband: transition_width must be in (0, 0.5)");
 
-	double pass_edge = 0.25 - tw / 2.0;
-	double stop_edge = 0.25 + tw / 2.0;
+	T pass_edge = quarter - tw / two;
+	T stop_edge = quarter + tw / two;
 
-	if (pass_edge <= 0.0 || stop_edge >= 0.5)
+	if (!(pass_edge > T{0}) || !(stop_edge < half))
 		throw std::invalid_argument(
 			"design_halfband: transition_width too large");
 
-	std::vector<T> bands   = {T{0}, static_cast<T>(pass_edge),
-	                          static_cast<T>(stop_edge), T(0.5)};
+	std::vector<T> bands   = {T{0}, pass_edge, stop_edge, half};
 	std::vector<T> desired = {T{1}, T{1}, T{0}, T{0}};
 	std::vector<T> weights = {T{1}, T{1}};
 
@@ -72,7 +75,7 @@ mtl::vec::dense_vector<T> design_halfband(
 
 	// Enforce exact half-band constraints
 	std::size_t center = (num_taps - 1) / 2;
-	taps[center] = static_cast<T>(0.5);
+	taps[center] = half;
 	for (std::size_t k = 2; k <= center; k += 2) {
 		taps[center - k] = T{0};
 		taps[center + k] = T{0};
@@ -80,22 +83,20 @@ mtl::vec::dense_vector<T> design_halfband(
 
 	// Enforce perfect symmetry on the non-zero taps
 	for (std::size_t k = 1; k <= center; k += 2) {
-		T avg = static_cast<T>(
-			(static_cast<double>(taps[center - k]) +
-			 static_cast<double>(taps[center + k])) / 2.0);
+		T avg = (taps[center - k] + taps[center + k]) / two;
 		taps[center - k] = avg;
 		taps[center + k] = avg;
 	}
 
 	// Normalize: center contributes 0.5, odd-offset taps must sum to 0.5
-	double sum_odd = 0.0;
+	T sum_odd{};
 	for (std::size_t k = 1; k <= center; k += 2) {
-		sum_odd += 2.0 * static_cast<double>(taps[center + k]);
+		sum_odd = sum_odd + two * taps[center + k];
 	}
-	if (std::abs(sum_odd) > 1e-15) {
-		double scale = 0.5 / sum_odd;
+	if (!(sum_odd == T{0})) {
+		T scale = half / sum_odd;
 		for (std::size_t k = 1; k <= center; k += 2) {
-			T val = static_cast<T>(static_cast<double>(taps[center + k]) * scale);
+			T val = taps[center + k] * scale;
 			taps[center - k] = val;
 			taps[center + k] = val;
 		}
@@ -130,6 +131,22 @@ public:
 		if ((taps.size() & 1) == 0)
 			throw std::invalid_argument("HalfBandFilter: num_taps must be odd");
 
+		// Validate half-band structure: even offsets from center must be zero,
+		// and taps must be symmetric
+		CoeffScalar zero{};
+		for (std::size_t k = 2; k <= center_; k += 2) {
+			if (!(taps[center_ - k] == zero) || !(taps[center_ + k] == zero))
+				throw std::invalid_argument(
+					"HalfBandFilter: even-offset taps must be zero "
+					"(offset " + std::to_string(k) + " is non-zero)");
+		}
+		for (std::size_t k = 1; k <= center_; ++k) {
+			if (!(taps[center_ - k] == taps[center_ + k]))
+				throw std::invalid_argument(
+					"HalfBandFilter: taps must be symmetric "
+					"(mismatch at offset " + std::to_string(k) + ")");
+		}
+
 		center_coeff_ = taps[center_];
 
 		for (std::size_t k = 1; k <= center_; k += 2) {
@@ -160,11 +177,13 @@ public:
 		return static_cast<SampleScalar>(acc);
 	}
 
-	// Block processing: full-rate
+	// Block processing: full-rate (output span must be >= input span)
 	void process_block(std::span<const SampleScalar> input,
 	                   std::span<SampleScalar> output) {
-		std::size_t n = std::min(input.size(), output.size());
-		for (std::size_t i = 0; i < n; ++i) {
+		if (output.size() < input.size())
+			throw std::invalid_argument(
+				"HalfBandFilter::process_block: output span too small");
+		for (std::size_t i = 0; i < input.size(); ++i) {
 			output[i] = process(input[i]);
 		}
 	}
@@ -212,27 +231,41 @@ public:
 		return {false, SampleScalar{}};
 	}
 
-	// Block decimation: process input, append decimated outputs to vector
-	void process_block_decimate(std::span<const SampleScalar> input,
-	                            std::vector<SampleScalar>& output) {
-		for (auto s : input) {
-			auto [ready, y] = process_decimate(s);
-			if (ready) output.push_back(y);
+	// Block decimation from span, returns dense_vector of decimated outputs
+	mtl::vec::dense_vector<SampleScalar> process_block_decimate(
+			std::span<const SampleScalar> input) {
+		// Pre-compute output count
+		std::size_t count = 0;
+		int phase = decimate_phase_;
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			if (phase == 1) ++count;
+			phase = (phase == 0) ? 1 : 0;
 		}
+		mtl::vec::dense_vector<SampleScalar> output(count);
+		std::size_t idx = 0;
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			auto [ready, y] = process_decimate(input[i]);
+			if (ready) output[idx++] = y;
+		}
+		return output;
 	}
 
 	// Dense-vector overload for decimation
 	mtl::vec::dense_vector<SampleScalar> process_block_decimate(
 			const mtl::vec::dense_vector<SampleScalar>& input) {
-		std::vector<SampleScalar> tmp;
-		tmp.reserve(input.size() / 2 + 1);
+		std::size_t count = 0;
+		int phase = decimate_phase_;
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			if (phase == 1) ++count;
+			phase = (phase == 0) ? 1 : 0;
+		}
+		mtl::vec::dense_vector<SampleScalar> output(count);
+		std::size_t idx = 0;
 		for (std::size_t i = 0; i < input.size(); ++i) {
 			auto [ready, y] = process_decimate(input[i]);
-			if (ready) tmp.push_back(y);
+			if (ready) output[idx++] = y;
 		}
-		mtl::vec::dense_vector<SampleScalar> result(tmp.size());
-		for (std::size_t i = 0; i < tmp.size(); ++i) result[i] = tmp[i];
-		return result;
+		return output;
 	}
 
 	void reset() {

--- a/include/sw/dsp/acquisition/halfband.hpp
+++ b/include/sw/dsp/acquisition/halfband.hpp
@@ -1,0 +1,257 @@
+#pragma once
+// halfband.hpp: Half-band FIR filter for efficient 2x decimation/interpolation
+//
+// Half-band filters satisfy H(w) + H(pi-w) = 1, which means nearly half the
+// coefficients are zero.  Combined with 2x decimation this yields ~4x
+// computational savings over naive filter-and-decimate.
+//
+// Three-scalar parameterization:
+//   CoeffScalar  - tap coefficients (design precision)
+//   StateScalar  - delay line and accumulation (processing precision)
+//   SampleScalar - input/output samples (streaming precision)
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/filter/fir/remez.hpp>
+#include <sw/dsp/math/constants.hpp>
+
+namespace sw::dsp {
+
+// Design an equiripple half-band lowpass filter via Remez exchange.
+//
+// Parameters:
+//   num_taps         - filter length, must be of the form 4K+3 (e.g., 7, 11, 15, 19, ...)
+//   transition_width - transition bandwidth in normalized frequency [0, 0.5];
+//                      passband edge = 0.25 - tw/2, stopband edge = 0.25 + tw/2
+//
+// Returns: dense_vector of half-band filter taps with enforced structure:
+//   h[center] = 0.5, h[center +/- 2k] = 0 for k >= 1
+template <DspField T>
+mtl::vec::dense_vector<T> design_halfband(
+    std::size_t num_taps,
+    T transition_width) {
+
+	if (num_taps < 3)
+		throw std::invalid_argument("design_halfband: num_taps must be >= 3");
+	if ((num_taps & 1) == 0)
+		throw std::invalid_argument("design_halfband: num_taps must be odd");
+	if ((num_taps % 4) != 3)
+		throw std::invalid_argument(
+			"design_halfband: num_taps must be of the form 4K+3 "
+			"(e.g., 3, 7, 11, 15, 19, ...)");
+
+	double tw = static_cast<double>(transition_width);
+	if (tw <= 0.0 || tw >= 0.5)
+		throw std::invalid_argument(
+			"design_halfband: transition_width must be in (0, 0.5)");
+
+	double pass_edge = 0.25 - tw / 2.0;
+	double stop_edge = 0.25 + tw / 2.0;
+
+	if (pass_edge <= 0.0 || stop_edge >= 0.5)
+		throw std::invalid_argument(
+			"design_halfband: transition_width too large");
+
+	std::vector<T> bands   = {T{0}, static_cast<T>(pass_edge),
+	                          static_cast<T>(stop_edge), T(0.5)};
+	std::vector<T> desired = {T{1}, T{1}, T{0}, T{0}};
+	std::vector<T> weights = {T{1}, T{1}};
+
+	auto taps = remez<T>(num_taps, bands, desired, weights);
+
+	// Enforce exact half-band constraints
+	std::size_t center = (num_taps - 1) / 2;
+	taps[center] = static_cast<T>(0.5);
+	for (std::size_t k = 2; k <= center; k += 2) {
+		taps[center - k] = T{0};
+		taps[center + k] = T{0};
+	}
+
+	// Enforce perfect symmetry on the non-zero taps
+	for (std::size_t k = 1; k <= center; k += 2) {
+		T avg = static_cast<T>(
+			(static_cast<double>(taps[center - k]) +
+			 static_cast<double>(taps[center + k])) / 2.0);
+		taps[center - k] = avg;
+		taps[center + k] = avg;
+	}
+
+	// Normalize: center contributes 0.5, odd-offset taps must sum to 0.5
+	double sum_odd = 0.0;
+	for (std::size_t k = 1; k <= center; k += 2) {
+		sum_odd += 2.0 * static_cast<double>(taps[center + k]);
+	}
+	if (std::abs(sum_odd) > 1e-15) {
+		double scale = 0.5 / sum_odd;
+		for (std::size_t k = 1; k <= center; k += 2) {
+			T val = static_cast<T>(static_cast<double>(taps[center + k]) * scale);
+			taps[center - k] = val;
+			taps[center + k] = val;
+		}
+	}
+
+	return taps;
+}
+
+// Half-band FIR filter with optimized computation that skips zero-valued taps.
+//
+// For 2x decimation, use process_decimate() or process_block_decimate() which
+// compute only the output samples that survive downsampling, yielding ~4x
+// savings over naive filter-then-decimate.
+template <DspField CoeffScalar = double,
+          DspField StateScalar = CoeffScalar,
+          DspScalar SampleScalar = StateScalar>
+class HalfBandFilter {
+public:
+	using coeff_scalar  = CoeffScalar;
+	using state_scalar  = StateScalar;
+	using sample_scalar = SampleScalar;
+
+	explicit HalfBandFilter(const mtl::vec::dense_vector<CoeffScalar>& taps)
+		: taps_(taps),
+		  delay_(taps.size(), StateScalar{}),
+		  write_pos_(0),
+		  center_((taps.size() - 1) / 2),
+		  decimate_phase_(0) {
+
+		if (taps.size() < 3)
+			throw std::invalid_argument("HalfBandFilter: need at least 3 taps");
+		if ((taps.size() & 1) == 0)
+			throw std::invalid_argument("HalfBandFilter: num_taps must be odd");
+
+		center_coeff_ = taps[center_];
+
+		for (std::size_t k = 1; k <= center_; k += 2) {
+			sym_offsets_.push_back(k);
+			sym_coeffs_.push_back(taps[center_ + k]);
+		}
+	}
+
+	// Full-rate: process one sample, produce one output
+	SampleScalar process(SampleScalar in) {
+		std::size_t N = taps_.size();
+		delay_[write_pos_] = static_cast<StateScalar>(in);
+
+		std::size_t ci = (write_pos_ + N - center_) % N;
+		StateScalar acc = static_cast<StateScalar>(center_coeff_) * delay_[ci];
+
+		for (std::size_t i = 0; i < sym_offsets_.size(); ++i) {
+			std::size_t k = sym_offsets_[i];
+			std::size_t left  = (ci + N - k) % N;
+			std::size_t right = (ci + k) % N;
+			acc = acc + static_cast<StateScalar>(sym_coeffs_[i]) *
+			            (delay_[left] + delay_[right]);
+		}
+
+		write_pos_ = (write_pos_ + 1) % N;
+		return static_cast<SampleScalar>(acc);
+	}
+
+	// Block processing: full-rate
+	void process_block(std::span<const SampleScalar> input,
+	                   std::span<SampleScalar> output) {
+		std::size_t n = std::min(input.size(), output.size());
+		for (std::size_t i = 0; i < n; ++i) {
+			output[i] = process(input[i]);
+		}
+	}
+
+	// Dense-vector overload
+	mtl::vec::dense_vector<SampleScalar> process_block(
+			const mtl::vec::dense_vector<SampleScalar>& input) {
+		mtl::vec::dense_vector<SampleScalar> output(input.size());
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			output[i] = process(input[i]);
+		}
+		return output;
+	}
+
+	// Integrated 2x decimation: push one sample, output emitted every other call.
+	// Returns {true, y} when output is ready, {false, 0} otherwise.
+	std::pair<bool, SampleScalar> process_decimate(SampleScalar in) {
+		std::size_t N = taps_.size();
+		delay_[write_pos_] = static_cast<StateScalar>(in);
+
+		bool emit = (decimate_phase_ == 1);
+
+		if (emit) {
+			std::size_t ci = (write_pos_ + N - center_) % N;
+			StateScalar acc =
+				static_cast<StateScalar>(center_coeff_) * delay_[ci];
+
+			for (std::size_t i = 0; i < sym_offsets_.size(); ++i) {
+				std::size_t k = sym_offsets_[i];
+				std::size_t left  = (ci + N - k) % N;
+				std::size_t right = (ci + k) % N;
+				acc = acc + static_cast<StateScalar>(sym_coeffs_[i]) *
+				            (delay_[left] + delay_[right]);
+			}
+
+			write_pos_ = (write_pos_ + 1) % N;
+			decimate_phase_ = 0;
+			return {true, static_cast<SampleScalar>(acc)};
+		}
+
+		write_pos_ = (write_pos_ + 1) % N;
+		decimate_phase_ = 1;
+		return {false, SampleScalar{}};
+	}
+
+	// Block decimation: process input, append decimated outputs
+	void process_block_decimate(std::span<const SampleScalar> input,
+	                            std::vector<SampleScalar>& output) {
+		for (auto s : input) {
+			auto [ready, y] = process_decimate(s);
+			if (ready) output.push_back(y);
+		}
+	}
+
+	// Dense-vector overload for decimation
+	mtl::vec::dense_vector<SampleScalar> process_block_decimate(
+			const mtl::vec::dense_vector<SampleScalar>& input) {
+		std::vector<SampleScalar> tmp;
+		tmp.reserve(input.size() / 2 + 1);
+		for (std::size_t i = 0; i < input.size(); ++i) {
+			auto [ready, y] = process_decimate(input[i]);
+			if (ready) tmp.push_back(y);
+		}
+		mtl::vec::dense_vector<SampleScalar> result(tmp.size());
+		for (std::size_t i = 0; i < tmp.size(); ++i) result[i] = tmp[i];
+		return result;
+	}
+
+	void reset() {
+		for (std::size_t i = 0; i < delay_.size(); ++i)
+			delay_[i] = StateScalar{};
+		write_pos_ = 0;
+		decimate_phase_ = 0;
+	}
+
+	std::size_t order()           const { return taps_.size() > 0 ? taps_.size() - 1 : 0; }
+	std::size_t num_taps()        const { return taps_.size(); }
+	std::size_t num_nonzero_taps() const { return 1 + 2 * sym_coeffs_.size(); }
+	const mtl::vec::dense_vector<CoeffScalar>& taps() const { return taps_; }
+
+private:
+	mtl::vec::dense_vector<CoeffScalar> taps_;
+	mtl::vec::dense_vector<StateScalar> delay_;
+	std::size_t write_pos_;
+	std::size_t center_;
+	int decimate_phase_;
+
+	CoeffScalar center_coeff_;
+	std::vector<std::size_t> sym_offsets_;
+	std::vector<CoeffScalar> sym_coeffs_;
+};
+
+} // namespace sw::dsp

--- a/include/sw/dsp/acquisition/halfband.hpp
+++ b/include/sw/dsp/acquisition/halfband.hpp
@@ -24,6 +24,7 @@
 #include <sw/dsp/concepts/scalar.hpp>
 #include <sw/dsp/filter/fir/remez.hpp>
 #include <sw/dsp/math/constants.hpp>
+#include <sw/dsp/math/denormal.hpp>
 
 namespace sw::dsp {
 
@@ -143,14 +144,16 @@ public:
 		delay_[write_pos_] = static_cast<StateScalar>(in);
 
 		std::size_t ci = (write_pos_ + N - center_) % N;
-		StateScalar acc = static_cast<StateScalar>(center_coeff_) * delay_[ci];
+		StateScalar acc = static_cast<StateScalar>(center_coeff_) * delay_[ci]
+		                + denormal_.ac();
 
 		for (std::size_t i = 0; i < sym_offsets_.size(); ++i) {
 			std::size_t k = sym_offsets_[i];
 			std::size_t left  = (ci + N - k) % N;
 			std::size_t right = (ci + k) % N;
 			acc = acc + static_cast<StateScalar>(sym_coeffs_[i]) *
-			            (delay_[left] + delay_[right]);
+			            (delay_[left] + delay_[right])
+			    + denormal_.ac();
 		}
 
 		write_pos_ = (write_pos_ + 1) % N;
@@ -187,14 +190,16 @@ public:
 		if (emit) {
 			std::size_t ci = (write_pos_ + N - center_) % N;
 			StateScalar acc =
-				static_cast<StateScalar>(center_coeff_) * delay_[ci];
+				static_cast<StateScalar>(center_coeff_) * delay_[ci]
+				+ denormal_.ac();
 
 			for (std::size_t i = 0; i < sym_offsets_.size(); ++i) {
 				std::size_t k = sym_offsets_[i];
 				std::size_t left  = (ci + N - k) % N;
 				std::size_t right = (ci + k) % N;
 				acc = acc + static_cast<StateScalar>(sym_coeffs_[i]) *
-				            (delay_[left] + delay_[right]);
+				            (delay_[left] + delay_[right])
+				    + denormal_.ac();
 			}
 
 			write_pos_ = (write_pos_ + 1) % N;
@@ -207,7 +212,7 @@ public:
 		return {false, SampleScalar{}};
 	}
 
-	// Block decimation: process input, append decimated outputs
+	// Block decimation: process input, append decimated outputs to vector
 	void process_block_decimate(std::span<const SampleScalar> input,
 	                            std::vector<SampleScalar>& output) {
 		for (auto s : input) {
@@ -252,6 +257,7 @@ private:
 	CoeffScalar center_coeff_;
 	std::vector<std::size_t> sym_offsets_;
 	std::vector<CoeffScalar> sym_coeffs_;
+	DenormalPrevention<StateScalar> denormal_;
 };
 
 } // namespace sw::dsp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,3 +87,6 @@ dsp_add_test(test_projection)
 
 # CIC decimation/interpolation (Issue #86)
 dsp_add_test(test_cic)
+
+# Half-band FIR decimation (Issue #87)
+dsp_add_test(test_halfband)

--- a/tests/test_halfband.cpp
+++ b/tests/test_halfband.cpp
@@ -78,6 +78,29 @@ void test_design_lengths() {
 }
 
 // ============================================================================
+// Design with float: verify parameterized design works for non-double types
+// ============================================================================
+
+void test_design_float() {
+	auto taps = design_halfband<float>(11, 0.1f);
+
+	if (taps.size() != 11)
+		throw std::runtime_error("test failed: float design tap count");
+
+	std::size_t center = 5;
+	if (!near(static_cast<double>(taps[center]), 0.5, 1e-6))
+		throw std::runtime_error("test failed: float center tap");
+
+	// Even offsets must be zero
+	for (std::size_t k = 2; k <= center; k += 2) {
+		if (taps[center - k] != 0.0f || taps[center + k] != 0.0f)
+			throw std::runtime_error("test failed: float even-offset non-zero");
+	}
+
+	std::cout << "  design_float: passed\n";
+}
+
+// ============================================================================
 // DC gain: sum of taps should be ~1.0
 // ============================================================================
 
@@ -232,6 +255,28 @@ void test_block_processing() {
 }
 
 // ============================================================================
+// process_block throws when output span is too small
+// ============================================================================
+
+void test_block_output_validation() {
+	auto taps = design_halfband<double>(11, 0.1);
+	HalfBandFilter<double> hb(taps);
+
+	std::vector<double> input(20, 1.0);
+	std::vector<double> output(10);
+	bool caught = false;
+	try {
+		hb.process_block(std::span<const double>(input),
+		                 std::span<double>(output));
+	}
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught)
+		throw std::runtime_error("test failed: undersized output should throw");
+
+	std::cout << "  block_output_validation: passed\n";
+}
+
+// ============================================================================
 // Decimation: output count and basic correctness
 // ============================================================================
 
@@ -240,8 +285,7 @@ void test_decimation_count() {
 	HalfBandFilter<double> hb(taps);
 
 	std::vector<double> input(100, 1.0);
-	std::vector<double> output;
-	hb.process_block_decimate(std::span<const double>(input), output);
+	auto output = hb.process_block_decimate(std::span<const double>(input));
 
 	// 100 input samples / 2 = 50 output samples
 	if (output.size() != 50)
@@ -257,8 +301,7 @@ void test_decimation_dc() {
 
 	// Feed DC = 1.0 through decimation — settled output should be ~1.0
 	std::vector<double> input(200, 1.0);
-	std::vector<double> output;
-	hb.process_block_decimate(std::span<const double>(input), output);
+	auto output = hb.process_block_decimate(std::span<const double>(input));
 
 	// Check last outputs are settled near 1.0
 	for (std::size_t i = output.size() - 10; i < output.size(); ++i) {
@@ -296,8 +339,7 @@ void test_decimation_correctness() {
 	}
 
 	// Integrated decimation
-	std::vector<double> dec_out;
-	hb_dec.process_block_decimate(std::span<const double>(input), dec_out);
+	auto dec_out = hb_dec.process_block_decimate(std::span<const double>(input));
 
 	if (downsampled.size() != dec_out.size())
 		throw std::runtime_error("test failed: decimation size mismatch: " +
@@ -414,6 +456,46 @@ void test_dense_vector() {
 }
 
 // ============================================================================
+// Constructor validation: rejects non-half-band taps
+// ============================================================================
+
+void test_constructor_validation() {
+	bool caught = false;
+
+	// Non-zero even offset from center
+	{
+		mtl::vec::dense_vector<double> bad(7, 0.0);
+		bad[3] = 0.5;    // center
+		bad[2] = 0.1;    // offset 1 (odd) — OK
+		bad[4] = 0.1;    // offset 1 (odd) — OK
+		bad[1] = 0.05;   // offset 2 (even) — should be zero
+		bad[5] = 0.05;   // offset 2 (even) — should be zero
+		bad[0] = 0.05;   // offset 3 (odd) — OK
+		bad[6] = 0.05;   // offset 3 (odd) — OK
+		caught = false;
+		try { HalfBandFilter<double> hb(bad); }
+		catch (const std::invalid_argument&) { caught = true; }
+		if (!caught)
+			throw std::runtime_error("test failed: non-zero even offset should throw");
+	}
+
+	// Asymmetric taps
+	{
+		mtl::vec::dense_vector<double> bad(7, 0.0);
+		bad[3] = 0.5;
+		bad[2] = 0.1;
+		bad[4] = 0.2;   // asymmetric
+		caught = false;
+		try { HalfBandFilter<double> hb(bad); }
+		catch (const std::invalid_argument&) { caught = true; }
+		if (!caught)
+			throw std::runtime_error("test failed: asymmetric taps should throw");
+	}
+
+	std::cout << "  constructor_validation: passed\n";
+}
+
+// ============================================================================
 // Parameter validation
 // ============================================================================
 
@@ -472,17 +554,20 @@ int main() {
 		std::cout << "Half-band FIR filter tests\n";
 		test_design_structure();
 		test_design_lengths();
+		test_design_float();
 		test_dc_gain();
 		test_nonzero_count();
 		test_impulse_response();
 		test_frequency_response();
 		test_block_processing();
+		test_block_output_validation();
 		test_decimation_count();
 		test_decimation_dc();
 		test_decimation_correctness();
 		test_reset();
 		test_mixed_precision();
 		test_dense_vector();
+		test_constructor_validation();
 		test_parameter_validation();
 		std::cout << "All half-band tests passed.\n";
 		return 0;

--- a/tests/test_halfband.cpp
+++ b/tests/test_halfband.cpp
@@ -6,6 +6,8 @@
 #include <sw/dsp/acquisition/halfband.hpp>
 #include <sw/dsp/math/constants.hpp>
 
+#include <universal/number/posit/posit.hpp>
+
 #include <cmath>
 #include <iostream>
 #include <stdexcept>
@@ -62,7 +64,7 @@ void test_design_structure() {
 
 void test_design_lengths() {
 	// Valid lengths: 4K+3 = 3, 7, 11, 15, 19
-	for (std::size_t n : {7, 11, 15, 19}) {
+	for (std::size_t n : {3, 7, 11, 15, 19}) {
 		auto taps = design_halfband<double>(n, 0.15);
 		if (taps.size() != n)
 			throw std::runtime_error("test failed: design length " +
@@ -304,7 +306,8 @@ void test_decimation_dc() {
 	auto output = hb.process_block_decimate(std::span<const double>(input));
 
 	// Check last outputs are settled near 1.0
-	for (std::size_t i = output.size() - 10; i < output.size(); ++i) {
+	std::size_t start = (output.size() > 10) ? (output.size() - 10) : 0;
+	for (std::size_t i = start; i < output.size(); ++i) {
 		if (!near(output[i], 1.0, 1e-3))
 			throw std::runtime_error("test failed: decimation DC at " +
 				std::to_string(i) + " = " + std::to_string(output[i]));
@@ -425,6 +428,71 @@ void test_mixed_precision() {
 			std::to_string(rel_err));
 
 	std::cout << "  mixed_precision: passed\n";
+}
+
+// ============================================================================
+// Posit type: design and process with posit<32,2> samples
+// ============================================================================
+
+void test_posit_types() {
+	using p32 = sw::universal::posit<32, 2>;
+
+	auto taps_d = design_halfband<double>(11, 0.1);
+
+	// Project taps to posit
+	mtl::vec::dense_vector<p32> taps_p(taps_d.size());
+	for (std::size_t i = 0; i < taps_d.size(); ++i) {
+		taps_p[i] = p32(static_cast<double>(taps_d[i]));
+	}
+
+	HalfBandFilter<p32, p32, p32> hb_posit(taps_p);
+	HalfBandFilter<double> hb_ref(taps_d);
+
+	// Feed a sinusoidal signal
+	double max_err = 0.0, max_val = 0.0;
+	for (int i = 0; i < 100; ++i) {
+		double x = std::sin(sw::dsp::two_pi * 0.05 * static_cast<double>(i));
+		double y_ref = hb_ref.process(x);
+		double y_pos = static_cast<double>(hb_posit.process(p32(x)));
+		max_err = std::max(max_err, std::abs(y_ref - y_pos));
+		max_val = std::max(max_val, std::abs(y_ref));
+	}
+
+	double rel_err = (max_val > 0.0) ? max_err / max_val : 0.0;
+	std::cout << "  posit_types: posit<32,2> vs double relative error = "
+	          << rel_err << "\n";
+
+	if (rel_err > 1e-4)
+		throw std::runtime_error("test failed: posit error too large: " +
+			std::to_string(rel_err));
+
+	std::cout << "  posit_types: passed\n";
+}
+
+// ============================================================================
+// Complex samples: process complex<double> through the filter
+// ============================================================================
+
+void test_complex_samples() {
+	using complex_t = complex_for_t<double>;
+
+	auto taps_d = design_halfband<double>(11, 0.1);
+	HalfBandFilter<double> hb_re(taps_d);
+	HalfBandFilter<double> hb_im(taps_d);
+
+	// A complex signal through the filter should equal component-wise filtering
+	for (int i = 0; i < 50; ++i) {
+		double re_in = std::cos(sw::dsp::two_pi * 0.07 * static_cast<double>(i));
+		double im_in = std::sin(sw::dsp::two_pi * 0.07 * static_cast<double>(i));
+
+		double re_out = hb_re.process(re_in);
+		double im_out = hb_im.process(im_in);
+
+		complex_t expected(re_out, im_out);
+		(void)expected;
+	}
+
+	std::cout << "  complex_samples: component-wise filtering verified, passed\n";
 }
 
 // ============================================================================
@@ -566,6 +634,8 @@ int main() {
 		test_decimation_correctness();
 		test_reset();
 		test_mixed_precision();
+		test_posit_types();
+		test_complex_samples();
 		test_dense_vector();
 		test_constructor_validation();
 		test_parameter_validation();

--- a/tests/test_halfband.cpp
+++ b/tests/test_halfband.cpp
@@ -1,0 +1,493 @@
+// test_halfband.cpp: test half-band FIR filter design, processing, and decimation
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/acquisition/halfband.hpp>
+#include <sw/dsp/math/constants.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace sw::dsp;
+
+bool near(double a, double b, double eps = 1e-6) {
+	return std::abs(a - b) < eps;
+}
+
+// ============================================================================
+// Design: verify half-band tap structure
+// ============================================================================
+
+void test_design_structure() {
+	auto taps = design_halfband<double>(11, 0.1);
+
+	if (taps.size() != 11)
+		throw std::runtime_error("test failed: design returned wrong tap count");
+
+	std::size_t center = 5;
+
+	// Center tap must be 0.5
+	if (!near(static_cast<double>(taps[center]), 0.5, 1e-12))
+		throw std::runtime_error("test failed: center tap = " +
+			std::to_string(static_cast<double>(taps[center])));
+
+	// Even offsets from center must be zero
+	for (std::size_t k = 2; k <= center; k += 2) {
+		if (!near(static_cast<double>(taps[center - k]), 0.0, 1e-15))
+			throw std::runtime_error("test failed: tap[" +
+				std::to_string(center - k) + "] should be 0");
+		if (!near(static_cast<double>(taps[center + k]), 0.0, 1e-15))
+			throw std::runtime_error("test failed: tap[" +
+				std::to_string(center + k) + "] should be 0");
+	}
+
+	// Symmetry: h[center-k] == h[center+k]
+	for (std::size_t k = 1; k <= center; ++k) {
+		if (!near(static_cast<double>(taps[center - k]),
+		          static_cast<double>(taps[center + k]), 1e-15))
+			throw std::runtime_error("test failed: symmetry at offset " +
+				std::to_string(k));
+	}
+
+	std::cout << "  design_structure: passed\n";
+}
+
+// ============================================================================
+// Design: verify different filter lengths
+// ============================================================================
+
+void test_design_lengths() {
+	// Valid lengths: 4K+3 = 3, 7, 11, 15, 19
+	for (std::size_t n : {7, 11, 15, 19}) {
+		auto taps = design_halfband<double>(n, 0.15);
+		if (taps.size() != n)
+			throw std::runtime_error("test failed: design length " +
+				std::to_string(n));
+
+		std::size_t center = (n - 1) / 2;
+		if (!near(static_cast<double>(taps[center]), 0.5, 1e-12))
+			throw std::runtime_error("test failed: center tap for N=" +
+				std::to_string(n));
+	}
+
+	std::cout << "  design_lengths: passed\n";
+}
+
+// ============================================================================
+// DC gain: sum of taps should be ~1.0
+// ============================================================================
+
+void test_dc_gain() {
+	auto taps = design_halfband<double>(15, 0.1);
+
+	double sum = 0.0;
+	for (std::size_t i = 0; i < taps.size(); ++i) {
+		sum += static_cast<double>(taps[i]);
+	}
+
+	if (!near(sum, 1.0, 1e-3))
+		throw std::runtime_error("test failed: DC gain = " +
+			std::to_string(sum) + ", expected ~1.0");
+
+	std::cout << "  dc_gain: sum=" << sum << ", passed\n";
+}
+
+// ============================================================================
+// Non-zero tap count verification
+// ============================================================================
+
+void test_nonzero_count() {
+	auto taps = design_halfband<double>(11, 0.1);
+	HalfBandFilter<double> hb(taps);
+
+	// N=11, center=5: non-zero at offsets 1,3,5 from center = 3 pairs + center = 7
+	if (hb.num_nonzero_taps() != 7)
+		throw std::runtime_error("test failed: nonzero_taps = " +
+			std::to_string(hb.num_nonzero_taps()) + ", expected 7");
+
+	if (hb.num_taps() != 11)
+		throw std::runtime_error("test failed: num_taps mismatch");
+
+	if (hb.order() != 10)
+		throw std::runtime_error("test failed: order mismatch");
+
+	std::cout << "  nonzero_count: " << hb.num_nonzero_taps()
+	          << " of " << hb.num_taps() << ", passed\n";
+}
+
+// ============================================================================
+// Impulse response: verify process() matches taps
+// ============================================================================
+
+void test_impulse_response() {
+	auto taps = design_halfband<double>(11, 0.1);
+	HalfBandFilter<double> hb(taps);
+
+	// Feed impulse followed by zeros
+	std::vector<double> output;
+	output.push_back(hb.process(1.0));
+	for (int i = 1; i < 11; ++i) {
+		output.push_back(hb.process(0.0));
+	}
+
+	// Output should match taps in reverse (convolution)
+	for (std::size_t i = 0; i < 11; ++i) {
+		if (!near(output[i], static_cast<double>(taps[i]), 1e-12))
+			throw std::runtime_error("test failed: impulse y[" +
+				std::to_string(i) + "] = " + std::to_string(output[i]) +
+				", expected " + std::to_string(static_cast<double>(taps[i])));
+	}
+
+	std::cout << "  impulse_response: passed\n";
+}
+
+// ============================================================================
+// Frequency response: passband and stopband
+// ============================================================================
+
+void test_frequency_response() {
+	double tw = 0.1;
+	auto taps = design_halfband<double>(19, tw);
+	std::size_t N = taps.size();
+
+	// Evaluate |H(f)| at several frequencies
+	auto eval_H = [&](double f_norm) -> double {
+		double re = 0.0, im = 0.0;
+		for (std::size_t n = 0; n < N; ++n) {
+			double h = static_cast<double>(taps[n]);
+			double angle = sw::dsp::two_pi * f_norm * static_cast<double>(n);
+			re += h * std::cos(angle);
+			im -= h * std::sin(angle);
+		}
+		return std::sqrt(re * re + im * im);
+	};
+
+	// Passband: |H(f)| ~= 1 for f < 0.25 - tw/2 = 0.20
+	for (double f = 0.01; f <= 0.18; f += 0.02) {
+		double mag = eval_H(f);
+		double mag_db = 20.0 * std::log10(std::max(mag, 1e-15));
+		if (mag_db < -1.0)
+			throw std::runtime_error("test failed: passband at f=" +
+				std::to_string(f) + " mag_dB=" + std::to_string(mag_db));
+	}
+
+	// Stopband: |H(f)| << 1 for f > 0.25 + tw/2 = 0.30
+	for (double f = 0.32; f <= 0.48; f += 0.02) {
+		double mag = eval_H(f);
+		double mag_db = 20.0 * std::log10(std::max(mag, 1e-15));
+		if (mag_db > -10.0)
+			throw std::runtime_error("test failed: stopband at f=" +
+				std::to_string(f) + " mag_dB=" + std::to_string(mag_db));
+	}
+
+	// Symmetry about pi/2: |H(0.25-df)| + |H(0.25+df)| ~= 1
+	for (double df = 0.01; df <= 0.15; df += 0.02) {
+		double mag_lo = eval_H(0.25 - df);
+		double mag_hi = eval_H(0.25 + df);
+		double sum = mag_lo + mag_hi;
+		if (!near(sum, 1.0, 0.05))
+			throw std::runtime_error("test failed: symmetry at df=" +
+				std::to_string(df) + " sum=" + std::to_string(sum));
+	}
+
+	std::cout << "  frequency_response: passed\n";
+}
+
+// ============================================================================
+// Block processing: matches sample-by-sample
+// ============================================================================
+
+void test_block_processing() {
+	auto taps = design_halfband<double>(11, 0.1);
+
+	HalfBandFilter<double> hb1(taps);
+	HalfBandFilter<double> hb2(taps);
+
+	// Generate test signal
+	std::vector<double> input(50);
+	for (std::size_t i = 0; i < input.size(); ++i) {
+		input[i] = std::sin(sw::dsp::two_pi * 0.05 * static_cast<double>(i));
+	}
+
+	// Sample-by-sample
+	std::vector<double> out1;
+	for (auto s : input) out1.push_back(hb1.process(s));
+
+	// Block
+	std::vector<double> out2(input.size());
+	hb2.process_block(std::span<const double>(input),
+	                  std::span<double>(out2));
+
+	for (std::size_t i = 0; i < out1.size(); ++i) {
+		if (!near(out1[i], out2[i], 1e-12))
+			throw std::runtime_error("test failed: block mismatch at " +
+				std::to_string(i));
+	}
+
+	std::cout << "  block_processing: passed\n";
+}
+
+// ============================================================================
+// Decimation: output count and basic correctness
+// ============================================================================
+
+void test_decimation_count() {
+	auto taps = design_halfband<double>(11, 0.1);
+	HalfBandFilter<double> hb(taps);
+
+	std::vector<double> input(100, 1.0);
+	std::vector<double> output;
+	hb.process_block_decimate(std::span<const double>(input), output);
+
+	// 100 input samples / 2 = 50 output samples
+	if (output.size() != 50)
+		throw std::runtime_error("test failed: decimation count = " +
+			std::to_string(output.size()) + ", expected 50");
+
+	std::cout << "  decimation_count: passed\n";
+}
+
+void test_decimation_dc() {
+	auto taps = design_halfband<double>(15, 0.1);
+	HalfBandFilter<double> hb(taps);
+
+	// Feed DC = 1.0 through decimation — settled output should be ~1.0
+	std::vector<double> input(200, 1.0);
+	std::vector<double> output;
+	hb.process_block_decimate(std::span<const double>(input), output);
+
+	// Check last outputs are settled near 1.0
+	for (std::size_t i = output.size() - 10; i < output.size(); ++i) {
+		if (!near(output[i], 1.0, 1e-3))
+			throw std::runtime_error("test failed: decimation DC at " +
+				std::to_string(i) + " = " + std::to_string(output[i]));
+	}
+
+	std::cout << "  decimation_dc: passed\n";
+}
+
+// ============================================================================
+// Decimation: compare with full-rate + downsample
+// ============================================================================
+
+void test_decimation_correctness() {
+	auto taps = design_halfband<double>(11, 0.1);
+
+	HalfBandFilter<double> hb_full(taps);
+	HalfBandFilter<double> hb_dec(taps);
+
+	// Generate lowpass signal (below Nyquist/4)
+	std::vector<double> input(100);
+	for (std::size_t i = 0; i < input.size(); ++i) {
+		input[i] = std::sin(sw::dsp::two_pi * 0.05 * static_cast<double>(i));
+	}
+
+	// Full-rate then downsample
+	std::vector<double> full_out;
+	for (auto s : input) full_out.push_back(hb_full.process(s));
+
+	std::vector<double> downsampled;
+	for (std::size_t i = 1; i < full_out.size(); i += 2) {
+		downsampled.push_back(full_out[i]);
+	}
+
+	// Integrated decimation
+	std::vector<double> dec_out;
+	hb_dec.process_block_decimate(std::span<const double>(input), dec_out);
+
+	if (downsampled.size() != dec_out.size())
+		throw std::runtime_error("test failed: decimation size mismatch: " +
+			std::to_string(downsampled.size()) + " vs " +
+			std::to_string(dec_out.size()));
+
+	for (std::size_t i = 0; i < dec_out.size(); ++i) {
+		if (!near(downsampled[i], dec_out[i], 1e-12))
+			throw std::runtime_error("test failed: decimation mismatch at " +
+				std::to_string(i));
+	}
+
+	std::cout << "  decimation_correctness: passed\n";
+}
+
+// ============================================================================
+// Reset clears state
+// ============================================================================
+
+void test_reset() {
+	auto taps = design_halfband<double>(11, 0.1);
+	HalfBandFilter<double> hb(taps);
+
+	std::vector<double> input(20);
+	for (std::size_t i = 0; i < input.size(); ++i) {
+		input[i] = std::sin(sw::dsp::two_pi * 0.1 * static_cast<double>(i));
+	}
+
+	std::vector<double> out1;
+	for (auto s : input) out1.push_back(hb.process(s));
+
+	hb.reset();
+
+	std::vector<double> out2;
+	for (auto s : input) out2.push_back(hb.process(s));
+
+	for (std::size_t i = 0; i < out1.size(); ++i) {
+		if (!near(out1[i], out2[i], 1e-12))
+			throw std::runtime_error("test failed: reset mismatch at " +
+				std::to_string(i));
+	}
+
+	std::cout << "  reset: passed\n";
+}
+
+// ============================================================================
+// Mixed precision: float coefficients with double state
+// ============================================================================
+
+void test_mixed_precision() {
+	auto taps_d = design_halfband<double>(15, 0.1);
+
+	// Project to float coefficients
+	mtl::vec::dense_vector<float> taps_f(taps_d.size());
+	for (std::size_t i = 0; i < taps_d.size(); ++i) {
+		taps_f[i] = static_cast<float>(taps_d[i]);
+	}
+
+	HalfBandFilter<double, double, double> hb_ref(taps_d);
+	HalfBandFilter<float, double, double>  hb_mix(taps_f);
+
+	// Signal: sum of two frequencies
+	std::vector<double> input(200);
+	for (std::size_t i = 0; i < input.size(); ++i) {
+		input[i] = std::sin(sw::dsp::two_pi * 0.05 * static_cast<double>(i))
+		         + 0.3 * std::sin(sw::dsp::two_pi * 0.12 * static_cast<double>(i));
+	}
+
+	double max_err = 0.0, max_val = 0.0;
+	for (auto s : input) {
+		double y_ref = hb_ref.process(s);
+		double y_mix = hb_mix.process(s);
+		max_err = std::max(max_err, std::abs(y_ref - y_mix));
+		max_val = std::max(max_val, std::abs(y_ref));
+	}
+
+	double rel_err = (max_val > 0.0) ? max_err / max_val : 0.0;
+	std::cout << "  mixed_precision: float vs double relative error = "
+	          << rel_err << "\n";
+
+	if (rel_err > 1e-5)
+		throw std::runtime_error("test failed: mixed-precision error too large: " +
+			std::to_string(rel_err));
+
+	std::cout << "  mixed_precision: passed\n";
+}
+
+// ============================================================================
+// Dense-vector overloads
+// ============================================================================
+
+void test_dense_vector() {
+	auto taps = design_halfband<double>(11, 0.1);
+	HalfBandFilter<double> hb1(taps);
+	HalfBandFilter<double> hb2(taps);
+
+	mtl::vec::dense_vector<double> input(30);
+	for (std::size_t i = 0; i < input.size(); ++i) {
+		input[i] = std::sin(sw::dsp::two_pi * 0.07 * static_cast<double>(i));
+	}
+
+	// Full-rate dense_vector
+	auto out_full = hb1.process_block(input);
+	if (out_full.size() != 30)
+		throw std::runtime_error("test failed: dense_vector full-rate size");
+
+	// Decimation dense_vector
+	auto out_dec = hb2.process_block_decimate(input);
+	if (out_dec.size() != 15)
+		throw std::runtime_error("test failed: dense_vector decimate size = " +
+			std::to_string(out_dec.size()));
+
+	std::cout << "  dense_vector: passed\n";
+}
+
+// ============================================================================
+// Parameter validation
+// ============================================================================
+
+void test_parameter_validation() {
+	bool caught = false;
+
+	// Design: even tap count
+	caught = false;
+	try { design_halfband<double>(10, 0.1); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: even taps should throw");
+
+	// Design: wrong form (4K+3 violation: 9 = 4*2+1, not 4K+3)
+	caught = false;
+	try { design_halfband<double>(9, 0.1); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: 4K+1 taps should throw");
+
+	// Design: transition width out of range
+	caught = false;
+	try { design_halfband<double>(11, 0.6); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: tw=0.6 should throw");
+
+	// Design: negative transition width
+	caught = false;
+	try { design_halfband<double>(11, -0.1); }
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: tw=-0.1 should throw");
+
+	// Filter: even tap count
+	caught = false;
+	try {
+		mtl::vec::dense_vector<double> bad(4, 0.25);
+		HalfBandFilter<double> hb(bad);
+	}
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: even filter taps should throw");
+
+	// Filter: too few taps
+	caught = false;
+	try {
+		mtl::vec::dense_vector<double> bad(1, 1.0);
+		HalfBandFilter<double> hb(bad);
+	}
+	catch (const std::invalid_argument&) { caught = true; }
+	if (!caught) throw std::runtime_error("test failed: 1-tap filter should throw");
+
+	std::cout << "  parameter_validation: passed\n";
+}
+
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "Half-band FIR filter tests\n";
+		test_design_structure();
+		test_design_lengths();
+		test_dc_gain();
+		test_nonzero_count();
+		test_impulse_response();
+		test_frequency_response();
+		test_block_processing();
+		test_decimation_count();
+		test_decimation_dc();
+		test_decimation_correctness();
+		test_reset();
+		test_mixed_precision();
+		test_dense_vector();
+		test_parameter_validation();
+		std::cout << "All half-band tests passed.\n";
+		return 0;
+	} catch (const std::exception& e) {
+		std::cerr << "FAIL: " << e.what() << '\n';
+		return 1;
+	}
+}

--- a/tests/test_halfband.cpp
+++ b/tests/test_halfband.cpp
@@ -8,6 +8,7 @@
 
 #include <universal/number/posit/posit.hpp>
 
+#include <array>
 #include <cmath>
 #include <iostream>
 #include <stdexcept>
@@ -153,10 +154,10 @@ void test_impulse_response() {
 	HalfBandFilter<double> hb(taps);
 
 	// Feed impulse followed by zeros
-	std::vector<double> output;
-	output.push_back(hb.process(1.0));
+	std::array<double, 11> output;
+	output[0] = hb.process(1.0);
 	for (int i = 1; i < 11; ++i) {
-		output.push_back(hb.process(0.0));
+		output[static_cast<std::size_t>(i)] = hb.process(0.0);
 	}
 
 	// Output should match taps: y[n] = h[n] for unit impulse at n=0
@@ -479,8 +480,9 @@ void test_complex_samples() {
 	auto taps_d = design_halfband<double>(11, 0.1);
 	HalfBandFilter<double> hb_re(taps_d);
 	HalfBandFilter<double> hb_im(taps_d);
+	HalfBandFilter<double, complex_t, complex_t> hb_cx(taps_d);
 
-	// A complex signal through the filter should equal component-wise filtering
+	// Complex filter output should match component-wise real filtering
 	for (int i = 0; i < 50; ++i) {
 		double re_in = std::cos(sw::dsp::two_pi * 0.07 * static_cast<double>(i));
 		double im_in = std::sin(sw::dsp::two_pi * 0.07 * static_cast<double>(i));
@@ -488,11 +490,15 @@ void test_complex_samples() {
 		double re_out = hb_re.process(re_in);
 		double im_out = hb_im.process(im_in);
 
-		complex_t expected(re_out, im_out);
-		(void)expected;
+		complex_t x(re_in, im_in);
+		complex_t y = hb_cx.process(x);
+		if (!near(y.real(), re_out, 1e-12) ||
+		    !near(y.imag(), im_out, 1e-12))
+			throw std::runtime_error("test failed: complex filtering mismatch at " +
+				std::to_string(i));
 	}
 
-	std::cout << "  complex_samples: component-wise filtering verified, passed\n";
+	std::cout << "  complex_samples: passed\n";
 }
 
 // ============================================================================

--- a/tests/test_halfband.cpp
+++ b/tests/test_halfband.cpp
@@ -134,7 +134,7 @@ void test_impulse_response() {
 		output.push_back(hb.process(0.0));
 	}
 
-	// Output should match taps in reverse (convolution)
+	// Output should match taps: y[n] = h[n] for unit impulse at n=0
 	for (std::size_t i = 0; i < 11; ++i) {
 		if (!near(output[i], static_cast<double>(taps[i]), 1e-12))
 			throw std::runtime_error("test failed: impulse y[" +


### PR DESCRIPTION
## Summary
- Add `HalfBandFilter` class with optimized computation that skips zero-valued taps
- Design function `design_halfband<T>()` via Remez exchange with enforced half-band constraints (center=0.5, even-offset zeros, DC gain normalization)
- Integrated 2× decimation mode (`process_decimate`, `process_block_decimate`) computes only surviving outputs for ~4× savings
- Three-scalar parameterization: `CoeffScalar`, `StateScalar`, `SampleScalar`

## Changes
- `include/sw/dsp/acquisition/halfband.hpp` — New half-band filter class and design function
- `include/sw/dsp/acquisition/acquisition.hpp` — Added halfband.hpp to umbrella
- `tests/test_halfband.cpp` — 14 tests covering structure, DC gain, impulse response, frequency response, block processing, decimation correctness, reset, mixed precision, dense_vector, parameter validation
- `tests/CMakeLists.txt` — Register test_halfband
- `docs-site/src/content/docs/acquisition/halfband.md` — Full documentation with theory, API, pipeline diagram, precision considerations

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_halfband | OK | PASS (14/14) | OK | PASS (14/14) |
| test_cic | — | PASS (regression) | — | — |
| test_fir | — | PASS (regression) | — | — |
| test_remez | — | PASS (regression) | — | — |
| test_fir_multirate | — | PASS (regression) | — | — |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a half-band FIR filter for efficient 2× decimation with full-rate and decimating processing, block APIs, reset/query methods, and mixed-precision support; now available via the acquisition header.

* **Documentation**
  * New guide on half-band properties, valid lengths, design guidance, performance trade-offs, cascade examples, and precision considerations.

* **Tests**
  * Comprehensive tests for design structure, frequency response, streaming/block/decimating behavior, mixed-precision, complex samples, and parameter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->