### PR TITLE
fix(windows): parameterize 8 window functions on T

### DIFF
--- a/include/sw/dsp/windows/bartlett_hann.hpp
+++ b/include/sw/dsp/windows/bartlett_hann.hpp
@@ -3,6 +3,8 @@
 //
 // w[n] = 0.62 - 0.48 * |n/(N-1) - 0.5| + 0.38 * cos(2*pi * (n/(N-1) - 0.5))
 //
+// Intermediate math runs in T; ADL trig and abs for Universal types.
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
@@ -16,12 +18,19 @@ namespace sw::dsp {
 
 template <DspField T>
 mtl::vec::dense_vector<T> bartlett_hann_window(std::size_t length) {
+	using std::cos; using std::abs;
 	mtl::vec::dense_vector<T> w(length);
-	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
-	double N = static_cast<double>(length - 1);
+	if (length <= 1) { if (length == 1) w[0] = T(1); return w; }
+
+	constexpr T two_pi_T = T(two_pi);
+	constexpr T half = T(0.5);
+	constexpr T a0   = T(0.62);
+	constexpr T a1   = T(0.48);
+	constexpr T a2   = T(0.38);
+	const T N = T(length - 1);
 	for (std::size_t n = 0; n < length; ++n) {
-		double x = static_cast<double>(n) / N - 0.5;
-		w[n] = static_cast<T>(0.62 - 0.48 * std::abs(x) + 0.38 * std::cos(two_pi * x));
+		const T x = T(n) / N - half;
+		w[n] = a0 - a1 * abs(x) + a2 * cos(two_pi_T * x);
 	}
 	return w;
 }

--- a/include/sw/dsp/windows/blackman.hpp
+++ b/include/sw/dsp/windows/blackman.hpp
@@ -3,6 +3,8 @@
 //
 // w[n] = 0.42 - 0.5*cos(2*pi*n/(N-1)) + 0.08*cos(4*pi*n/(N-1))
 //
+// Intermediate math runs in T; ADL trig for Universal types.
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
@@ -16,12 +18,19 @@ namespace sw::dsp {
 
 template <DspField T>
 mtl::vec::dense_vector<T> blackman_window(std::size_t length) {
+	using std::cos;
 	mtl::vec::dense_vector<T> w(length);
-	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
-	double N = static_cast<double>(length - 1);
+	if (length <= 1) { if (length == 1) w[0] = T(1); return w; }
+
+	constexpr T two_pi_T = T(two_pi);
+	constexpr T a0 = T(0.42);
+	constexpr T a1 = T(0.5);
+	constexpr T a2 = T(0.08);
+	constexpr T two = T(2);
+	const T N = T(length - 1);
 	for (std::size_t n = 0; n < length; ++n) {
-		double x = static_cast<double>(n) / N;
-		w[n] = static_cast<T>(0.42 - 0.5 * std::cos(two_pi * x) + 0.08 * std::cos(2.0 * two_pi * x));
+		const T x = two_pi_T * T(n) / N;
+		w[n] = a0 - a1 * cos(x) + a2 * cos(two * x);
 	}
 	return w;
 }

--- a/include/sw/dsp/windows/flat_top.hpp
+++ b/include/sw/dsp/windows/flat_top.hpp
@@ -8,6 +8,8 @@
 // Coefficients from ISO 18431-2 (HFT90D):
 // a0=1, a1=1.942604, a2=1.340318, a3=0.440811, a4=0.043097
 //
+// Intermediate math runs in T; ADL trig for Universal types.
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
@@ -21,13 +23,26 @@ namespace sw::dsp {
 
 template <DspField T>
 mtl::vec::dense_vector<T> flat_top_window(std::size_t length) {
+	using std::cos;
 	mtl::vec::dense_vector<T> w(length);
-	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
-	double N = static_cast<double>(length - 1);
-	constexpr double a0 = 1.0, a1 = 1.942604, a2 = 1.340318, a3 = 0.440811, a4 = 0.043097;
+	if (length <= 1) { if (length == 1) w[0] = T(1); return w; }
+
+	constexpr T two_pi_T = T(two_pi);
+	constexpr T a0 = T(1.0);
+	constexpr T a1 = T(1.942604);
+	constexpr T a2 = T(1.340318);
+	constexpr T a3 = T(0.440811);
+	constexpr T a4 = T(0.043097);
+	constexpr T two   = T(2);
+	constexpr T three = T(3);
+	constexpr T four  = T(4);
+	const T N = T(length - 1);
 	for (std::size_t n = 0; n < length; ++n) {
-		double x = two_pi * static_cast<double>(n) / N;
-		w[n] = static_cast<T>(a0 - a1*std::cos(x) + a2*std::cos(2*x) - a3*std::cos(3*x) + a4*std::cos(4*x));
+		const T x = two_pi_T * T(n) / N;
+		w[n] = a0 - a1 * cos(x)
+		          + a2 * cos(two   * x)
+		          - a3 * cos(three * x)
+		          + a4 * cos(four  * x);
 	}
 	return w;
 }

--- a/include/sw/dsp/windows/gaussian.hpp
+++ b/include/sw/dsp/windows/gaussian.hpp
@@ -3,6 +3,9 @@
 //
 // w[n] = exp(-0.5 * ((n - (N-1)/2) / (sigma * (N-1)/2))^2)
 //
+// Intermediate math runs in T; ADL std::exp picks up sw::universal::exp
+// for Universal types.
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
@@ -15,14 +18,19 @@ namespace sw::dsp {
 
 template <DspField T>
 mtl::vec::dense_vector<T> gaussian_window(std::size_t length, double sigma = 0.4) {
+	using std::exp;
 	mtl::vec::dense_vector<T> w(length);
-	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
+	if (length <= 1) { if (length == 1) w[0] = T(1); return w; }
 	if (sigma <= 0.0) sigma = 0.4;
-	double half_N = static_cast<double>(length - 1) * 0.5;
-	double denom = sigma * half_N;
+
+	constexpr T neg_half = T(-0.5);
+	constexpr T half = T(0.5);
+	const T N_minus_1 = T(length - 1);
+	const T half_N = N_minus_1 * half;
+	const T denom = T(sigma) * half_N;
 	for (std::size_t n = 0; n < length; ++n) {
-		double x = (static_cast<double>(n) - half_N) / denom;
-		w[n] = static_cast<T>(std::exp(-0.5 * x * x));
+		const T x = (T(n) - half_N) / denom;
+		w[n] = exp(neg_half * x * x);
 	}
 	return w;
 }

--- a/include/sw/dsp/windows/hamming.hpp
+++ b/include/sw/dsp/windows/hamming.hpp
@@ -3,6 +3,11 @@
 //
 // w[n] = 0.54 - 0.46 * cos(2*pi*n / (N-1))
 //
+// Intermediate math runs in T so posit/cfloat/etc. callers get the
+// window computed at their declared precision (required for embedded
+// mixed-precision deployments). ADL trig (using std::cos) selects
+// sw::universal::cos for Universal types and std::cos for native.
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
@@ -16,11 +21,18 @@ namespace sw::dsp {
 
 template <DspField T>
 mtl::vec::dense_vector<T> hamming_window(std::size_t length) {
+	using std::cos;
 	mtl::vec::dense_vector<T> w(length);
-	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
-	double N = static_cast<double>(length - 1);
+	if (length <= 1) { if (length == 1) w[0] = T(1); return w; }
+
+	// Constants are built from double literals via the constexpr ctor
+	// (operator/ is not yet constexpr for posit).
+	constexpr T two_pi_T = T(two_pi);
+	constexpr T a0 = T(0.54);
+	constexpr T a1 = T(0.46);
+	const T N = T(length - 1);
 	for (std::size_t n = 0; n < length; ++n) {
-		w[n] = static_cast<T>(0.54 - 0.46 * std::cos(two_pi * static_cast<double>(n) / N));
+		w[n] = a0 - a1 * cos(two_pi_T * T(n) / N);
 	}
 	return w;
 }

--- a/include/sw/dsp/windows/hanning.hpp
+++ b/include/sw/dsp/windows/hanning.hpp
@@ -3,6 +3,8 @@
 //
 // w[n] = 0.5 * (1 - cos(2*pi*n / (N-1)))
 //
+// Intermediate math runs in T; ADL trig for Universal types.
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
@@ -16,11 +18,16 @@ namespace sw::dsp {
 
 template <DspField T>
 mtl::vec::dense_vector<T> hanning_window(std::size_t length) {
+	using std::cos;
 	mtl::vec::dense_vector<T> w(length);
-	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
-	double N = static_cast<double>(length - 1);
+	if (length <= 1) { if (length == 1) w[0] = T(1); return w; }
+
+	constexpr T two_pi_T = T(two_pi);
+	constexpr T half = T(0.5);
+	constexpr T one  = T(1);
+	const T N = T(length - 1);
 	for (std::size_t n = 0; n < length; ++n) {
-		w[n] = static_cast<T>(0.5 * (1.0 - std::cos(two_pi * static_cast<double>(n) / N)));
+		w[n] = half * (one - cos(two_pi_T * T(n) / N));
 	}
 	return w;
 }

--- a/include/sw/dsp/windows/kaiser.hpp
+++ b/include/sw/dsp/windows/kaiser.hpp
@@ -6,6 +6,10 @@
 // where I0 is the zeroth-order modified Bessel function of the first kind.
 // beta controls the trade-off between main lobe width and side lobe level.
 //
+// Intermediate math runs in T. detail::bessel_I0 is templated so the
+// Bessel series expansion runs at the caller's declared precision;
+// sqrt and max dispatch via ADL.
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
@@ -20,14 +24,20 @@ namespace detail {
 
 // Modified Bessel function of the first kind, order 0.
 // Series expansion: I0(x) = sum_{k=0}^{inf} ((x/2)^k / k!)^2
-inline double bessel_I0(double x) {
-	double sum = 1.0;
-	double term = 1.0;
-	double x_half = x * 0.5;
+// Evaluated entirely in T so non-native CoeffScalar callers don't
+// silently fall back to double precision.
+template <DspField T>
+T bessel_I0(const T& x) {
+	constexpr T half = T(0.5);
+	constexpr T tol  = T(1e-15);
+	T sum  = T(1);
+	T term = T(1);
+	const T x_half = x * half;
 	for (int k = 1; k < 30; ++k) {
-		term *= (x_half / k) * (x_half / k);
-		sum += term;
-		if (term < sum * 1e-15) break;
+		const T ratio = x_half / T(k);
+		term = term * ratio * ratio;
+		sum = sum + term;
+		if (term < sum * tol) break;
 	}
 	return sum;
 }
@@ -36,14 +46,22 @@ inline double bessel_I0(double x) {
 
 template <DspField T>
 mtl::vec::dense_vector<T> kaiser_window(std::size_t length, double beta = 8.6) {
+	using std::sqrt;
 	mtl::vec::dense_vector<T> w(length);
-	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
-	double N = static_cast<double>(length - 1);
-	double I0_beta = detail::bessel_I0(beta);
+	if (length <= 1) { if (length == 1) w[0] = T(1); return w; }
+
+	constexpr T zero = T(0);
+	constexpr T one  = T(1);
+	constexpr T two  = T(2);
+	const T N = T(length - 1);
+	const T beta_T = T(beta);
+	const T I0_beta = detail::bessel_I0(beta_T);
 	for (std::size_t n = 0; n < length; ++n) {
-		double x = 2.0 * static_cast<double>(n) / N - 1.0;
-		double arg = beta * std::sqrt(std::max(0.0, 1.0 - x * x));
-		w[n] = static_cast<T>(detail::bessel_I0(arg) / I0_beta);
+		const T x = two * T(n) / N - one;
+		const T radicand = one - x * x;
+		const T clamped  = (radicand < zero) ? zero : radicand;
+		const T arg = beta_T * sqrt(clamped);
+		w[n] = detail::bessel_I0(arg) / I0_beta;
 	}
 	return w;
 }

--- a/include/sw/dsp/windows/tukey.hpp
+++ b/include/sw/dsp/windows/tukey.hpp
@@ -5,7 +5,11 @@
 //        { 1                                                          for alpha*(N-1)/2 <= n <= (N-1)*(1-alpha/2)
 //        { 0.5 * (1 - cos(2*pi*(N-1-n) / (alpha*(N-1))))             for (N-1)*(1-alpha/2) < n <= N-1
 //
-// alpha=0 → rectangular, alpha=1 → Hanning
+// alpha=0 -> rectangular, alpha=1 -> Hanning.
+//
+// Intermediate math runs in T; ADL trig for Universal types. `alpha`
+// stays as a double parameter since it's a design-time knob, but the
+// per-sample computation is performed entirely in T.
 //
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -20,29 +24,38 @@ namespace sw::dsp {
 
 template <DspField T>
 mtl::vec::dense_vector<T> tukey_window(std::size_t length, double alpha = 0.5) {
+	using std::cos;
 	mtl::vec::dense_vector<T> w(length);
-	if (length <= 1) { if (length == 1) w[0] = T{1}; return w; }
+	if (length <= 1) { if (length == 1) w[0] = T(1); return w; }
 	if (alpha <= 0.0) {
-		for (std::size_t n = 0; n < length; ++n) w[n] = T{1};
+		for (std::size_t n = 0; n < length; ++n) w[n] = T(1);
 		return w;
 	}
+
+	constexpr T two_pi_T = T(two_pi);
+	constexpr T half = T(0.5);
+	constexpr T one  = T(1);
+
 	if (alpha >= 1.0) {
-		double N = static_cast<double>(length - 1);
+		const T N = T(length - 1);
 		for (std::size_t n = 0; n < length; ++n) {
-			w[n] = static_cast<T>(0.5 * (1.0 - std::cos(two_pi * static_cast<double>(n) / N)));
+			w[n] = half * (one - cos(two_pi_T * T(n) / N));
 		}
 		return w;
 	}
-	double N = static_cast<double>(length - 1);
-	double half_taper = alpha * N * 0.5;
+
+	const T N = T(length - 1);
+	const T alpha_T = T(alpha);
+	const T alpha_N = alpha_T * N;
+	const T half_taper = alpha_N * half;
 	for (std::size_t n = 0; n < length; ++n) {
-		double nd = static_cast<double>(n);
+		const T nd = T(n);
 		if (nd < half_taper) {
-			w[n] = static_cast<T>(0.5 * (1.0 - std::cos(two_pi * nd / (alpha * N))));
+			w[n] = half * (one - cos(two_pi_T * nd / alpha_N));
 		} else if (nd > N - half_taper) {
-			w[n] = static_cast<T>(0.5 * (1.0 - std::cos(two_pi * (N - nd) / (alpha * N))));
+			w[n] = half * (one - cos(two_pi_T * (N - nd) / alpha_N));
 		} else {
-			w[n] = T{1};
+			w[n] = one;
 		}
 	}
 	return w;

--- a/tests/test_windows.cpp
+++ b/tests/test_windows.cpp
@@ -261,8 +261,11 @@ void test_windows_in_posit_precision() {
 
 	auto compare_window = [&](const char* name, const auto& win_d, const auto& win_p,
 	                          double eps) {
-		if (win_p.size() != N)
-			throw std::runtime_error(std::string("test failed: ") + name + " size");
+		if (win_d.size() != N || win_p.size() != N)
+			throw std::runtime_error(std::string("compare_window: ") + name +
+				" size mismatch: win_d=" + std::to_string(win_d.size()) +
+				" win_p=" + std::to_string(win_p.size()) +
+				" expected=" + std::to_string(N));
 		double max_diff = 0.0;
 		for (std::size_t i = 0; i < N; ++i) {
 			double diff = std::abs(static_cast<double>(win_p[i]) - win_d[i]);

--- a/tests/test_windows.cpp
+++ b/tests/test_windows.cpp
@@ -286,8 +286,10 @@ void test_windows_in_posit_precision() {
 	// Kaiser — exercises bessel_I0 template and sqrt
 	auto kai_d = kaiser_window<double>(N, 8.6);
 	auto kai_p = kaiser_window<posit_t>(N, 8.6);
-	// Kaiser's Bessel series has more accumulated rounding; allow slightly wider.
-	double kai_diff = compare_window("kaiser", kai_d, kai_p, 1e-6);
+	// Kaiser's Bessel series has more accumulated rounding than the simple
+	// windows. Measured ~8e-8; 1e-7 gives modest headroom for platform ULP
+	// variance while still catching meaningful regressions.
+	double kai_diff = compare_window("kaiser", kai_d, kai_p, 1e-7);
 
 	// Gaussian — exercises exp
 	auto gau_d = gaussian_window<double>(N, 0.4);

--- a/tests/test_windows.cpp
+++ b/tests/test_windows.cpp
@@ -12,6 +12,8 @@
 #include <iostream>
 #include <stdexcept>
 
+#include <universal/number/posit/posit.hpp>
+
 using namespace sw::dsp;
 
 bool near(double a, double b, double eps = 1e-6) {
@@ -247,6 +249,54 @@ void test_upsample_downsample_roundtrip() {
 	std::cout << "  upsample_downsample_roundtrip: passed\n";
 }
 
+// ============================================================================
+// Posit<32,2> regression: verify window templates run intermediate math in T.
+// Compares posit-designed windows against double references; agreement must
+// be within posit<32,2> precision (~2^-28 ULP near unit magnitude).
+// ============================================================================
+
+void test_windows_in_posit_precision() {
+	using posit_t = sw::universal::posit<32, 2>;
+	constexpr std::size_t N = 64;
+
+	auto compare_window = [&](const char* name, const auto& win_d, const auto& win_p,
+	                          double eps) {
+		if (win_p.size() != N)
+			throw std::runtime_error(std::string("test failed: ") + name + " size");
+		double max_diff = 0.0;
+		for (std::size_t i = 0; i < N; ++i) {
+			double diff = std::abs(static_cast<double>(win_p[i]) - win_d[i]);
+			if (diff > max_diff) max_diff = diff;
+		}
+		if (max_diff > eps)
+			throw std::runtime_error(std::string("test failed: ") + name +
+				" posit-vs-double max diff = " + std::to_string(max_diff) +
+				" (eps=" + std::to_string(eps) + ")");
+		return max_diff;
+	};
+
+	// Hamming — simple cosine
+	auto ham_d = hamming_window<double>(N);
+	auto ham_p = hamming_window<posit_t>(N);
+	double ham_diff = compare_window("hamming", ham_d, ham_p, 1e-7);
+
+	// Kaiser — exercises bessel_I0 template and sqrt
+	auto kai_d = kaiser_window<double>(N, 8.6);
+	auto kai_p = kaiser_window<posit_t>(N, 8.6);
+	// Kaiser's Bessel series has more accumulated rounding; allow slightly wider.
+	double kai_diff = compare_window("kaiser", kai_d, kai_p, 1e-6);
+
+	// Gaussian — exercises exp
+	auto gau_d = gaussian_window<double>(N, 0.4);
+	auto gau_p = gaussian_window<posit_t>(N, 0.4);
+	double gau_diff = compare_window("gaussian", gau_d, gau_p, 1e-7);
+
+	std::cout << "  windows_in_posit_precision: hamming=" << ham_diff
+	          << " kaiser=" << kai_diff
+	          << " gaussian=" << gau_diff
+	          << ", passed\n";
+}
+
 int main() {
 	try {
 		std::cout << "Window & Signal Tests\n";
@@ -263,6 +313,7 @@ int main() {
 		test_bartlett_hann();
 		test_apply_window();
 		test_window_float();
+		test_windows_in_posit_precision();
 
 		test_signal_wrapper();
 


### PR DESCRIPTION
## Summary
- 8 of the 9 window functions in \`include/sw/dsp/windows/\` now compute their samples end-to-end in the template scalar T, not double
- Dolph-Chebyshev deferred to follow-up issue [#121](https://github.com/stillwater-sc/mixed-precision-dsp/issues/121) — its full DFT-and-Chebyshev-polynomial design warrants a standalone PR (per the original issue's own note)
- Continues the T-parameterization cleanup from #111 (FIR, PR #117), #112 (RBJ, PR #118), and #114 (Elliptic, PR #120)

## Changes
- \`include/sw/dsp/windows/hamming.hpp\` — simple cosine, constexpr T(0.54), T(0.46)
- \`include/sw/dsp/windows/hanning.hpp\` — simple cosine
- \`include/sw/dsp/windows/blackman.hpp\` — two-cosine series
- \`include/sw/dsp/windows/bartlett_hann.hpp\` — uses ADL abs + cos
- \`include/sw/dsp/windows/flat_top.hpp\` — four-cosine series with ISO 18431-2 coefficients
- \`include/sw/dsp/windows/tukey.hpp\` — conditional cosine taper; all three branches in T
- \`include/sw/dsp/windows/gaussian.hpp\` — uses ADL exp
- \`include/sw/dsp/windows/kaiser.hpp\` — **port detail::bessel_I0 to a template** so the Bessel series runs at the caller's precision; ADL sqrt for the arg
- \`tests/test_windows.cpp\` — new \`test_windows_in_posit_precision\` comparing posit<32,2> against double references for hamming, kaiser, gaussian

## Root cause
Every window followed the same pattern:
\`\`\`cpp
double N = static_cast<double>(length - 1);
for (std::size_t n = 0; n < length; ++n) {
    double x = ...;
    w[n] = static_cast<T>(0.5 * (1.0 - std::cos(two_pi * x)));  // double cos, cast at end
}
\`\`\`
This breaks the mixed-precision invariant — a user asking for a posit<16,1> window got posit tap values but the design math ran through IEEE double and can't execute on a target lacking double support.

Kaiser was the most interesting case: \`detail::bessel_I0\` was a plain \`double\` function, so even if the caller passed a posit, the Bessel series ran in double. The fix templates that helper on T so the series recurrence runs at the declared precision.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_windows | OK | PASS | OK | PASS |

Full gcc ctest: 31/31 pass.

### Posit<32,2> agreement (new test)
| Window | Max diff vs double |
|---|---|
| hamming | 3.2e-8 |
| kaiser (beta=8.6) | 8.0e-8 |
| gaussian (sigma=0.4) | 2.9e-9 |

All within posit<32,2> ULP near unit magnitude. Kaiser has slightly more accumulated rounding due to the Bessel series.

## Notes on constants
Constants like \`T(0.54)\` use the \`T(double)\` ctor which Universal v4.6.10 made constexpr. I use \`T(0.54)\` rather than \`T(54)/T(100)\` because posit's \`operator/\` is not yet constexpr.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Resolves #115
Relates to #121 (Dolph-Chebyshev follow-up)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Window functions (Bartlett‑Hann, Blackman, Flat‑top, Gaussian, Hamming, Hanning, Kaiser, Tukey) now perform computations entirely in their template numeric type, improving compatibility with custom numeric types and consistent behavior.

* **Tests**
  * Added regression tests validating custom-numeric instantiations of several windows against double implementations to ensure numerical fidelity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->