### PR TITLE
feat(acquisition): expose PolyphaseDecimator from acquisition module

### DIFF
--- a/include/sw/dsp/acquisition/acquisition.hpp
+++ b/include/sw/dsp/acquisition/acquisition.hpp
@@ -9,3 +9,4 @@
 #include <sw/dsp/acquisition/decimation_chain.hpp>
 #include <sw/dsp/acquisition/halfband.hpp>
 #include <sw/dsp/acquisition/nco.hpp>
+#include <sw/dsp/acquisition/polyphase_decimator.hpp>

--- a/include/sw/dsp/acquisition/polyphase_decimator.hpp
+++ b/include/sw/dsp/acquisition/polyphase_decimator.hpp
@@ -1,0 +1,42 @@
+#pragma once
+// polyphase_decimator.hpp: high-rate data acquisition entry point for the
+// general-purpose polyphase FIR decimator.
+//
+// The PolyphaseDecimator class itself lives in the FIR module
+// (<sw/dsp/filter/fir/polyphase.hpp>) because it's a general multirate
+// FIR primitive — used both by the data-acquisition pipeline (DDC,
+// DecimationChain) and by anyone designing FIR multirate flows
+// directly. This header makes it discoverable via the acquisition
+// module's namespace and adds documentation specific to the
+// high-rate-data-acquisition use case.
+//
+// Polyphase decimation by M decomposes an N-tap FIR prototype into M
+// sub-filters of length ceil(N/M). Each sub-filter advances once per
+// output sample (not once per input sample), so the multiplier
+// budget is ~N mults per output instead of ~N*M for the naive
+// filter-then-downsample. For the high-rate data-acquisition chain
+// (CIC -> half-band -> polyphase FIR -> baseband), this is the
+// channel-shaping stage at the lowest sample rate where the
+// arithmetic cost is amortized over fewer outputs.
+//
+// Three-scalar parameterization:
+//   CoeffScalar  - tap coefficients (designed in high precision)
+//   StateScalar  - delay-line accumulation precision
+//   SampleScalar - input/output samples
+//
+// Public design helper polyphase_decompose<T>(taps, factor) returns
+// the M sub-tap arrays for inspection or external sub-filter use.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/filter/fir/polyphase.hpp>
+
+namespace sw::dsp {
+// PolyphaseDecimator and PolyphaseInterpolator are defined in
+// <sw/dsp/filter/fir/polyphase.hpp> and are visible here via the
+// transitive include — re-stating them as `using` declarations would
+// add an extra name without functional benefit. Documentation
+// referring to "the acquisition polyphase decimator" should point
+// readers at PolyphaseDecimator from this header.
+} // namespace sw::dsp

--- a/include/sw/dsp/filter/fir/polyphase.hpp
+++ b/include/sw/dsp/filter/fir/polyphase.hpp
@@ -72,6 +72,26 @@ decompose_polyphase(const mtl::vec::dense_vector<T>& taps, std::size_t factor) {
 
 } // namespace detail
 
+// Public design helper: decompose an FIR prototype into the M sub-filter
+// branches used by polyphase decimation/interpolation.
+//
+// Arguments:
+//   taps   - prototype FIR impulse response, length N
+//   factor - rate-change factor M (decimation or interpolation), > 0
+//
+// Returns:
+//   M sub-filters of length ceil(N / M). sub[q][p] = taps[p*M + q] with
+//   zero-padding at the tail so all branches have identical length.
+//
+// Useful when callers want to inspect the polyphase matrix (e.g., for
+// pre-quantization analysis or hardware coefficient placement) without
+// instantiating a runtime PolyphaseDecimator/Interpolator.
+template <typename T>
+std::vector<mtl::vec::dense_vector<T>>
+polyphase_decompose(const mtl::vec::dense_vector<T>& taps, std::size_t factor) {
+	return detail::decompose_polyphase(taps, factor);
+}
+
 // -----------------------------------------------------------------------------
 // PolyphaseInterpolator: integer-factor upsampling with embedded FIR smoothing.
 // -----------------------------------------------------------------------------

--- a/include/sw/dsp/filter/fir/polyphase.hpp
+++ b/include/sw/dsp/filter/fir/polyphase.hpp
@@ -76,12 +76,15 @@ decompose_polyphase(const mtl::vec::dense_vector<T>& taps, std::size_t factor) {
 // branches used by polyphase decimation/interpolation.
 //
 // Arguments:
-//   taps   - prototype FIR impulse response, length N
-//   factor - rate-change factor M (decimation or interpolation), > 0
+//   taps   - prototype FIR impulse response, length N. Must not be empty.
+//   factor - rate-change factor M (decimation or interpolation). Must be > 0.
 //
 // Returns:
 //   M sub-filters of length ceil(N / M). sub[q][p] = taps[p*M + q] with
 //   zero-padding at the tail so all branches have identical length.
+//
+// Throws:
+//   std::invalid_argument if `factor == 0` or `taps` is empty.
 //
 // Useful when callers want to inspect the polyphase matrix (e.g., for
 // pre-quantization analysis or hardware coefficient placement) without

--- a/tests/test_fir_multirate.cpp
+++ b/tests/test_fir_multirate.cpp
@@ -423,11 +423,20 @@ void test_polyphase_decompose_helper() {
 		}
 	}
 
-	// Validation
+	// Validation: both preconditions stated in the doc must throw
+	// std::invalid_argument.
 	bool threw = false;
 	try { polyphase_decompose(h, 0); }
 	catch (const std::invalid_argument&) { threw = true; }
 	if (!threw) throw std::runtime_error("test failed: factor=0 should throw");
+
+	threw = false;
+	try {
+		mtl::vec::dense_vector<double> empty;
+		polyphase_decompose(empty, 3);
+	}
+	catch (const std::invalid_argument&) { threw = true; }
+	if (!threw) throw std::runtime_error("test failed: empty taps should throw");
 
 	std::cout << "  polyphase_decompose_helper: passed\n";
 }

--- a/tests/test_fir_multirate.cpp
+++ b/tests/test_fir_multirate.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <sw/dsp/filter/fir/fir.hpp>
+#include <sw/dsp/acquisition/polyphase_decimator.hpp>
 #include <sw/dsp/signals/sampling.hpp>
 
 #include <cmath>
@@ -11,6 +12,9 @@
 #include <iostream>
 #include <random>
 #include <stdexcept>
+
+#include <universal/number/posit/posit.hpp>
+#include <universal/number/cfloat/cfloat.hpp>
 
 using namespace sw::dsp;
 
@@ -299,6 +303,135 @@ void test_overlap_convolver_state_persistence() {
 	std::cout << "  overlap_convolver_state_persistence: passed\n";
 }
 
+// ============================================================================
+// Issue #91: Polyphase decimator with non-native CoeffScalar
+//
+// Acceptance criterion calls for unit tests at posit and cfloat. Each test
+// designs taps in double, casts to T, runs the decimator at T, and compares
+// against an at-T reference (FIR-then-downsample). Tolerance is set to the
+// type's ULP scale; structurally these are identical computations, so any
+// drift signals an actual bug rather than precision loss.
+// ============================================================================
+
+namespace {
+
+template <typename T>
+mtl::vec::dense_vector<T> cast_signal(const mtl::vec::dense_vector<double>& x) {
+	mtl::vec::dense_vector<T> y(x.size());
+	for (std::size_t i = 0; i < x.size(); ++i) y[i] = T(x[i]);
+	return y;
+}
+
+template <typename T>
+mtl::vec::dense_vector<T> reference_decimate_T(const mtl::vec::dense_vector<T>& x,
+                                                 const mtl::vec::dense_vector<T>& h,
+                                                 std::size_t M) {
+	FIRFilter<T> f(h);
+	mtl::vec::dense_vector<T> y_full(x.size(), T{});
+	for (std::size_t i = 0; i < x.size(); ++i) y_full[i] = f.process(x[i]);
+	return downsample(y_full, M);
+}
+
+template <typename T>
+double max_diff_to_double(const mtl::vec::dense_vector<T>& a,
+                          const mtl::vec::dense_vector<T>& b) {
+	if (a.size() != b.size()) return 1e30;
+	double m = 0.0;
+	for (std::size_t i = 0; i < a.size(); ++i) {
+		double d = std::abs(static_cast<double>(a[i]) - static_cast<double>(b[i]));
+		if (d > m) m = d;
+	}
+	return m;
+}
+
+} // anonymous namespace
+
+void test_polyphase_decimator_in_posit() {
+	using posit_t = sw::universal::posit<32, 2>;
+
+	for (std::size_t M : {2u, 3u, 4u, 5u}) {
+		auto h_d = lowpass_taps(31);
+		auto x_d = random_signal(300, 11);
+		std::size_t trimmed = (x_d.size() / M) * M;
+		mtl::vec::dense_vector<double> x_t(trimmed);
+		for (std::size_t i = 0; i < trimmed; ++i) x_t[i] = x_d[i];
+
+		auto h_p = cast_signal<posit_t>(h_d);
+		auto x_p = cast_signal<posit_t>(x_t);
+
+		PolyphaseDecimator<posit_t> dec(h_p, M);
+		auto y_poly = dec.process_block(std::span<const posit_t>(x_p.data(), x_p.size()));
+		auto y_ref  = reference_decimate_T(x_p, h_p, M);
+
+		double err = max_diff_to_double(y_poly, y_ref);
+		// posit<32,2> has ~28 mantissa bits near unity. With 31 taps, accumulated
+		// rounding stays within ~1e-7 — same as the structural double bound but
+		// scaled to posit ULP.
+		if (err > 1e-7)
+			throw std::runtime_error("test failed: posit decimator M=" +
+				std::to_string(M) + " max error " + std::to_string(err));
+	}
+	std::cout << "  polyphase_decimator_in_posit: passed\n";
+}
+
+void test_polyphase_decimator_in_cfloat() {
+	// cfloat<32,8>: same width as IEEE float, useful as a sanity check that
+	// the decimator works with cfloat's representation even at native widths.
+	using cfloat32 = sw::universal::cfloat<32, 8, std::uint32_t, true, false, false>;
+
+	for (std::size_t M : {2u, 3u, 4u}) {
+		auto h_d = lowpass_taps(21);
+		auto x_d = random_signal(200, 17);
+		std::size_t trimmed = (x_d.size() / M) * M;
+		mtl::vec::dense_vector<double> x_t(trimmed);
+		for (std::size_t i = 0; i < trimmed; ++i) x_t[i] = x_d[i];
+
+		auto h_c = cast_signal<cfloat32>(h_d);
+		auto x_c = cast_signal<cfloat32>(x_t);
+
+		PolyphaseDecimator<cfloat32> dec(h_c, M);
+		auto y_poly = dec.process_block(std::span<const cfloat32>(x_c.data(), x_c.size()));
+		auto y_ref  = reference_decimate_T(x_c, h_c, M);
+
+		double err = max_diff_to_double(y_poly, y_ref);
+		// cfloat<32,8> ULP near unity is ~1e-7 (same as IEEE float)
+		if (err > 1e-6)
+			throw std::runtime_error("test failed: cfloat decimator M=" +
+				std::to_string(M) + " max error " + std::to_string(err));
+	}
+	std::cout << "  polyphase_decimator_in_cfloat: passed\n";
+}
+
+void test_polyphase_decompose_helper() {
+	// The public polyphase_decompose helper should match the per-element
+	// formula sub_taps[q][p] = h[p*M + q] with zero padding at the tail.
+	mtl::vec::dense_vector<double> h({1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0});
+	auto sub = polyphase_decompose(h, 3);
+
+	if (sub.size() != 3)
+		throw std::runtime_error("test failed: decompose factor count");
+	const std::size_t expected_len = (h.size() + 3 - 1) / 3;  // ceil(7/3) = 3
+	for (std::size_t q = 0; q < 3; ++q) {
+		if (sub[q].size() != expected_len)
+			throw std::runtime_error("test failed: decompose sub-length");
+		for (std::size_t p = 0; p < expected_len; ++p) {
+			std::size_t src = p * 3 + q;
+			double expected = (src < h.size()) ? h[src] : 0.0;
+			if (sub[q][p] != expected)
+				throw std::runtime_error("test failed: decompose sub[" +
+					std::to_string(q) + "][" + std::to_string(p) + "]");
+		}
+	}
+
+	// Validation
+	bool threw = false;
+	try { polyphase_decompose(h, 0); }
+	catch (const std::invalid_argument&) { threw = true; }
+	if (!threw) throw std::runtime_error("test failed: factor=0 should throw");
+
+	std::cout << "  polyphase_decompose_helper: passed\n";
+}
+
 int main() {
 	try {
 		std::cout << "FIR Multirate Tests\n";
@@ -307,6 +440,9 @@ int main() {
 		test_polyphase_interpolator_equivalence();
 		test_polyphase_decimator_equivalence();
 		test_polyphase_reset();
+		test_polyphase_decimator_in_posit();
+		test_polyphase_decimator_in_cfloat();
+		test_polyphase_decompose_helper();
 		test_overlap_add_equivalence();
 		test_overlap_save_equivalence();
 		test_overlap_add_default_block();


### PR DESCRIPTION
## Summary
The `PolyphaseDecimator` class itself was already built in PR #110 (DDC + DecimationChain) at `include/sw/dsp/filter/fir/polyphase.hpp`, where it lives correctly as a general-purpose multirate FIR primitive used by both the FIR module and the high-rate-data-acquisition pipeline. This PR closes the gap between that implementation and what issue #91 asked for explicitly:

1. **Convenience acquisition header** at `include/sw/dsp/acquisition/polyphase_decimator.hpp` — re-exports `PolyphaseDecimator` via transitive include, with documentation framing it as the channel-shaping stage in the CIC → half-band → polyphase FIR → baseband chain.
2. **Public `polyphase_decompose<T>` helper** — promotes the existing `detail::decompose_polyphase` to a documented public API so callers can inspect the polyphase decomposition without instantiating a runtime decimator.
3. **Posit + cfloat unit tests** — the issue's acceptance criterion `[ ] Unit tests with double, posit, cfloat`. Coverage was double-only.

## Why not move the class?
`PolyphaseDecimator` is used by:
- `DDC` (acquisition module)
- `DecimationChain` (acquisition module)
- `test_fir_multirate` (FIR module)
- direct user code that builds bespoke multirate flows

Moving it under `acquisition/` would force a wrong taxonomy on the FIR-module usage and break unrelated callers' includes. A convenience header at the requested path makes the high-rate-data-acquisition story discoverable without that cost.

## Changes
- `include/sw/dsp/acquisition/polyphase_decimator.hpp` — NEW (convenience header + doc)
- `include/sw/dsp/acquisition/acquisition.hpp` — add to umbrella
- `include/sw/dsp/filter/fir/polyphase.hpp` — add public `polyphase_decompose<T>` free function
- `tests/test_fir_multirate.cpp` — three new tests:
  - `test_polyphase_decimator_in_posit` — sweeps M={2,3,4,5} with posit<32,2>
  - `test_polyphase_decimator_in_cfloat` — sweeps M={2,3,4} with cfloat<32,8>
  - `test_polyphase_decompose_helper` — verifies sub-tap formula, rejects factor=0

Each at-T decimator is checked against an at-T reference FIR-then-downsample so the comparison isolates polyphase structural correctness from precision loss.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_fir_multirate | OK | PASS | OK | PASS |

Full gcc ctest: 31/31 pass.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Resolves #91

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polyphase decimator is now exposed through the acquisition module's public interface.
  * Added a utility to inspect and analyze FIR filter polyphase decomposition at design time.

* **Tests**
  * Expanded coverage for the polyphase decimator across multiple numeric types and data representations.
  * New tests validate polyphase decomposition behavior, tail-padding, and invalid-input error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->