### PR TITLE
fix(iir): support non-native CoeffScalar in biquad infrastructure

### DIFF
--- a/include/sw/dsp/filter/biquad/cascade.hpp
+++ b/include/sw/dsp/filter/biquad/cascade.hpp
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <complex>
 #include <cmath>
+#include <sw/dsp/concepts/scalar.hpp>
 #include <sw/dsp/types/biquad_coefficients.hpp>
 #include <sw/dsp/filter/layout/layout.hpp>
 #include <sw/dsp/math/constants.hpp>
@@ -87,9 +88,13 @@ public:
 		return out;
 	}
 
-	// Evaluate frequency response at normalized frequency f in [0, 0.5]
-	std::complex<CoeffScalar> response(double normalized_freq) const {
-		std::complex<CoeffScalar> result(CoeffScalar{1});
+	// Evaluate frequency response at normalized frequency f in [0, 0.5].
+	// Return type is complex_for_t<CoeffScalar> so Universal number types
+	// (posit etc.) receive sw::universal::complex<T> instead of
+	// std::complex<T> (which the C++ standard only defines for native
+	// floating-point types).
+	complex_for_t<CoeffScalar> response(double normalized_freq) const {
+		complex_for_t<CoeffScalar> result(CoeffScalar{1});
 		for (int i = 0; i < num_stages_; ++i) {
 			result = result * stages_[i].response(normalized_freq);
 		}

--- a/include/sw/dsp/math/constants.hpp
+++ b/include/sw/dsp/math/constants.hpp
@@ -7,27 +7,34 @@
 namespace sw::dsp {
 
 // Mathematical constants templated on scalar type for precision-correct values.
+//
+// Literals are `double` (not `long double`) so that T(literal) resolves to
+// the constexpr `T(double)` ctor for Universal number types like posit —
+// their `T(long double)` paths are not yet fully constexpr. Native types
+// (float, double, long double) pick up the same literal via implicit
+// widening conversion; the few digits of precision beyond double are
+// below the noise floor for all filter-design and DSP math we do.
 
 template <typename T>
-inline constexpr T pi_v = T(3.14159265358979323846264338327950288419716939937510L);
+inline constexpr T pi_v = T(3.14159265358979323846264338327950288419716939937510);
 
 template <typename T>
-inline constexpr T two_pi_v = T(6.28318530717958647692528676655900576839433879875021L);
+inline constexpr T two_pi_v = T(6.28318530717958647692528676655900576839433879875021);
 
 template <typename T>
-inline constexpr T half_pi_v = T(1.57079632679489661923132169163975144209858469968755L);
+inline constexpr T half_pi_v = T(1.57079632679489661923132169163975144209858469968755);
 
 template <typename T>
-inline constexpr T ln2_v = T(0.69314718055994530941723212145817656807550013436026L);
+inline constexpr T ln2_v = T(0.69314718055994530941723212145817656807550013436026);
 
 template <typename T>
-inline constexpr T ln10_v = T(2.30258509299404568401799145468436420760110148862877L);
+inline constexpr T ln10_v = T(2.30258509299404568401799145468436420760110148862877);
 
 template <typename T>
-inline constexpr T sqrt2_v = T(1.41421356237309504880168872420969807856967187537694L);
+inline constexpr T sqrt2_v = T(1.41421356237309504880168872420969807856967187537694);
 
 template <typename T>
-inline constexpr T inv_sqrt2_v = T(0.70710678118654752440084436210484903928483593768847L);
+inline constexpr T inv_sqrt2_v = T(0.70710678118654752440084436210484903928483593768847);
 
 // Convenience aliases for double
 inline constexpr double pi       = pi_v<double>;

--- a/include/sw/dsp/types/biquad_coefficients.hpp
+++ b/include/sw/dsp/types/biquad_coefficients.hpp
@@ -39,8 +39,8 @@ struct BiquadCoefficients {
 	}
 
 	// Set coefficients from a single pole/zero pair (first-order section)
-	void set_one_pole(const std::complex<CoeffScalar>& pole,
-	                  const std::complex<CoeffScalar>& zero) {
+	void set_one_pole(const complex_for_t<CoeffScalar>& pole,
+	                  const complex_for_t<CoeffScalar>& zero) {
 		b0 = CoeffScalar{1};
 		b1 = CoeffScalar{-1} * zero.real();
 		b2 = CoeffScalar{};
@@ -49,10 +49,10 @@ struct BiquadCoefficients {
 	}
 
 	// Set coefficients from a conjugate pair of poles/zeros (second-order section)
-	void set_two_pole(const std::complex<CoeffScalar>& pole1,
-	                  const std::complex<CoeffScalar>& zero1,
-	                  const std::complex<CoeffScalar>& pole2,
-	                  const std::complex<CoeffScalar>& zero2) {
+	void set_two_pole(const complex_for_t<CoeffScalar>& pole1,
+	                  const complex_for_t<CoeffScalar>& zero1,
+	                  const complex_for_t<CoeffScalar>& pole2,
+	                  const complex_for_t<CoeffScalar>& zero2) {
 		using std::real;
 		using std::imag;
 
@@ -89,8 +89,14 @@ struct BiquadCoefficients {
 	}
 
 	// Evaluate frequency response at normalized frequency f in [0, 0.5]
-	// where f = frequency / sample_rate
-	std::complex<CoeffScalar> response(double normalized_freq) const {
+	// where f = frequency / sample_rate.
+	//
+	// Intermediate math uses std::complex<double> for the cis/division —
+	// design-time analysis at double precision matches the pattern in
+	// analysis/stability.hpp. The return type is complex_for_t<CoeffScalar>
+	// so callers using Universal number types (posit etc.) receive the
+	// correctly-dispatched complex type.
+	complex_for_t<CoeffScalar> response(double normalized_freq) const {
 		using complex_t = std::complex<double>;
 		const double w = 2.0 * 3.14159265358979323846 * normalized_freq;
 		const complex_t z1 = std::exp(complex_t(0, -w));        // z^-1
@@ -104,7 +110,7 @@ struct BiquadCoefficients {
 		              + static_cast<double>(a2) * z2;
 
 		auto result = num / den;
-		return std::complex<CoeffScalar>(
+		return complex_for_t<CoeffScalar>(
 			static_cast<CoeffScalar>(result.real()),
 			static_cast<CoeffScalar>(result.imag()));
 	}

--- a/tests/test_elliptic.cpp
+++ b/tests/test_elliptic.cpp
@@ -440,6 +440,53 @@ void test_spec_prewarp_in_posit_precision() {
 	std::cout << "  spec_prewarp_in_posit_precision: passed\n";
 }
 
+// ============================================================================
+// Issue #119: EllipticLowPassSpec<posit<32,2>> full end-to-end instantiation.
+// Previously blocked by std::complex-vs-complex_for_t dispatch in
+// BiquadCoefficients and Cascade::response. Now that those are fixed, we can
+// compare the posit-designed filter's frequency response against the double
+// reference at several probe frequencies.
+// ============================================================================
+
+void test_spec_end_to_end_in_posit_precision() {
+	using posit_t = sw::universal::posit<32, 2>;
+
+	iir::EllipticLowPassSpec<8, double>  lp_d;
+	iir::EllipticLowPassSpec<8, posit_t> lp_p;
+
+	const int n = iir::elliptic_minimum_order(1.0, 40.0, 2000.0, 3000.0, 44100.0);
+	lp_d.setup(n, 44100.0, 2000.0, 3000.0, 1.0, 40.0);
+	lp_p.setup(n, 44100.0, 2000.0, 3000.0, 1.0, 40.0);
+
+	double max_db_diff = 0.0;
+	for (double f_hz : {100.0, 500.0, 1000.0, 1500.0, 1800.0, 2200.0,
+	                     2700.0, 3500.0, 5000.0, 8000.0}) {
+		const double f = f_hz / 44100.0;
+		auto resp_d = lp_d.cascade().response(f);
+		auto resp_p = lp_p.cascade().response(f);
+		const double mag_d = std::abs(resp_d);
+		const double rp = static_cast<double>(resp_p.real());
+		const double ip = static_cast<double>(resp_p.imag());
+		const double mag_p = std::sqrt(rp * rp + ip * ip);
+		const double db_d = 20.0 * std::log10(std::max(mag_d, 1e-15));
+		const double db_p = 20.0 * std::log10(std::max(mag_p, 1e-15));
+		const double d = std::abs(db_d - db_p);
+		if (d > max_db_diff) max_db_diff = d;
+	}
+
+	// Filter design is heavy on transcendentals and involves elliptic
+	// integrals; posit<32,2> ULP propagates through. A 0.1 dB agreement
+	// across passband, transition, and stopband is tight enough to catch
+	// any regression in the complex-type dispatch but loose enough not to
+	// fail on legitimate posit rounding.
+	if (max_db_diff > 0.1)
+		throw std::runtime_error("test failed: spec LP posit-vs-double max |dB diff| = " +
+			std::to_string(max_db_diff));
+
+	std::cout << "  spec_end_to_end_in_posit_precision: max |dB diff| = "
+	          << max_db_diff << ", passed\n";
+}
+
 void test_spec_rejects_invalid() {
 	iir::EllipticLowPassSpec<4> f;
 
@@ -492,6 +539,7 @@ int main() {
 		test_spec_bandstop();
 		test_spec_simple_filter();
 		test_spec_prewarp_in_posit_precision();
+		test_spec_end_to_end_in_posit_precision();
 		test_spec_rejects_invalid();
 
 		std::cout << "All Elliptic filter tests passed.\n";


### PR DESCRIPTION
## Summary
- `EllipticLowPassSpec<posit<32,2>>` (and other IIR Spec classes with non-native scalars) now compiles and runs end-to-end
- Fixes two blockers simultaneously: `std::complex<T>` dispatch mismatch (the issue's primary focus) and a secondary `pi_v<T>` long-double constexpr issue that surfaced once the first was resolved

## Root causes & fixes

### 1. Complex type dispatch (the issue's main problem)
`BiquadCoefficients::set_one_pole` / `set_two_pole` / `response` and `Cascade::response` were hardcoded to `std::complex<T>`. All call sites already pass values typed via `complex_for_t<T>` (from `ComplexPair<T>`), which dispatches to `sw::universal::complex<T>` for Universal types — the standard only defines `std::complex` for float/double/long double.

**Fix:** change the affected signatures and local types to `complex_for_t<T>`. Zero breaking changes — every existing call site already supplies the correct type.

### 2. `pi_v<T>` long-double literal
`constants.hpp` defined `pi_v<T> = T(3.14...L)` with a long double literal. Posit's `T(long double)` constructor is not yet constexpr in Universal v4.6.10, so `pi_v<posit>` failed to instantiate — breaking every bilinear/prewarp path that referenced it.

**Fix:** drop the `L` suffix. Literals are now `double` (~16 digits). Native types (`float`/`double`/`long double`) pick up the same literal via implicit widening; posit's constexpr `double` ctor path works. The few extra digits of long double precision are well below the noise floor for any DSP math we do.

## Changes
- `include/sw/dsp/types/biquad_coefficients.hpp` — 4 signatures / return types updated
- `include/sw/dsp/filter/biquad/cascade.hpp` — response() return type and local accumulator
- `include/sw/dsp/math/constants.hpp` — 7 constants drop the `L` suffix
- `tests/test_elliptic.cpp` — new `test_spec_end_to_end_in_posit_precision`

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_elliptic | OK | PASS | OK | PASS |

Full gcc ctest: 31/31 pass.

### Posit<32,2> EllipticLowPassSpec end-to-end vs double (new test)
10 probe frequencies across passband, transition, stopband:
- Max |dB diff| = **7.6e-6** (well under 0.1 dB bound)

### Spot-check: other IIR families also now instantiate with posit
- `ButterworthLowPass<4, posit<32,2>>` — compiles, runs, sane response
- `ChebyshevILowPass<4, posit<32,2>>` — compiles, runs, sane response
- `ChebyshevIILowPass<4, posit<32,2>>` — compiles, runs, sane response

This matches the issue's acceptance criterion: "Butterworth and Chebyshev Spec classes also instantiate for posit (same infrastructure)".

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Resolves #119

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated filter API signatures (frequency response and pole/zero configuration methods) to better support specialized numeric types alongside standard floating-point types.

* **Tests**
  * Added regression test for elliptic lowpass filter specification, validating behavior across different numeric type implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->