### PR TITLE
fix(filter): parameterize FIR window-method design on T

### DIFF
--- a/include/sw/dsp/filter/fir/fir_design.hpp
+++ b/include/sw/dsp/filter/fir/fir_design.hpp
@@ -5,6 +5,13 @@
 // an ideal (sinc) impulse response. The window controls the
 // trade-off between transition bandwidth and stopband attenuation.
 //
+// Intermediate math runs in the template scalar T so that callers using
+// posit, cfloat, fixpnt, etc. get design-time computation at their
+// declared precision — a requirement for embedded mixed-precision
+// deployments where filter design may execute on-target. ADL-friendly
+// trig (using std::sin) picks up sw::universal::sin for Universal number
+// types and std::sin for native floats.
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
@@ -27,21 +34,33 @@ namespace sw::dsp {
 template <DspField T>
 mtl::vec::dense_vector<T> design_fir_lowpass(std::size_t num_taps, T cutoff,
                                               const mtl::vec::dense_vector<T>& window) {
+	using std::abs; using std::sin;
 	if (window.size() != num_taps)
 		throw std::invalid_argument("design_fir_lowpass: window size must equal num_taps");
 	mtl::vec::dense_vector<T> taps(num_taps);
-	int M = static_cast<int>(num_taps - 1);
-	double fc = static_cast<double>(cutoff);
+
+	// Constants built from pure constructor calls (constexpr since
+	// Universal v4.6.10 for posit's IEEE-754 ctors).
+	constexpr T two    = T(2);
+	constexpr T pi_T   = T(pi);
+	constexpr T two_pi_T = T(two_pi);
+	// Odd num_taps gives M/2 an integer, so x=0 at the center tap exactly.
+	// Even num_taps gives M/2 a half-integer, so the sinc argument never
+	// lands on 0. `tiny` is a safety threshold against floating-point drift.
+	const     T tiny   = T(1) / T(1'000'000'000'000LL);
+
+	const std::size_t M = num_taps - 1;
+	const T half_M = T(M) / two;
 
 	for (std::size_t n = 0; n < num_taps; ++n) {
-		double x = static_cast<double>(n) - M * 0.5;
-		double h;
-		if (std::abs(x) < 1e-10) {
-			h = 2.0 * fc;  // sinc(0) = 1, scaled by 2*fc
+		T x = T(n) - half_M;
+		T h;
+		if (abs(x) < tiny) {
+			h = two * cutoff;  // sinc(0) = 1, scaled by 2*fc
 		} else {
-			h = std::sin(2.0 * pi * fc * x) / (pi * x);
+			h = sin(two_pi_T * cutoff * x) / (pi_T * x);
 		}
-		taps[n] = static_cast<T>(h) * window[n];
+		taps[n] = h * window[n];
 	}
 	return taps;
 }
@@ -51,14 +70,16 @@ mtl::vec::dense_vector<T> design_fir_lowpass(std::size_t num_taps, T cutoff,
 template <DspField T>
 mtl::vec::dense_vector<T> design_fir_highpass(std::size_t num_taps, T cutoff,
                                                const mtl::vec::dense_vector<T>& window) {
-	auto lp = design_fir_lowpass(num_taps, cutoff, window);
+	auto lp = design_fir_lowpass<T>(num_taps, cutoff, window);
+
+	constexpr T one = T(1);
 
 	// Spectral inversion: negate all taps, add 1 to center tap
 	for (std::size_t n = 0; n < num_taps; ++n) {
-		lp[n] = T{} - lp[n];
+		lp[n] = -lp[n];
 	}
 	std::size_t center = (num_taps - 1) / 2;
-	lp[center] = lp[center] + T{1};
+	lp[center] = lp[center] + one;
 
 	return lp;
 }
@@ -69,8 +90,8 @@ template <DspField T>
 mtl::vec::dense_vector<T> design_fir_bandpass(std::size_t num_taps,
                                                T f_low, T f_high,
                                                const mtl::vec::dense_vector<T>& window) {
-	auto lp_high = design_fir_lowpass(num_taps, f_high, window);
-	auto lp_low = design_fir_lowpass(num_taps, f_low, window);
+	auto lp_high = design_fir_lowpass<T>(num_taps, f_high, window);
+	auto lp_low  = design_fir_lowpass<T>(num_taps, f_low,  window);
 
 	mtl::vec::dense_vector<T> bp(num_taps);
 	for (std::size_t n = 0; n < num_taps; ++n) {

--- a/tests/test_fir.cpp
+++ b/tests/test_fir.cpp
@@ -13,6 +13,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include <universal/number/posit/posit.hpp>
+
 using namespace sw::dsp;
 
 bool near(double a, double b, double eps = 1e-6) {
@@ -241,6 +243,90 @@ void test_fir_filtering_signal() {
 	          << high_energy_out / high_energy_in << ")\n";
 }
 
+// ============================================================================
+// Posit<32,2> regression: verify that design_fir_lowpass/highpass/bandpass
+// run their intermediate math in T, not double. Compares a posit-designed
+// tap set against a double-designed reference; agreement must be within
+// posit<32,2> precision (~2^-28 ULP near unit magnitude).
+// ============================================================================
+
+void test_design_in_posit_precision() {
+	using posit_t = sw::universal::posit<32, 2>;
+	std::size_t N = 31;
+	double cutoff_d = 0.2;
+	posit_t cutoff_p(cutoff_d);
+
+	// Design the window in double, cast to posit (windows are a separate
+	// cleanup — issue #115; here we only exercise fir_design in posit).
+	auto win_d = hamming_window<double>(N);
+	mtl::vec::dense_vector<posit_t> win_p(N);
+	for (std::size_t i = 0; i < N; ++i) win_p[i] = posit_t(win_d[i]);
+
+	// ---- lowpass
+	auto lp_d = design_fir_lowpass<double>(N, cutoff_d, win_d);
+	auto lp_p = design_fir_lowpass<posit_t>(N, cutoff_p, win_p);
+
+	if (lp_p.size() != N)
+		throw std::runtime_error("test failed: posit lowpass length");
+
+	// Symmetric (linear phase)
+	double max_asym = 0.0;
+	for (std::size_t i = 0; i < N / 2; ++i) {
+		double li = static_cast<double>(lp_p[i]);
+		double ri = static_cast<double>(lp_p[N - 1 - i]);
+		double a = std::abs(li - ri);
+		if (a > max_asym) max_asym = a;
+	}
+	if (max_asym > 1e-6)
+		throw std::runtime_error("test failed: posit lowpass asymmetry = " +
+			std::to_string(max_asym));
+
+	// Agreement with double reference
+	double max_diff = 0.0;
+	for (std::size_t i = 0; i < N; ++i) {
+		double d = std::abs(static_cast<double>(lp_p[i]) - lp_d[i]);
+		if (d > max_diff) max_diff = d;
+	}
+	if (max_diff > 1e-6)
+		throw std::runtime_error("test failed: posit lowpass max diff vs double = " +
+			std::to_string(max_diff));
+
+	// ---- highpass
+	auto hp_d = design_fir_highpass<double>(N, cutoff_d, win_d);
+	auto hp_p = design_fir_highpass<posit_t>(N, cutoff_p, win_p);
+	double hp_max_diff = 0.0;
+	for (std::size_t i = 0; i < N; ++i) {
+		double d = std::abs(static_cast<double>(hp_p[i]) - hp_d[i]);
+		if (d > hp_max_diff) hp_max_diff = d;
+	}
+	if (hp_max_diff > 1e-6)
+		throw std::runtime_error("test failed: posit highpass max diff = " +
+			std::to_string(hp_max_diff));
+
+	// ---- bandpass
+	std::size_t Nbp = 63;
+	auto win_d_bp = hamming_window<double>(Nbp);
+	mtl::vec::dense_vector<posit_t> win_p_bp(Nbp);
+	for (std::size_t i = 0; i < Nbp; ++i) win_p_bp[i] = posit_t(win_d_bp[i]);
+
+	auto bp_d = design_fir_bandpass<double>(Nbp, 0.15, 0.35, win_d_bp);
+	auto bp_p = design_fir_bandpass<posit_t>(Nbp, posit_t(0.15), posit_t(0.35), win_p_bp);
+	double bp_max_diff = 0.0;
+	for (std::size_t i = 0; i < Nbp; ++i) {
+		double d = std::abs(static_cast<double>(bp_p[i]) - bp_d[i]);
+		if (d > bp_max_diff) bp_max_diff = d;
+	}
+	if (bp_max_diff > 1e-6)
+		throw std::runtime_error("test failed: posit bandpass max diff = " +
+			std::to_string(bp_max_diff));
+
+	std::cout << "  design_in_posit_precision: lowpass asym=" << max_asym
+	          << " diff=" << max_diff
+	          << ", highpass diff=" << hp_max_diff
+	          << ", bandpass diff=" << bp_max_diff
+	          << ", passed\n";
+}
+
 void test_fir_validation() {
 	// Empty taps should throw
 	bool caught = false;
@@ -266,6 +352,7 @@ int main() {
 		test_design_lowpass();
 		test_design_highpass();
 		test_design_bandpass();
+		test_design_in_posit_precision();
 		test_fir_filtering_signal();
 		test_fir_validation();
 


### PR DESCRIPTION
## Summary
- Refactors `design_fir_lowpass`, `design_fir_highpass`, `design_fir_bandpass` so all intermediate math runs in the template scalar `T` — not `double`
- Adds a posit<32,2> regression test verifying agreement with the double reference across all three functions
- Matches the `design_cic_compensator` precedent from PR #110 (commit 0e739b6) and the Universal v4.6.10 constexpr-posit upgrade from PR #110 (commit fecc760)

## Root cause
The sinc kernel ran entirely through `double` (`double fc`, `double x`, `double h`, `std::sin(double)`), casting the result to `T` only at the output assignment. Users instantiating with `posit<32,2>` / `cfloat` / `fixpnt` got output in their chosen type but the design-time math went through IEEE 64-bit — the library can't execute on embedded targets that lack double support, and the mixed-precision value proposition is undermined.

## Changes
- `include/sw/dsp/filter/fir/fir_design.hpp` — all intermediates in T, ADL trig, `constexpr` constants for the ctor-only values (enabled by Universal v4.6.10)
- `tests/test_fir.cpp` — new `test_design_in_posit_precision` covering all three functions

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_fir | OK | PASS | OK | PASS |

Full gcc ctest: 31/31 pass. Clang regression on fir/remez/src/halfband/decimation_chain: 6/6 pass.

### Posit<32,2> vs double agreement (new test)
| Filter | Max diff vs double |
|---|---|
| lowpass | 1.35e-9 |
| highpass | 1.49e-9 |
| bandpass | 3.17e-9 |

All well within posit<32,2> ULP near unit magnitude.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Resolves #111

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * FIR filter design computations now use template scalar types throughout for improved precision handling across different numeric types.

* **Tests**
  * Added regression test validating filter design with posit precision support.

* **Documentation**
  * Updated documentation reflecting precision-aware design-time computation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->