### PR TITLE
fix(filter): parameterize RBJ biquad design on CoeffScalar

### DIFF
--- a/include/sw/dsp/filter/iir/rbj.hpp
+++ b/include/sw/dsp/filter/iir/rbj.hpp
@@ -4,6 +4,16 @@
 // Direct coefficient formulas — no analog prototype needed.
 // Reference: http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt
 //
+// The public setup() APIs take `double` parameters (sample_rate, freq, Q,
+// gain_db, slope) for interface stability, but all intermediate
+// coefficient math runs in CoeffScalar. A posit or fixed-point CoeffScalar
+// therefore produces coefficients that were computed end-to-end at the
+// caller's declared precision — required for embedded mixed-precision
+// deployments where filter design executes on the target.
+//
+// ADL-friendly trig (using std::cos; cos(x);) picks up sw::universal::cos
+// for Universal number types and std::cos for native floats.
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
@@ -58,19 +68,24 @@ public:
 	static constexpr int max_stages = 1;
 
 	void setup(double sample_rate, double cutoff_freq, double q = 0.7071) {
+		using std::cos; using std::sin;
 		detail::validate_freq(sample_rate, cutoff_freq, "rbj::LowPass");
 		detail::validate_q(q, "rbj::LowPass");
-		CoeffScalar w0 = two_pi_v<CoeffScalar> * static_cast<CoeffScalar>(cutoff_freq / sample_rate);
-		CoeffScalar cs = static_cast<CoeffScalar>(std::cos(static_cast<double>(w0)));
-		CoeffScalar sn = static_cast<CoeffScalar>(std::sin(static_cast<double>(w0)));
-		CoeffScalar alpha = sn / (CoeffScalar{2} * static_cast<CoeffScalar>(q));
 
-		CoeffScalar b0 = (CoeffScalar{1} - cs) / CoeffScalar{2};
-		CoeffScalar b1 =  CoeffScalar{1} - cs;
-		CoeffScalar b2 = (CoeffScalar{1} - cs) / CoeffScalar{2};
-		CoeffScalar a0 =  CoeffScalar{1} + alpha;
-		CoeffScalar a1 =  CoeffScalar{-2} * cs;
-		CoeffScalar a2 =  CoeffScalar{1} - alpha;
+		constexpr CoeffScalar one = CoeffScalar(1);
+		constexpr CoeffScalar two = CoeffScalar(2);
+		const CoeffScalar w0 = CoeffScalar(two_pi)
+		                     * CoeffScalar(cutoff_freq) / CoeffScalar(sample_rate);
+		const CoeffScalar cs = cos(w0);
+		const CoeffScalar sn = sin(w0);
+		const CoeffScalar alpha = sn / (two * CoeffScalar(q));
+
+		CoeffScalar b0 = (one - cs) / two;
+		CoeffScalar b1 =  one - cs;
+		CoeffScalar b2 = (one - cs) / two;
+		CoeffScalar a0 =  one + alpha;
+		CoeffScalar a1 = -(two * cs);
+		CoeffScalar a2 =  one - alpha;
 
 		cascade_.set_num_stages(1);
 		cascade_.stage(0) = detail::normalize(b0, b1, b2, a0, a1, a2);
@@ -93,19 +108,24 @@ public:
 	static constexpr int max_stages = 1;
 
 	void setup(double sample_rate, double cutoff_freq, double q = 0.7071) {
+		using std::cos; using std::sin;
 		detail::validate_freq(sample_rate, cutoff_freq, "rbj::HighPass");
 		detail::validate_q(q, "rbj::HighPass");
-		CoeffScalar w0 = two_pi_v<CoeffScalar> * static_cast<CoeffScalar>(cutoff_freq / sample_rate);
-		CoeffScalar cs = static_cast<CoeffScalar>(std::cos(static_cast<double>(w0)));
-		CoeffScalar sn = static_cast<CoeffScalar>(std::sin(static_cast<double>(w0)));
-		CoeffScalar alpha = sn / (CoeffScalar{2} * static_cast<CoeffScalar>(q));
 
-		CoeffScalar b0 =  (CoeffScalar{1} + cs) / CoeffScalar{2};
-		CoeffScalar b1 = -(CoeffScalar{1} + cs);
-		CoeffScalar b2 =  (CoeffScalar{1} + cs) / CoeffScalar{2};
-		CoeffScalar a0 =  CoeffScalar{1} + alpha;
-		CoeffScalar a1 =  CoeffScalar{-2} * cs;
-		CoeffScalar a2 =  CoeffScalar{1} - alpha;
+		constexpr CoeffScalar one = CoeffScalar(1);
+		constexpr CoeffScalar two = CoeffScalar(2);
+		const CoeffScalar w0 = CoeffScalar(two_pi)
+		                     * CoeffScalar(cutoff_freq) / CoeffScalar(sample_rate);
+		const CoeffScalar cs = cos(w0);
+		const CoeffScalar sn = sin(w0);
+		const CoeffScalar alpha = sn / (two * CoeffScalar(q));
+
+		CoeffScalar b0 =  (one + cs) / two;
+		CoeffScalar b1 = -(one + cs);
+		CoeffScalar b2 =  (one + cs) / two;
+		CoeffScalar a0 =   one + alpha;
+		CoeffScalar a1 = -(two * cs);
+		CoeffScalar a2 =   one - alpha;
 
 		cascade_.set_num_stages(1);
 		cascade_.stage(0) = detail::normalize(b0, b1, b2, a0, a1, a2);
@@ -128,19 +148,25 @@ public:
 	static constexpr int max_stages = 1;
 
 	void setup(double sample_rate, double center_freq, double bandwidth = 1.0) {
+		using std::cos; using std::sin;
 		detail::validate_freq(sample_rate, center_freq, "rbj::BandPass");
 		detail::validate_q(bandwidth, "rbj::BandPass");
-		CoeffScalar w0 = two_pi_v<CoeffScalar> * static_cast<CoeffScalar>(center_freq / sample_rate);
-		CoeffScalar cs = static_cast<CoeffScalar>(std::cos(static_cast<double>(w0)));
-		CoeffScalar sn = static_cast<CoeffScalar>(std::sin(static_cast<double>(w0)));
-		CoeffScalar alpha = sn / (CoeffScalar{2} * static_cast<CoeffScalar>(bandwidth));
+
+		constexpr CoeffScalar zero = CoeffScalar(0);
+		constexpr CoeffScalar one  = CoeffScalar(1);
+		constexpr CoeffScalar two  = CoeffScalar(2);
+		const CoeffScalar w0 = CoeffScalar(two_pi)
+		                     * CoeffScalar(center_freq) / CoeffScalar(sample_rate);
+		const CoeffScalar cs = cos(w0);
+		const CoeffScalar sn = sin(w0);
+		const CoeffScalar alpha = sn / (two * CoeffScalar(bandwidth));
 
 		CoeffScalar b0 =  alpha;
-		CoeffScalar b1 =  CoeffScalar{};
+		CoeffScalar b1 =  zero;
 		CoeffScalar b2 = -alpha;
-		CoeffScalar a0 =  CoeffScalar{1} + alpha;
-		CoeffScalar a1 =  CoeffScalar{-2} * cs;
-		CoeffScalar a2 =  CoeffScalar{1} - alpha;
+		CoeffScalar a0 =  one + alpha;
+		CoeffScalar a1 = -(two * cs);
+		CoeffScalar a2 =  one - alpha;
 
 		cascade_.set_num_stages(1);
 		cascade_.stage(0) = detail::normalize(b0, b1, b2, a0, a1, a2);
@@ -163,19 +189,24 @@ public:
 	static constexpr int max_stages = 1;
 
 	void setup(double sample_rate, double center_freq, double bandwidth = 1.0) {
+		using std::cos; using std::sin;
 		detail::validate_freq(sample_rate, center_freq, "rbj::BandStop");
 		detail::validate_q(bandwidth, "rbj::BandStop");
-		CoeffScalar w0 = two_pi_v<CoeffScalar> * static_cast<CoeffScalar>(center_freq / sample_rate);
-		CoeffScalar cs = static_cast<CoeffScalar>(std::cos(static_cast<double>(w0)));
-		CoeffScalar sn = static_cast<CoeffScalar>(std::sin(static_cast<double>(w0)));
-		CoeffScalar alpha = sn / (CoeffScalar{2} * static_cast<CoeffScalar>(bandwidth));
 
-		CoeffScalar b0 =  CoeffScalar{1};
-		CoeffScalar b1 =  CoeffScalar{-2} * cs;
-		CoeffScalar b2 =  CoeffScalar{1};
-		CoeffScalar a0 =  CoeffScalar{1} + alpha;
-		CoeffScalar a1 =  CoeffScalar{-2} * cs;
-		CoeffScalar a2 =  CoeffScalar{1} - alpha;
+		constexpr CoeffScalar one = CoeffScalar(1);
+		constexpr CoeffScalar two = CoeffScalar(2);
+		const CoeffScalar w0 = CoeffScalar(two_pi)
+		                     * CoeffScalar(center_freq) / CoeffScalar(sample_rate);
+		const CoeffScalar cs = cos(w0);
+		const CoeffScalar sn = sin(w0);
+		const CoeffScalar alpha = sn / (two * CoeffScalar(bandwidth));
+
+		CoeffScalar b0 =  one;
+		CoeffScalar b1 = -(two * cs);
+		CoeffScalar b2 =  one;
+		CoeffScalar a0 =  one + alpha;
+		CoeffScalar a1 = -(two * cs);
+		CoeffScalar a2 =  one - alpha;
 
 		cascade_.set_num_stages(1);
 		cascade_.stage(0) = detail::normalize(b0, b1, b2, a0, a1, a2);
@@ -198,19 +229,24 @@ public:
 	static constexpr int max_stages = 1;
 
 	void setup(double sample_rate, double center_freq, double q = 0.7071) {
+		using std::cos; using std::sin;
 		detail::validate_freq(sample_rate, center_freq, "rbj::AllPass");
 		detail::validate_q(q, "rbj::AllPass");
-		CoeffScalar w0 = two_pi_v<CoeffScalar> * static_cast<CoeffScalar>(center_freq / sample_rate);
-		CoeffScalar cs = static_cast<CoeffScalar>(std::cos(static_cast<double>(w0)));
-		CoeffScalar sn = static_cast<CoeffScalar>(std::sin(static_cast<double>(w0)));
-		CoeffScalar alpha = sn / (CoeffScalar{2} * static_cast<CoeffScalar>(q));
 
-		CoeffScalar b0 =  CoeffScalar{1} - alpha;
-		CoeffScalar b1 =  CoeffScalar{-2} * cs;
-		CoeffScalar b2 =  CoeffScalar{1} + alpha;
-		CoeffScalar a0 =  CoeffScalar{1} + alpha;
-		CoeffScalar a1 =  CoeffScalar{-2} * cs;
-		CoeffScalar a2 =  CoeffScalar{1} - alpha;
+		constexpr CoeffScalar one = CoeffScalar(1);
+		constexpr CoeffScalar two = CoeffScalar(2);
+		const CoeffScalar w0 = CoeffScalar(two_pi)
+		                     * CoeffScalar(center_freq) / CoeffScalar(sample_rate);
+		const CoeffScalar cs = cos(w0);
+		const CoeffScalar sn = sin(w0);
+		const CoeffScalar alpha = sn / (two * CoeffScalar(q));
+
+		CoeffScalar b0 =  one - alpha;
+		CoeffScalar b1 = -(two * cs);
+		CoeffScalar b2 =  one + alpha;
+		CoeffScalar a0 =  one + alpha;
+		CoeffScalar a1 = -(two * cs);
+		CoeffScalar a2 =  one - alpha;
 
 		cascade_.set_num_stages(1);
 		cascade_.stage(0) = detail::normalize(b0, b1, b2, a0, a1, a2);
@@ -233,25 +269,38 @@ public:
 	static constexpr int max_stages = 1;
 
 	void setup(double sample_rate, double cutoff_freq, double gain_db, double slope = 1.0) {
+		using std::cos; using std::sin; using std::pow; using std::sqrt;
 		detail::validate_freq(sample_rate, cutoff_freq, "rbj::LowShelf");
 		if (!(slope > 0.0)) throw std::invalid_argument("rbj::LowShelf: slope must be > 0");
 		if (!std::isfinite(gain_db)) throw std::invalid_argument("rbj::LowShelf: gain_db must be finite");
-		double A  = std::pow(10.0, gain_db / 40.0);
-		CoeffScalar w0 = two_pi_v<CoeffScalar> * static_cast<CoeffScalar>(cutoff_freq / sample_rate);
-		double cs = std::cos(static_cast<double>(w0));
-		double sn = std::sin(static_cast<double>(w0));
-		double radicand = (A + 1.0/A) * (1.0/slope - 1.0) + 2.0;
-		double alpha = sn / 2.0 * std::sqrt(std::max(0.0, radicand));
-		double sq = 2.0 * std::sqrt(A) * alpha;
 
-		auto C = [](double v) { return static_cast<CoeffScalar>(v); };
+		constexpr CoeffScalar zero = CoeffScalar(0);
+		constexpr CoeffScalar one  = CoeffScalar(1);
+		constexpr CoeffScalar two  = CoeffScalar(2);
+		constexpr CoeffScalar ten  = CoeffScalar(10);
+		constexpr CoeffScalar forty = CoeffScalar(40);
 
-		CoeffScalar b0 = C(A * ((A+1) - (A-1)*cs + sq));
-		CoeffScalar b1 = C(2*A * ((A-1) - (A+1)*cs));
-		CoeffScalar b2 = C(A * ((A+1) - (A-1)*cs - sq));
-		CoeffScalar a0 = C((A+1) + (A-1)*cs + sq);
-		CoeffScalar a1 = C(-2 * ((A-1) + (A+1)*cs));
-		CoeffScalar a2 = C((A+1) + (A-1)*cs - sq);
+		const CoeffScalar A = pow(ten, CoeffScalar(gain_db) / forty);
+		const CoeffScalar w0 = CoeffScalar(two_pi)
+		                     * CoeffScalar(cutoff_freq) / CoeffScalar(sample_rate);
+		const CoeffScalar cs = cos(w0);
+		const CoeffScalar sn = sin(w0);
+		const CoeffScalar inv_A = one / A;
+		const CoeffScalar inv_slope = one / CoeffScalar(slope);
+		CoeffScalar radicand = (A + inv_A) * (inv_slope - one) + two;
+		if (radicand < zero) radicand = zero;
+		const CoeffScalar alpha = sn / two * sqrt(radicand);
+		const CoeffScalar sq = two * sqrt(A) * alpha;
+
+		const CoeffScalar Ap1 = A + one;
+		const CoeffScalar Am1 = A - one;
+
+		CoeffScalar b0 =  A * (Ap1 - Am1*cs + sq);
+		CoeffScalar b1 =  two * A * (Am1 - Ap1*cs);
+		CoeffScalar b2 =  A * (Ap1 - Am1*cs - sq);
+		CoeffScalar a0 =  Ap1 + Am1*cs + sq;
+		CoeffScalar a1 = -(two * (Am1 + Ap1*cs));
+		CoeffScalar a2 =  Ap1 + Am1*cs - sq;
 
 		cascade_.set_num_stages(1);
 		cascade_.stage(0) = detail::normalize(b0, b1, b2, a0, a1, a2);
@@ -274,25 +323,38 @@ public:
 	static constexpr int max_stages = 1;
 
 	void setup(double sample_rate, double cutoff_freq, double gain_db, double slope = 1.0) {
+		using std::cos; using std::sin; using std::pow; using std::sqrt;
 		detail::validate_freq(sample_rate, cutoff_freq, "rbj::HighShelf");
 		if (!(slope > 0.0)) throw std::invalid_argument("rbj::HighShelf: slope must be > 0");
 		if (!std::isfinite(gain_db)) throw std::invalid_argument("rbj::HighShelf: gain_db must be finite");
-		double A  = std::pow(10.0, gain_db / 40.0);
-		CoeffScalar w0 = two_pi_v<CoeffScalar> * static_cast<CoeffScalar>(cutoff_freq / sample_rate);
-		double cs = std::cos(static_cast<double>(w0));
-		double sn = std::sin(static_cast<double>(w0));
-		double radicand = (A + 1.0/A) * (1.0/slope - 1.0) + 2.0;
-		double alpha = sn / 2.0 * std::sqrt(std::max(0.0, radicand));
-		double sq = 2.0 * std::sqrt(A) * alpha;
 
-		auto C = [](double v) { return static_cast<CoeffScalar>(v); };
+		constexpr CoeffScalar zero = CoeffScalar(0);
+		constexpr CoeffScalar one  = CoeffScalar(1);
+		constexpr CoeffScalar two  = CoeffScalar(2);
+		constexpr CoeffScalar ten  = CoeffScalar(10);
+		constexpr CoeffScalar forty = CoeffScalar(40);
 
-		CoeffScalar b0 = C(A * ((A+1) + (A-1)*cs + sq));
-		CoeffScalar b1 = C(-2*A * ((A-1) + (A+1)*cs));
-		CoeffScalar b2 = C(A * ((A+1) + (A-1)*cs - sq));
-		CoeffScalar a0 = C((A+1) - (A-1)*cs + sq);
-		CoeffScalar a1 = C(2 * ((A-1) - (A+1)*cs));
-		CoeffScalar a2 = C((A+1) - (A-1)*cs - sq);
+		const CoeffScalar A = pow(ten, CoeffScalar(gain_db) / forty);
+		const CoeffScalar w0 = CoeffScalar(two_pi)
+		                     * CoeffScalar(cutoff_freq) / CoeffScalar(sample_rate);
+		const CoeffScalar cs = cos(w0);
+		const CoeffScalar sn = sin(w0);
+		const CoeffScalar inv_A = one / A;
+		const CoeffScalar inv_slope = one / CoeffScalar(slope);
+		CoeffScalar radicand = (A + inv_A) * (inv_slope - one) + two;
+		if (radicand < zero) radicand = zero;
+		const CoeffScalar alpha = sn / two * sqrt(radicand);
+		const CoeffScalar sq = two * sqrt(A) * alpha;
+
+		const CoeffScalar Ap1 = A + one;
+		const CoeffScalar Am1 = A - one;
+
+		CoeffScalar b0 =  A * (Ap1 + Am1*cs + sq);
+		CoeffScalar b1 = -(two * A * (Am1 + Ap1*cs));
+		CoeffScalar b2 =  A * (Ap1 + Am1*cs - sq);
+		CoeffScalar a0 =  Ap1 - Am1*cs + sq;
+		CoeffScalar a1 =  two * (Am1 - Ap1*cs);
+		CoeffScalar a2 =  Ap1 - Am1*cs - sq;
 
 		cascade_.set_num_stages(1);
 		cascade_.stage(0) = detail::normalize(b0, b1, b2, a0, a1, a2);

--- a/tests/test_chebyshev.cpp
+++ b/tests/test_chebyshev.cpp
@@ -13,6 +13,8 @@
 #include <stdexcept>
 #include <iostream>
 
+#include <universal/number/posit/posit.hpp>
+
 using namespace sw::dsp;
 
 bool near(double a, double b, double eps = 1e-4) {
@@ -247,6 +249,82 @@ void test_rbj_simple_filter() {
 	std::cout << "  rbj_simple_filter: passed\n";
 }
 
+// ========== Posit<32,2> regression: RBJ biquad coefficients in T ==========
+//
+// Verifies that rbj::setup() runs its coefficient math in CoeffScalar, not
+// double. A posit-designed biquad must agree with the double reference to
+// within posit<32,2> precision across its five coefficients.
+
+void test_rbj_in_posit_precision() {
+	using posit_t = sw::universal::posit<32, 2>;
+
+	auto compare_biquad = [](const auto& cs_d, const auto& cs_p, const char* label) {
+		const auto& coef_d = cs_d.stage(0);
+		const auto& coef_p = cs_p.stage(0);
+		double max_diff = 0.0;
+		double dd[5] = {
+			static_cast<double>(coef_d.b0), static_cast<double>(coef_d.b1),
+			static_cast<double>(coef_d.b2), static_cast<double>(coef_d.a1),
+			static_cast<double>(coef_d.a2)
+		};
+		double pp[5] = {
+			static_cast<double>(coef_p.b0), static_cast<double>(coef_p.b1),
+			static_cast<double>(coef_p.b2), static_cast<double>(coef_p.a1),
+			static_cast<double>(coef_p.a2)
+		};
+		for (int i = 0; i < 5; ++i) {
+			double d = std::abs(dd[i] - pp[i]);
+			if (d > max_diff) max_diff = d;
+		}
+		if (max_diff > 1e-6)
+			throw std::runtime_error(std::string("test failed: ") + label +
+				" posit vs double max diff = " + std::to_string(max_diff));
+		return max_diff;
+	};
+
+	// LowPass (basic filter)
+	iir::rbj::LowPass<double>  lp_d;
+	iir::rbj::LowPass<posit_t> lp_p;
+	lp_d.setup(44100.0, 1000.0, 0.7071);
+	lp_p.setup(44100.0, 1000.0, 0.7071);
+	double lp_diff = compare_biquad(lp_d.cascade(), lp_p.cascade(), "LowPass");
+
+	// HighPass
+	iir::rbj::HighPass<double>  hp_d;
+	iir::rbj::HighPass<posit_t> hp_p;
+	hp_d.setup(44100.0, 1000.0, 0.7071);
+	hp_p.setup(44100.0, 1000.0, 0.7071);
+	double hp_diff = compare_biquad(hp_d.cascade(), hp_p.cascade(), "HighPass");
+
+	// BandPass
+	iir::rbj::BandPass<double>  bp_d;
+	iir::rbj::BandPass<posit_t> bp_p;
+	bp_d.setup(44100.0, 4000.0, 1.0);
+	bp_p.setup(44100.0, 4000.0, 1.0);
+	double bp_diff = compare_biquad(bp_d.cascade(), bp_p.cascade(), "BandPass");
+
+	// LowShelf (tests pow/sqrt path)
+	iir::rbj::LowShelf<double>  ls_d;
+	iir::rbj::LowShelf<posit_t> ls_p;
+	ls_d.setup(44100.0, 1000.0, 6.0);
+	ls_p.setup(44100.0, 1000.0, 6.0);
+	double ls_diff = compare_biquad(ls_d.cascade(), ls_p.cascade(), "LowShelf");
+
+	// HighShelf
+	iir::rbj::HighShelf<double>  hs_d;
+	iir::rbj::HighShelf<posit_t> hs_p;
+	hs_d.setup(44100.0, 1000.0, 6.0);
+	hs_p.setup(44100.0, 1000.0, 6.0);
+	double hs_diff = compare_biquad(hs_d.cascade(), hs_p.cascade(), "HighShelf");
+
+	std::cout << "  rbj_in_posit_precision: LowPass=" << lp_diff
+	          << " HighPass=" << hp_diff
+	          << " BandPass=" << bp_diff
+	          << " LowShelf=" << ls_diff
+	          << " HighShelf=" << hs_diff
+	          << ", passed\n";
+}
+
 int main() {
 	try {
 		std::cout << "Chebyshev & RBJ Filter Tests\n";
@@ -270,6 +348,7 @@ int main() {
 		test_rbj_allpass();
 		test_rbj_shelves();
 		test_rbj_simple_filter();
+		test_rbj_in_posit_precision();
 
 		std::cout << "All Chebyshev & RBJ tests passed.\n";
 		return 0;

--- a/tests/test_chebyshev.cpp
+++ b/tests/test_chebyshev.cpp
@@ -303,6 +303,20 @@ void test_rbj_in_posit_precision() {
 	bp_p.setup(44100.0, 4000.0, 1.0);
 	double bp_diff = compare_biquad(bp_d.cascade(), bp_p.cascade(), "BandPass");
 
+	// BandStop
+	iir::rbj::BandStop<double>  bs_d;
+	iir::rbj::BandStop<posit_t> bs_p;
+	bs_d.setup(44100.0, 4000.0, 1.0);
+	bs_p.setup(44100.0, 4000.0, 1.0);
+	double bs_diff = compare_biquad(bs_d.cascade(), bs_p.cascade(), "BandStop");
+
+	// AllPass
+	iir::rbj::AllPass<double>  ap_d;
+	iir::rbj::AllPass<posit_t> ap_p;
+	ap_d.setup(44100.0, 4000.0, 0.7071);
+	ap_p.setup(44100.0, 4000.0, 0.7071);
+	double ap_diff = compare_biquad(ap_d.cascade(), ap_p.cascade(), "AllPass");
+
 	// LowShelf (tests pow/sqrt path)
 	iir::rbj::LowShelf<double>  ls_d;
 	iir::rbj::LowShelf<posit_t> ls_p;
@@ -320,6 +334,8 @@ void test_rbj_in_posit_precision() {
 	std::cout << "  rbj_in_posit_precision: LowPass=" << lp_diff
 	          << " HighPass=" << hp_diff
 	          << " BandPass=" << bp_diff
+	          << " BandStop=" << bs_diff
+	          << " AllPass=" << ap_diff
 	          << " LowShelf=" << ls_diff
 	          << " HighShelf=" << hs_diff
 	          << ", passed\n";


### PR DESCRIPTION
## Summary
- All seven RBJ biquad `setup()` methods (LowPass, HighPass, BandPass, BandStop, AllPass, LowShelf, HighShelf) now compute coefficients end-to-end in `CoeffScalar` rather than double
- New posit<32,2> regression test covering both basic and shelf filters
- Continues the T-parameterization cleanup from PR #117 (fir_design); reference implementation is `design_cic_compensator` from PR #110

## Root cause

The public API takes `double` sample_rate/freq/Q/gain_db/slope parameters. Previously, basic filters did `std::cos(static_cast<double>(w0))` and the shelf filters computed A, alpha, sq, sqrt in double for every coefficient. A user instantiating `rbj::LowShelf<posit<32,2>>` got posit-typed coefficients but the math that produced them ran through IEEE double — defeating the mixed-precision-DSP mission.

## Changes
- `include/sw/dsp/filter/iir/rbj.hpp` — all seven `setup()` methods refactored
  - Double parameters converted to CoeffScalar once at entry
  - ADL trig (`using std::cos; cos(w0)`) replaces the `static_cast<double>` round-trip
  - Shelf A/alpha/sq/sqrt all in CoeffScalar via ADL `pow` and `sqrt`
  - `constexpr` constants (zero/one/two/ten/forty) enabled by Universal v4.6.10 constexpr posit ctors
  - `two_pi_v<CoeffScalar>` replaced with `CoeffScalar(two_pi)` — the template alias uses a `long double` literal and posit's `long double` ctor is not yet constexpr; `CoeffScalar(double two_pi)` works
- `tests/test_chebyshev.cpp` — new `test_rbj_in_posit_precision` comparing posit<32,2> coefficients against double reference across LowPass, HighPass, BandPass, LowShelf, HighShelf

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_chebyshev | OK | PASS | OK | PASS |

Full gcc ctest: 31/31 pass.

### Posit<32,2> coefficient agreement (new test)
| Filter | Max coefficient diff vs double |
|---|---|
| LowPass | 9.22e-9 |
| HighPass | 9.22e-9 |
| BandPass | 2.81e-9 |
| LowShelf | 6.53e-9 |
| HighShelf | 4.27e-9 |

All within posit<32,2> ULP around the coefficient magnitudes involved.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Resolves #112

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for universal numeric types in RBJ biquad coefficient computation.

* **Improvements**
  * Coefficient calculations now preserve precision by avoiding intermediate type conversions and using consistent numeric operations.

* **Tests**
  * Added a regression test to validate RBJ biquad coefficient accuracy with an alternative numeric type, enforcing tight numerical agreement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->