### PR TITLE
feat(analysis): acquisition pipeline precision-analysis primitives

### DIFF
--- a/include/sw/dsp/analysis/acquisition_precision.hpp
+++ b/include/sw/dsp/analysis/acquisition_precision.hpp
@@ -96,11 +96,12 @@ double snr_db(const mtl::vec::dense_vector<RefScalar>& reference,
 template <class NCO>
 double measure_nco_sfdr_db(NCO& nco, std::size_t fft_size,
                            std::size_t guard_bins = 2) {
+	if (fft_size == 0)
+		throw std::invalid_argument("measure_nco_sfdr_db: fft_size must be > 0");
+
 	// Round fft_size up to next power of 2 for the FFT.
 	std::size_t N = 1;
 	while (N < fft_size) N <<= 1;
-	if (N == 0)
-		throw std::invalid_argument("measure_nco_sfdr_db: fft_size must be > 0");
 
 	using complex_t = typename NCO::complex_t;
 	mtl::vec::dense_vector<std::complex<double>> data(N);

--- a/include/sw/dsp/analysis/acquisition_precision.hpp
+++ b/include/sw/dsp/analysis/acquisition_precision.hpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <cstddef>
 #include <fstream>
+#include <limits>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -99,9 +100,18 @@ double measure_nco_sfdr_db(NCO& nco, std::size_t fft_size,
 	if (fft_size == 0)
 		throw std::invalid_argument("measure_nco_sfdr_db: fft_size must be > 0");
 
-	// Round fft_size up to next power of 2 for the FFT.
+	// Round fft_size up to next power of 2 for the FFT. Guard against the
+	// shift wrapping N to 0 for pathologically large fft_size — that would
+	// turn the loop infinite (since 0 < fft_size stays true and 0 << 1 = 0).
 	std::size_t N = 1;
-	while (N < fft_size) N <<= 1;
+	constexpr std::size_t shift_limit = std::numeric_limits<std::size_t>::max() >> 1;
+	while (N < fft_size) {
+		if (N > shift_limit)
+			throw std::overflow_error(
+				"measure_nco_sfdr_db: fft_size too large to round up to a "
+				"power of 2 within size_t");
+		N <<= 1;
+	}
 
 	using complex_t = typename NCO::complex_t;
 	mtl::vec::dense_vector<std::complex<double>> data(N);

--- a/include/sw/dsp/analysis/acquisition_precision.hpp
+++ b/include/sw/dsp/analysis/acquisition_precision.hpp
@@ -52,6 +52,7 @@ inline double enob_from_snr_db(double snr_db) {
 // is below the double-precision underflow boundary, signalling a
 // bit-identical match.
 template <class RefScalar, class TestScalar>
+	requires ConvertibleToDouble<RefScalar> && ConvertibleToDouble<TestScalar>
 double snr_db(std::span<const RefScalar> reference,
               std::span<const TestScalar> test) {
 	if (reference.size() != test.size())
@@ -75,6 +76,7 @@ double snr_db(std::span<const RefScalar> reference,
 
 // Convenience overload for mtl::vec::dense_vector.
 template <class RefScalar, class TestScalar>
+	requires ConvertibleToDouble<RefScalar> && ConvertibleToDouble<TestScalar>
 double snr_db(const mtl::vec::dense_vector<RefScalar>& reference,
               const mtl::vec::dense_vector<TestScalar>& test) {
 	return snr_db(std::span<const RefScalar>(reference.data(), reference.size()),
@@ -172,6 +174,8 @@ struct CICBitGrowthReport {
 // width — the standard CIC analysis assumes 2's-complement wrap is
 // preserved, which `int`/`fixpnt` accumulators naturally provide.
 template <class CIC, class Sample>
+	requires ConvertibleToDouble<Sample> &&
+	         requires(const CIC& c) { static_cast<double>(c.output()); }
 CICBitGrowthReport check_cic_bit_growth(CIC& cic,
                                          std::span<const Sample> input) {
 	double max_abs = 0.0;

--- a/include/sw/dsp/analysis/acquisition_precision.hpp
+++ b/include/sw/dsp/analysis/acquisition_precision.hpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <complex>
 #include <cstddef>
 #include <fstream>
 #include <limits>
@@ -116,13 +117,14 @@ double measure_nco_sfdr_db(NCO& nco, std::size_t fft_size,
 	}
 
 	using complex_t = typename NCO::complex_t;
-	mtl::vec::dense_vector<std::complex<double>> data(N);
+	using fft_complex_t = complex_for_t<double>;
+	mtl::vec::dense_vector<fft_complex_t> data(N);
 	for (std::size_t n = 0; n < fft_size; ++n) {
 		complex_t z = nco.generate_sample();
-		data[n] = std::complex<double>(static_cast<double>(z.real()),
-		                                static_cast<double>(z.imag()));
+		data[n] = fft_complex_t(static_cast<double>(z.real()),
+		                         static_cast<double>(z.imag()));
 	}
-	for (std::size_t n = fft_size; n < N; ++n) data[n] = std::complex<double>(0, 0);
+	for (std::size_t n = fft_size; n < N; ++n) data[n] = fft_complex_t(0, 0);
 
 	sw::dsp::spectral::fft_forward<double>(data);
 

--- a/include/sw/dsp/analysis/acquisition_precision.hpp
+++ b/include/sw/dsp/analysis/acquisition_precision.hpp
@@ -1,0 +1,242 @@
+#pragma once
+// acquisition_precision.hpp: precision-analysis primitives for high-rate
+// data acquisition pipelines (NCO, CIC, half-band, polyphase FIR, DDC,
+// DecimationChain).
+//
+// This header provides the primitives needed to characterize how the
+// arithmetic precision of each stage affects output quality:
+//
+//   snr_db / enob_from_snr_db   - scalar quality metrics
+//   measure_nco_sfdr_db          - spurious-free dynamic range of an NCO
+//   check_cic_bit_growth         - verify observed vs theoretical bit growth
+//   AcquisitionPrecisionRow      - schema-compatible Pareto-row record
+//   write_acquisition_csv        - CSV writer matching precision_sweep schema
+//
+// Per-stage noise budgeting is a workflow built on top of these primitives:
+// the user constructs two Chain instances that differ in exactly one
+// stage's scalar type, runs the same input through both, and uses
+// snr_db on the outputs to isolate that stage's contribution.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/spectral/fft.hpp>
+
+namespace sw::dsp::analysis {
+
+// ---------------------------------------------------------------------------
+// Scalar quality metrics
+// ---------------------------------------------------------------------------
+
+// Effective number of bits from SNR in dB. Standard formula:
+//   ENOB = (SNR_dB - 1.76) / 6.02
+// Source: Walt Kester / Analog Devices "Define ENOB" tutorial. Assumes
+// a sinusoidal full-scale input with quantization-noise dominated error.
+inline double enob_from_snr_db(double snr_db) {
+	return (snr_db - 1.76) / 6.02;
+}
+
+// SNR in dB of a test signal against a reference. Both spans must have
+// the same length. Returns +300 (effectively infinite) when noise power
+// is below the double-precision underflow boundary, signalling a
+// bit-identical match.
+template <class RefScalar, class TestScalar>
+double snr_db(std::span<const RefScalar> reference,
+              std::span<const TestScalar> test) {
+	if (reference.size() != test.size())
+		throw std::invalid_argument(
+			"snr_db: reference and test spans must have the same length");
+	if (reference.empty()) return 0.0;
+
+	double signal_power = 0.0;
+	double noise_power = 0.0;
+	for (std::size_t i = 0; i < reference.size(); ++i) {
+		const double r = static_cast<double>(reference[i]);
+		const double t = static_cast<double>(test[i]);
+		signal_power += r * r;
+		const double e = r - t;
+		noise_power += e * e;
+	}
+	if (signal_power <= 0.0) return 0.0;
+	if (noise_power < 1e-300) return 300.0;
+	return 10.0 * std::log10(signal_power / noise_power);
+}
+
+// Convenience overload for mtl::vec::dense_vector.
+template <class RefScalar, class TestScalar>
+double snr_db(const mtl::vec::dense_vector<RefScalar>& reference,
+              const mtl::vec::dense_vector<TestScalar>& test) {
+	return snr_db(std::span<const RefScalar>(reference.data(), reference.size()),
+	              std::span<const TestScalar>(test.data(), test.size()));
+}
+
+// ---------------------------------------------------------------------------
+// NCO spurious-free dynamic range
+// ---------------------------------------------------------------------------
+
+// Measure SFDR of an NCO by:
+//   1. Generating fft_size complex samples
+//   2. Forward FFT (zero-pad to next power of 2 if needed)
+//   3. Locating the peak bin, then the largest spur outside a small
+//      guard band around the peak
+//   4. Returning 20 * log10(peak / spur) in dB
+//
+// The NCO is mutated (its phase advances). Caller may want to reset()
+// before/after to keep the run reproducible.
+template <class NCO>
+double measure_nco_sfdr_db(NCO& nco, std::size_t fft_size,
+                           std::size_t guard_bins = 2) {
+	// Round fft_size up to next power of 2 for the FFT.
+	std::size_t N = 1;
+	while (N < fft_size) N <<= 1;
+	if (N == 0)
+		throw std::invalid_argument("measure_nco_sfdr_db: fft_size must be > 0");
+
+	using complex_t = typename NCO::complex_t;
+	mtl::vec::dense_vector<std::complex<double>> data(N);
+	for (std::size_t n = 0; n < fft_size; ++n) {
+		complex_t z = nco.generate_sample();
+		data[n] = std::complex<double>(static_cast<double>(z.real()),
+		                                static_cast<double>(z.imag()));
+	}
+	for (std::size_t n = fft_size; n < N; ++n) data[n] = std::complex<double>(0, 0);
+
+	sw::dsp::spectral::fft_forward<double>(data);
+
+	// Find peak (excluding bin 0 = DC).
+	double peak_mag = 0.0;
+	std::size_t peak_bin = 0;
+	for (std::size_t k = 1; k < N; ++k) {
+		const double m = std::abs(data[k]);
+		if (m > peak_mag) { peak_mag = m; peak_bin = k; }
+	}
+	if (peak_mag <= 0.0)
+		throw std::runtime_error("measure_nco_sfdr_db: signal has zero magnitude");
+
+	// Max spur outside guard around peak.
+	double spur_mag = 0.0;
+	for (std::size_t k = 1; k < N; ++k) {
+		const std::size_t dist = (k > peak_bin) ? (k - peak_bin) : (peak_bin - k);
+		if (dist <= guard_bins) continue;
+		const double m = std::abs(data[k]);
+		if (m > spur_mag) spur_mag = m;
+	}
+	if (spur_mag <= 0.0) return 300.0;
+	return 20.0 * std::log10(peak_mag / spur_mag);
+}
+
+// ---------------------------------------------------------------------------
+// CIC bit-growth verification
+// ---------------------------------------------------------------------------
+
+struct CICBitGrowthReport {
+	int    theoretical_bits;     // M * ceil(log2(R*D)) — Hogenauer's formula
+	int    observed_bits;        // ceil(log2(max |output|)) for the test input
+	double max_abs_output;       // raw measured peak
+	double headroom_bits;        // theoretical - observed, both as floats
+	bool   within_theory;        // true when observed <= theoretical
+};
+
+// Process the input through a CIC, recording the absolute peak of its
+// output samples, then compare against the theoretical worst-case
+// growth M*ceil(log2(R*D)). For a full-scale all-ones input the
+// theoretical and observed values converge.
+//
+// Note: this measures the OUTPUT peak (which is what the StateScalar
+// must accommodate at the comb-stage end). Internal integrator
+// magnitudes can be larger transiently but wrap around modulo their
+// width — the standard CIC analysis assumes 2's-complement wrap is
+// preserved, which `int`/`fixpnt` accumulators naturally provide.
+template <class CIC, class Sample>
+CICBitGrowthReport check_cic_bit_growth(CIC& cic,
+                                         std::span<const Sample> input) {
+	double max_abs = 0.0;
+	for (std::size_t n = 0; n < input.size(); ++n) {
+		if (cic.push(input[n])) {
+			const double y = std::abs(static_cast<double>(cic.output()));
+			if (y > max_abs) max_abs = y;
+		}
+	}
+
+	const int R = cic.decimation_ratio();
+	const int M = cic.num_stages();
+	const int D = cic.differential_delay();
+	const int theoretical = M * static_cast<int>(std::ceil(std::log2(
+		static_cast<double>(R) * static_cast<double>(D))));
+	const double observed_f = (max_abs > 0.0) ? std::log2(max_abs) : 0.0;
+	const int observed = static_cast<int>(std::ceil(observed_f));
+	return CICBitGrowthReport{
+		theoretical,
+		observed,
+		max_abs,
+		static_cast<double>(theoretical) - observed_f,
+		observed <= theoretical
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Pareto-row record + CSV writer (schema-compatible with precision_sweep)
+// ---------------------------------------------------------------------------
+
+struct AcquisitionPrecisionRow {
+	std::string pipeline;       // "ddc" | "decim_chain" | "nco" | etc.
+	std::string config_name;    // human-readable configuration label
+	std::string coeff_type;     // string repr of CoeffScalar
+	std::string state_type;     // string repr of StateScalar
+	std::string sample_type;    // string repr of SampleScalar
+	int         total_bits = 0; // sum of bit-widths across the three scalars
+	double      output_snr_db = 0.0;
+	double      output_enob = 0.0;
+	double      nco_sfdr_db = -1.0;          // -1 = N/A
+	double      cic_overflow_margin_bits = -1.0;  // -1 = N/A
+};
+
+namespace detail {
+inline std::string csv_quote(const std::string& s) {
+	if (s.find_first_of(",\"\n") == std::string::npos) return s;
+	std::string out = "\"";
+	for (char c : s) {
+		if (c == '"') out += "\"\"";
+		else out += c;
+	}
+	out += '"';
+	return out;
+}
+} // namespace detail
+
+// Write a header + one line per row. The first five string columns and
+// the SNR column align with applications/precision_sweep/precision_sweep.csv
+// so the existing Python visualization can read either file's common columns.
+inline void write_acquisition_csv(const std::string& path,
+                                  const std::vector<AcquisitionPrecisionRow>& rows) {
+	std::ofstream out(path);
+	if (!out)
+		throw std::runtime_error("write_acquisition_csv: cannot open " + path);
+	out << "pipeline,config_name,coeff_type,state_type,sample_type,"
+	    << "total_bits,output_snr_db,output_enob,nco_sfdr_db,"
+	    << "cic_overflow_margin_bits\n";
+	for (const auto& r : rows) {
+		out << detail::csv_quote(r.pipeline) << ','
+		    << detail::csv_quote(r.config_name) << ','
+		    << detail::csv_quote(r.coeff_type) << ','
+		    << detail::csv_quote(r.state_type) << ','
+		    << detail::csv_quote(r.sample_type) << ','
+		    << r.total_bits << ','
+		    << r.output_snr_db << ','
+		    << r.output_enob << ','
+		    << r.nco_sfdr_db << ','
+		    << r.cic_overflow_margin_bits << '\n';
+	}
+}
+
+} // namespace sw::dsp::analysis

--- a/include/sw/dsp/analysis/acquisition_precision.hpp
+++ b/include/sw/dsp/analysis/acquisition_precision.hpp
@@ -134,10 +134,13 @@ double measure_nco_sfdr_db(NCO& nco, std::size_t fft_size,
 	if (peak_mag <= 0.0)
 		throw std::runtime_error("measure_nco_sfdr_db: signal has zero magnitude");
 
-	// Max spur outside guard around peak.
+	// Max spur outside guard around peak. Use circular bin distance so
+	// peaks near bin 1 or N-1 don't treat their wrap-adjacent neighbours
+	// as far-away spurs.
 	double spur_mag = 0.0;
 	for (std::size_t k = 1; k < N; ++k) {
-		const std::size_t dist = (k > peak_bin) ? (k - peak_bin) : (peak_bin - k);
+		const std::size_t diff = (k > peak_bin) ? (k - peak_bin) : (peak_bin - k);
+		const std::size_t dist = std::min(diff, N - diff);
 		if (dist <= guard_bins) continue;
 		const double m = std::abs(data[k]);
 		if (m > spur_mag) spur_mag = m;

--- a/include/sw/dsp/analysis/analysis.hpp
+++ b/include/sw/dsp/analysis/analysis.hpp
@@ -7,3 +7,4 @@
 #include <sw/dsp/analysis/stability.hpp>
 #include <sw/dsp/analysis/sensitivity.hpp>
 #include <sw/dsp/analysis/condition.hpp>
+#include <sw/dsp/analysis/acquisition_precision.hpp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,3 +99,6 @@ dsp_add_test(test_ddc)
 
 # Multi-stage decimation chain (Issue #90)
 dsp_add_test(test_decimation_chain)
+
+# Acquisition pipeline precision analysis (Issue #92)
+dsp_add_test(test_acquisition_precision)

--- a/tests/test_acquisition_precision.cpp
+++ b/tests/test_acquisition_precision.cpp
@@ -14,6 +14,7 @@
 #include <sw/dsp/math/constants.hpp>
 #include <sw/dsp/windows/hamming.hpp>
 
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <filesystem>
@@ -289,10 +290,12 @@ void test_csv_writer_schema() {
 	}
 
 	// std::filesystem::temp_directory_path() is portable across Linux/macOS/
-	// Windows; tmpnam triggers a glibc deprecation warning and has known
-	// race issues — overkill here since the test owns the file end-to-end.
+	// Windows; the steady_clock suffix prevents collisions when ctest runs
+	// tests in parallel or when the test process is repeated.
+	const auto unique = std::to_string(
+		std::chrono::steady_clock::now().time_since_epoch().count());
 	const std::string path = (std::filesystem::temp_directory_path() /
-		"test_acquisition_precision.csv").string();
+		("test_acquisition_precision_" + unique + ".csv")).string();
 	write_acquisition_csv(path, rows);
 
 	std::ifstream in(path);

--- a/tests/test_acquisition_precision.cpp
+++ b/tests/test_acquisition_precision.cpp
@@ -118,6 +118,16 @@ void test_nco_sfdr_double() {
 	std::cout << "  nco_sfdr_double: " << sfdr << " dB, passed\n";
 }
 
+void test_nco_sfdr_zero_size_throws() {
+	NCO<double> nco(1.0, 1024.0);
+	bool threw = false;
+	try { measure_nco_sfdr_db(nco, 0); }
+	catch (const std::invalid_argument&) { threw = true; }
+	if (!threw)
+		throw std::runtime_error("test failed: fft_size=0 should throw");
+	std::cout << "  nco_sfdr_zero_size_throws: passed\n";
+}
+
 void test_nco_sfdr_posit() {
 	using posit_t = sw::universal::posit<32, 2>;
 	const std::size_t N = 4096;
@@ -334,6 +344,7 @@ int main() {
 		test_snr_with_known_noise();
 		test_snr_size_mismatch_throws();
 		test_nco_sfdr_double();
+		test_nco_sfdr_zero_size_throws();
 		test_nco_sfdr_posit();
 		test_cic_bit_growth_dc();
 		test_per_stage_noise_via_snr();

--- a/tests/test_acquisition_precision.cpp
+++ b/tests/test_acquisition_precision.cpp
@@ -1,0 +1,348 @@
+// test_acquisition_precision.cpp: tests for the acquisition precision-analysis
+// primitives.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/analysis/acquisition_precision.hpp>
+#include <sw/dsp/acquisition/cic.hpp>
+#include <sw/dsp/acquisition/decimation_chain.hpp>
+#include <sw/dsp/acquisition/halfband.hpp>
+#include <sw/dsp/acquisition/nco.hpp>
+#include <sw/dsp/filter/fir/fir_design.hpp>
+#include <sw/dsp/filter/fir/polyphase.hpp>
+#include <sw/dsp/math/constants.hpp>
+#include <sw/dsp/windows/hamming.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <universal/number/posit/posit.hpp>
+
+using namespace sw::dsp;
+using namespace sw::dsp::analysis;
+
+bool near(double a, double b, double eps = 1e-6) {
+	return std::abs(a - b) < eps;
+}
+
+// ============================================================================
+// ENOB formula
+// ============================================================================
+
+void test_enob_formula() {
+	// 6.02 N + 1.76 inverted: at 6.02 dB, ENOB ~= 0.703; at 98.09 dB ENOB = 16.
+	if (!near(enob_from_snr_db(6.02), (6.02 - 1.76) / 6.02, 1e-12))
+		throw std::runtime_error("test failed: enob @ 6.02");
+	if (!near(enob_from_snr_db(98.09), (98.09 - 1.76) / 6.02, 1e-12))
+		throw std::runtime_error("test failed: enob @ 98.09");
+	// 16-bit converter SNR ~= 6.02*16 + 1.76 = 98.08 dB
+	if (!near(enob_from_snr_db(98.08), 16.0, 0.01))
+		throw std::runtime_error("test failed: enob ~= 16 at 98.08 dB");
+	std::cout << "  enob_formula: passed\n";
+}
+
+// ============================================================================
+// SNR identity and basic measurement
+// ============================================================================
+
+void test_snr_identity() {
+	mtl::vec::dense_vector<double> a(64);
+	mtl::vec::dense_vector<double> b(64);
+	for (std::size_t i = 0; i < 64; ++i) {
+		a[i] = std::sin(2.0 * pi * static_cast<double>(i) / 64.0);
+		b[i] = a[i];
+	}
+	// Bit-identical: should clip to the underflow guard at 300 dB.
+	double s = snr_db(a, b);
+	if (!(s >= 299.0))
+		throw std::runtime_error("test failed: identity SNR = " + std::to_string(s));
+	std::cout << "  snr_identity: " << s << " dB, passed\n";
+}
+
+void test_snr_with_known_noise() {
+	// Inject 1% RMS noise into a unit-amplitude sine. Expected SNR = 40 dB.
+	std::size_t N = 4096;
+	mtl::vec::dense_vector<double> ref(N);
+	mtl::vec::dense_vector<double> tst(N);
+	double noise = 0.01;  // amplitude
+	for (std::size_t i = 0; i < N; ++i) {
+		double v = std::sin(2.0 * pi * 5.0 * static_cast<double>(i) / static_cast<double>(N));
+		ref[i] = v;
+		// Deterministic uniform-ish noise via a hash of i.
+		double phase = std::sin(static_cast<double>(i) * 0.7853981633974483);
+		tst[i] = v + noise * phase;
+	}
+	double s = snr_db(ref, tst);
+	// Expected ~40 dB; allow generous slack for the deterministic-noise PDF.
+	if (!(s > 30.0 && s < 50.0))
+		throw std::runtime_error("test failed: noisy SNR = " + std::to_string(s) +
+			" (expected ~40 dB)");
+	std::cout << "  snr_with_known_noise: " << s << " dB, passed\n";
+}
+
+void test_snr_size_mismatch_throws() {
+	mtl::vec::dense_vector<double> a(10);
+	mtl::vec::dense_vector<double> b(11);
+	bool threw = false;
+	try { snr_db(a, b); }
+	catch (const std::invalid_argument&) { threw = true; }
+	if (!threw)
+		throw std::runtime_error("test failed: size mismatch should throw");
+	std::cout << "  snr_size_mismatch_throws: passed\n";
+}
+
+// ============================================================================
+// NCO SFDR
+// ============================================================================
+
+void test_nco_sfdr_double() {
+	// A pure double NCO at a non-trivial frequency should have very high
+	// SFDR, limited only by FFT leakage. Use a bin-aligned tone for
+	// minimal leakage so the spurs stay well below the peak.
+	const std::size_t N = 4096;
+	const double fs = static_cast<double>(N);   // pick fs so f_tone is on a bin
+	const double f_tone = 137.0;                // 137 cycles in 4096 samples
+	NCO<double> nco(f_tone, fs);
+	double sfdr = measure_nco_sfdr_db(nco, N);
+	if (!(sfdr > 80.0))
+		throw std::runtime_error("test failed: double NCO SFDR = " +
+			std::to_string(sfdr) + " dB (expected > 80)");
+	std::cout << "  nco_sfdr_double: " << sfdr << " dB, passed\n";
+}
+
+void test_nco_sfdr_posit() {
+	using posit_t = sw::universal::posit<32, 2>;
+	const std::size_t N = 4096;
+	const posit_t fs(static_cast<double>(N));
+	const posit_t f_tone(137.0);
+	NCO<posit_t> nco(f_tone, fs);
+	double sfdr = measure_nco_sfdr_db(nco, N);
+	// Posit<32,2> tapered precision near unity is ~28 bits; theoretical
+	// SFDR of ~6.02*28 = ~168 dB. FFT spectral leakage and posit rounding
+	// cap it lower in practice; 60 dB is a defensive lower bound.
+	if (!(sfdr > 60.0))
+		throw std::runtime_error("test failed: posit NCO SFDR = " +
+			std::to_string(sfdr) + " dB (expected > 60)");
+	std::cout << "  nco_sfdr_posit: " << sfdr << " dB, passed\n";
+}
+
+// ============================================================================
+// CIC bit-growth verification
+// ============================================================================
+
+void test_cic_bit_growth_dc() {
+	// All-ones DC input is the worst case. After settling, the CIC output
+	// converges to (R*D)^M = 64 for R=4, M=3, D=1. So observed_bits should
+	// match theoretical = 3 * ceil(log2(4)) = 6 bits.
+	const int R = 4, M = 3;
+	CICDecimator<double> cic(R, M);
+	std::vector<double> input(256, 1.0);
+	auto report = check_cic_bit_growth(cic,
+		std::span<const double>(input.data(), input.size()));
+
+	const int expected_theoretical = M * static_cast<int>(std::ceil(std::log2(double(R))));
+	if (report.theoretical_bits != expected_theoretical)
+		throw std::runtime_error("test failed: theoretical_bits = " +
+			std::to_string(report.theoretical_bits) +
+			", expected " + std::to_string(expected_theoretical));
+	if (!report.within_theory)
+		throw std::runtime_error("test failed: observed " +
+			std::to_string(report.observed_bits) +
+			" exceeds theoretical " + std::to_string(report.theoretical_bits));
+	// Max output for DC=1 should be exactly (R*D)^M = 64.
+	const double expected_peak = std::pow(double(R), double(M));
+	if (std::abs(report.max_abs_output - expected_peak) > 1e-9)
+		throw std::runtime_error("test failed: peak " +
+			std::to_string(report.max_abs_output) +
+			", expected " + std::to_string(expected_peak));
+	std::cout << "  cic_bit_growth_dc: theoretical=" << report.theoretical_bits
+	          << " bits, observed=" << report.observed_bits
+	          << " bits, peak=" << report.max_abs_output
+	          << ", passed\n";
+}
+
+// ============================================================================
+// Per-stage noise budget on a DecimationChain
+// ============================================================================
+
+void test_per_stage_noise_via_snr() {
+	// Build two chains with identical structure (CIC-4 -> half-band -> FIR-2)
+	// and identical taps, but one uses double end-to-end and the other uses
+	// posit<32,2>. Compare outputs via snr_db; the cross-precision SNR
+	// quantifies the posit chain's deviation from the ideal.
+	using posit_t = sw::universal::posit<32, 2>;
+
+	const double fs = 1'000'000.0;
+	const std::size_t R_fir = 2;
+
+	auto build_double_chain = [&]() {
+		CICDecimator<double> cic(4, 2);
+		auto hb_taps = design_halfband<double>(15, 0.15);
+		HalfBandFilter<double> hb(hb_taps);
+		auto win = hamming_window<double>(17);
+		auto fir_taps = design_fir_lowpass<double>(17, 0.2, win);
+		PolyphaseDecimator<double> pf(fir_taps, R_fir);
+		return DecimationChain<double, CICDecimator<double>,
+		                                 HalfBandFilter<double>,
+		                                 PolyphaseDecimator<double>>(fs, cic, hb, pf);
+	};
+
+	auto build_posit_chain = [&]() {
+		CICDecimator<posit_t> cic(4, 2);
+		auto hb_d = design_halfband<double>(15, 0.15);
+		mtl::vec::dense_vector<posit_t> hb_p(hb_d.size());
+		for (std::size_t i = 0; i < hb_d.size(); ++i) hb_p[i] = posit_t(hb_d[i]);
+		HalfBandFilter<posit_t> hb(hb_p);
+		auto win = hamming_window<double>(17);
+		auto fir_d = design_fir_lowpass<double>(17, 0.2, win);
+		mtl::vec::dense_vector<posit_t> fir_p(fir_d.size());
+		for (std::size_t i = 0; i < fir_d.size(); ++i) fir_p[i] = posit_t(fir_d[i]);
+		PolyphaseDecimator<posit_t> pf(fir_p, R_fir);
+		return DecimationChain<posit_t, CICDecimator<posit_t>,
+		                                  HalfBandFilter<posit_t>,
+		                                  PolyphaseDecimator<posit_t>>(posit_t(fs), cic, hb, pf);
+	};
+
+	auto chain_d = build_double_chain();
+	auto chain_p = build_posit_chain();
+
+	const std::size_t N = 1024;
+	mtl::vec::dense_vector<double> in_d(N);
+	mtl::vec::dense_vector<posit_t> in_p(N);
+	for (std::size_t n = 0; n < N; ++n) {
+		double v = std::cos(2.0 * pi * 1000.0 * static_cast<double>(n) / fs);
+		in_d[n] = v;
+		in_p[n] = posit_t(v);
+	}
+	auto out_d = chain_d.process_block(in_d);
+	auto out_p = chain_p.process_block(in_p);
+
+	// Cast posit output to double for the SNR comparison.
+	mtl::vec::dense_vector<double> out_p_as_d(out_p.size());
+	for (std::size_t i = 0; i < out_p.size(); ++i) out_p_as_d[i] = static_cast<double>(out_p[i]);
+
+	if (out_d.size() != out_p_as_d.size())
+		throw std::runtime_error("test failed: chain output size mismatch");
+
+	double s = snr_db(out_d, out_p_as_d);
+	double enob = enob_from_snr_db(s);
+	// posit<32,2> through this 3-stage chain measures ~98 dB SNR (~16 ENOB).
+	// CIC accumulates to gain 64 = (R*D)^M for R=4,M=2,D=1, where posit's
+	// tapered precision is somewhat lower than at unity. 90 dB / ~14.7 ENOB
+	// gives modest headroom for cross-toolchain libm variance while still
+	// asserting "this is a high-quality posit pipeline".
+	if (!(s > 90.0))
+		throw std::runtime_error("test failed: posit chain SNR = " +
+			std::to_string(s) + " (expected > 90)");
+	std::cout << "  per_stage_noise_via_snr: SNR=" << s
+	          << " dB, ENOB=" << enob << ", passed\n";
+}
+
+// ============================================================================
+// CSV writer schema check
+// ============================================================================
+
+void test_csv_writer_schema() {
+	std::vector<AcquisitionPrecisionRow> rows;
+	{
+		AcquisitionPrecisionRow r;
+		r.pipeline = "ddc";
+		r.config_name = "uniform_double";
+		r.coeff_type = "double";
+		r.state_type = "double";
+		r.sample_type = "double";
+		r.total_bits = 192;
+		r.output_snr_db = 250.0;
+		r.output_enob = 41.3;
+		rows.push_back(r);
+	}
+	{
+		AcquisitionPrecisionRow r;
+		r.pipeline = "decim_chain";
+		r.config_name = "posit32_uniform";
+		r.coeff_type = "posit<32,2>";
+		r.state_type = "posit<32,2>";
+		r.sample_type = "posit<32,2>";
+		r.total_bits = 96;
+		r.output_snr_db = 110.0;
+		r.output_enob = 17.97;
+		r.cic_overflow_margin_bits = 12.0;
+		rows.push_back(r);
+	}
+
+	// std::filesystem::temp_directory_path() is portable across Linux/macOS/
+	// Windows; tmpnam triggers a glibc deprecation warning and has known
+	// race issues — overkill here since the test owns the file end-to-end.
+	const std::string path = (std::filesystem::temp_directory_path() /
+		"test_acquisition_precision.csv").string();
+	write_acquisition_csv(path, rows);
+
+	std::ifstream in(path);
+	if (!in)
+		throw std::runtime_error("test failed: cannot read written CSV");
+	std::string header;
+	std::getline(in, header);
+	std::string expected_header =
+		"pipeline,config_name,coeff_type,state_type,sample_type,"
+		"total_bits,output_snr_db,output_enob,nco_sfdr_db,"
+		"cic_overflow_margin_bits";
+	if (header != expected_header)
+		throw std::runtime_error("test failed: CSV header mismatch:\n  got: " +
+			header + "\n  exp: " + expected_header);
+
+	int line_count = 0;
+	std::string line;
+	while (std::getline(in, line)) {
+		if (!line.empty()) ++line_count;
+	}
+	if (line_count != 2)
+		throw std::runtime_error("test failed: expected 2 data rows, got " +
+			std::to_string(line_count));
+
+	// Verify the second row has the quoted "posit<32,2>" preserved (no
+	// special chars to quote there, but the schema must be intact).
+	std::ifstream in2(path);
+	std::string h, r1, r2;
+	std::getline(in2, h);
+	std::getline(in2, r1);
+	std::getline(in2, r2);
+	if (r2.find("posit<32,2>") == std::string::npos)
+		throw std::runtime_error("test failed: posit type string not preserved");
+
+	std::remove(path.c_str());
+	std::cout << "  csv_writer_schema: passed\n";
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "Acquisition Precision Analysis Tests\n";
+
+		test_enob_formula();
+		test_snr_identity();
+		test_snr_with_known_noise();
+		test_snr_size_mismatch_throws();
+		test_nco_sfdr_double();
+		test_nco_sfdr_posit();
+		test_cic_bit_growth_dc();
+		test_per_stage_noise_via_snr();
+		test_csv_writer_schema();
+
+		std::cout << "All acquisition precision tests passed.\n";
+	} catch (const std::exception& e) {
+		std::cerr << "FAILED: " << e.what() << "\n";
+		return 1;
+	}
+	return 0;
+}

--- a/tests/test_acquisition_precision.cpp
+++ b/tests/test_acquisition_precision.cpp
@@ -129,6 +129,22 @@ void test_nco_sfdr_zero_size_throws() {
 	std::cout << "  nco_sfdr_zero_size_throws: passed\n";
 }
 
+void test_nco_sfdr_low_bin_circular_guard() {
+	// Tone at bin 1 — wrap-adjacent bin N-1 must be excluded by the
+	// circular guard. With the previous linear-distance code, bin N-1
+	// would slip through and the SFDR floor would collapse.
+	const std::size_t N = 4096;
+	const double fs = static_cast<double>(N);
+	const double f_tone = 1.0;  // exactly bin 1
+	NCO<double> nco(f_tone, fs);
+	double sfdr = measure_nco_sfdr_db(nco, N, /*guard_bins=*/2);
+	if (!(sfdr > 80.0))
+		throw std::runtime_error("test failed: low-bin SFDR = " +
+			std::to_string(sfdr) +
+			" dB (expected > 80; circular guard not working?)");
+	std::cout << "  nco_sfdr_low_bin_circular_guard: " << sfdr << " dB, passed\n";
+}
+
 void test_nco_sfdr_posit() {
 	using posit_t = sw::universal::posit<32, 2>;
 	const std::size_t N = 4096;
@@ -348,6 +364,7 @@ int main() {
 		test_snr_size_mismatch_throws();
 		test_nco_sfdr_double();
 		test_nco_sfdr_zero_size_throws();
+		test_nco_sfdr_low_bin_circular_guard();
 		test_nco_sfdr_posit();
 		test_cic_bit_growth_dc();
 		test_per_stage_noise_via_snr();

--- a/tests/test_acquisition_precision.cpp
+++ b/tests/test_acquisition_precision.cpp
@@ -19,6 +19,8 @@
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <limits>
+#include <system_error>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
@@ -127,6 +129,20 @@ void test_nco_sfdr_zero_size_throws() {
 	if (!threw)
 		throw std::runtime_error("test failed: fft_size=0 should throw");
 	std::cout << "  nco_sfdr_zero_size_throws: passed\n";
+}
+
+void test_nco_sfdr_huge_size_throws_overflow() {
+	// Lock in the round-2 fix: a fft_size near size_t max would have
+	// previously wrapped N to 0 and spun forever.
+	NCO<double> nco(1.0, 1024.0);
+	bool threw = false;
+	try {
+		measure_nco_sfdr_db(nco, std::numeric_limits<std::size_t>::max());
+	}
+	catch (const std::overflow_error&) { threw = true; }
+	if (!threw)
+		throw std::runtime_error("test failed: huge fft_size should throw overflow_error");
+	std::cout << "  nco_sfdr_huge_size_throws_overflow: passed\n";
 }
 
 void test_nco_sfdr_low_bin_circular_guard() {
@@ -346,7 +362,16 @@ void test_csv_writer_schema() {
 	if (r2.find("posit<32,2>") == std::string::npos)
 		throw std::runtime_error("test failed: posit type string not preserved");
 
-	std::remove(path.c_str());
+	// Close all ifstream handles before unlinking the file. On Linux this
+	// isn't strictly necessary (you can unlink open files), but on Windows
+	// std::filesystem::remove fails for files that are still held open.
+	in.close();
+	in2.close();
+	std::error_code ec;
+	std::filesystem::remove(path, ec);
+	if (ec)
+		throw std::runtime_error("test failed: temp CSV cleanup failed: " +
+			ec.message());
 	std::cout << "  csv_writer_schema: passed\n";
 }
 
@@ -364,6 +389,7 @@ int main() {
 		test_snr_size_mismatch_throws();
 		test_nco_sfdr_double();
 		test_nco_sfdr_zero_size_throws();
+		test_nco_sfdr_huge_size_throws_overflow();
 		test_nco_sfdr_low_bin_circular_guard();
 		test_nco_sfdr_posit();
 		test_cic_bit_growth_dc();


### PR DESCRIPTION
## Summary
New header `include/sw/dsp/analysis/acquisition_precision.hpp` provides the building blocks for measuring how arithmetic precision at each stage of an acquisition chain affects output quality. Targets the primary acceptance items in #92; follow-up work for a standalone sweep application + Python visualization is intentionally deferred.

## Primitives
- `enob_from_snr_db(snr_db)` — standard `(snr - 1.76) / 6.02` conversion
- `snr_db<RefT, TestT>(reference, test)` — SNR with a 300 dB underflow guard for bit-identical signals
- `measure_nco_sfdr_db<NCO>(nco, fft_size, guard)` — peak-to-spur ratio via FFT, with a configurable guard band around the peak
- `check_cic_bit_growth<CIC, Sample>(cic, input)` — measures the observed output peak and compares against Hogenauer's `M·ceil(log2(R·D))`
- `AcquisitionPrecisionRow` + `write_acquisition_csv` — Pareto-row record whose CSV schema is a superset of `precision_sweep.csv` so the existing Python visualization tooling reads the common columns

Per-stage noise budgeting is a workflow on top of these primitives: construct two `Chain` instances differing in one stage's scalar type, run identical input, then `snr_db` the outputs to isolate that stage's contribution.

## Changes
- `include/sw/dsp/analysis/acquisition_precision.hpp` — NEW (~240 lines)
- `include/sw/dsp/analysis/analysis.hpp` — add to umbrella
- `tests/test_acquisition_precision.cpp` — NEW; 9 tests
- `tests/CMakeLists.txt` — register test (Issue #92)

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| test_acquisition_precision | OK | PASS (9/9) | OK | PASS (9/9) |

Full gcc ctest: 32/32.

### Highlights
- Double NCO SFDR (bin-aligned tone, FFT-leakage limited): **319 dB**
- Posit<32,2> NCO SFDR: **175 dB**
- CIC R=4, M=3, D=1 with DC-1 input: observed peak exactly `(R·D)^M = 64`, `observed_bits == theoretical_bits == 6`
- Posit<32,2> 3-stage DecimationChain (CIC-4 → HB → FIR-2) vs double reference: **SNR = 98.3 dB**, **ENOB = 16.04**

## Out of scope (intentionally deferred)
- Standalone `applications/acquisition_precision_sweep/` runner
- Python visualization integration

These belong in a follow-up "use the framework" PR after the framework lands.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Resolves #92

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added acquisition-precision toolkit: SNR/ENOB computation, NCO SFDR measurement (with guard-band handling), CIC bit-growth and headroom analysis, and CSV export with a fixed header; exposed via the analysis umbrella.

* **Tests**
  * Added end-to-end tests for ENOB/SNR (including extreme/no-noise cases), NCO SFDR behavior and error conditions, CIC bit-growth checks, multi-stage chain SNR across precisions, and CSV output; test added to the suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->