### PR TITLE
feat(applications): acquisition pipeline mixed-precision demo

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -30,5 +30,8 @@ add_subdirectory(precision_sweep)
 # FFT trade-off analysis (Issue #74)
 add_subdirectory(fft_tradeoff)
 
+# Acquisition pipeline demo (Issue #93)
+add_subdirectory(acquisition_demo)
+
 # Phase 8: Signal conditioning
 # add_subdirectory(conditioning_demo)

--- a/applications/acquisition_demo/CMakeLists.txt
+++ b/applications/acquisition_demo/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(acquisition_demo acquisition_demo.cpp)
+target_link_libraries(acquisition_demo PRIVATE sw::dsp)

--- a/applications/acquisition_demo/acquisition_demo.cpp
+++ b/applications/acquisition_demo/acquisition_demo.cpp
@@ -36,6 +36,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <random>
 #include <string>
 #include <vector>
@@ -83,7 +84,10 @@ mtl::vec::dense_vector<double> simulate_adc(int adc_bits, unsigned seed = 0xACDC
 	std::normal_distribution<double> noise(0.0, params::kNoiseRms);
 
 	const double full_scale = 1.0;
-	const double levels = static_cast<double>(1 << (adc_bits - 1));
+	// std::ldexp(1.0, n) computes 2^n as a double for any non-negative n,
+	// avoiding the UB of `1 << 63` (the literal `1` is a 32-bit int) when
+	// the ADC scan calls simulate_adc(64) for the unquantized reference.
+	const double levels = std::ldexp(1.0, adc_bits - 1);
 	const double q_step = full_scale / levels;
 
 	for (std::size_t n = 0; n < params::kNumSamples; ++n) {
@@ -152,6 +156,27 @@ run_ddc_pipeline(const mtl::vec::dense_vector<double>& adc_in_double) {
 // SNR/ENOB on the magnitude streams.
 // ============================================================================
 
+// Compare two complex baseband streams' magnitude envelopes after skipping
+// `skip` transient samples (the polyphase delay line takes ~num_taps/decim
+// samples to fill — using 16 to be safe). Returns NaN if sizes mismatch or
+// there aren't enough samples; NaN unambiguously says "no measurement",
+// distinguishing it from a legitimate poor SNR (e.g., 0 dB or -3 dB).
+double measure_baseband_snr_db(
+		const std::vector<std::complex<double>>& reference_out,
+		const std::vector<std::complex<double>>& test_out,
+		std::size_t skip = 16) {
+	if (test_out.size() != reference_out.size() || test_out.size() <= skip)
+		return std::numeric_limits<double>::quiet_NaN();
+	std::vector<double> ref_mag(test_out.size() - skip);
+	std::vector<double> tst_mag(test_out.size() - skip);
+	for (std::size_t i = skip; i < test_out.size(); ++i) {
+		ref_mag[i - skip] = std::abs(reference_out[i]);
+		tst_mag[i - skip] = std::abs(test_out[i]);
+	}
+	return snr_db(std::span<const double>(ref_mag.data(), ref_mag.size()),
+	              std::span<const double>(tst_mag.data(), tst_mag.size()));
+}
+
 template <class CoeffScalar, class StateScalar, class SampleScalar>
 AcquisitionPrecisionRow measure_config(
 		const std::string& config_name,
@@ -172,26 +197,11 @@ AcquisitionPrecisionRow measure_config(
 	row.cic_overflow_margin_bits = -1.0;     // CIC not used in this pipeline
 
 	auto test_out = run_ddc_pipeline<CoeffScalar, StateScalar, SampleScalar>(adc_in);
-
-	// Compare magnitude envelopes — they're the meaningful baseband output of a
-	// real-IF DDC. Skip the first few samples to let the polyphase delay line
-	// fill (roughly num_taps / decimation = 65/8 ≈ 8 samples).
-	const std::size_t skip = 16;
-	if (test_out.size() != reference_out.size() || test_out.size() <= skip) {
-		row.output_snr_db = 0.0;
-		row.output_enob   = 0.0;
-		return row;
-	}
-	std::vector<double> ref_mag(test_out.size() - skip);
-	std::vector<double> tst_mag(test_out.size() - skip);
-	for (std::size_t i = skip; i < test_out.size(); ++i) {
-		ref_mag[i - skip] = std::abs(reference_out[i]);
-		tst_mag[i - skip] = std::abs(test_out[i]);
-	}
-	const double s = snr_db(std::span<const double>(ref_mag.data(), ref_mag.size()),
-	                         std::span<const double>(tst_mag.data(), tst_mag.size()));
+	const double s = measure_baseband_snr_db(reference_out, test_out);
 	row.output_snr_db = s;
-	row.output_enob   = enob_from_snr_db(s);
+	row.output_enob   = std::isnan(s)
+		? std::numeric_limits<double>::quiet_NaN()
+		: enob_from_snr_db(s);
 	return row;
 }
 
@@ -264,7 +274,10 @@ void print_sweep_table(const std::vector<AcquisitionPrecisionRow>& rows) {
 	for (const auto& r : rows) {
 		std::cout << std::left  << std::setw(28) << r.config_name
 		          << std::right << std::setw(8)  << r.total_bits;
-		if (r.output_snr_db >= 299.0) {
+		if (std::isnan(r.output_snr_db)) {
+			std::cout << std::right << std::setw(11) << "FAIL"
+			          << std::right << std::setw(8)  << "—";
+		} else if (r.output_snr_db >= 299.0) {
 			std::cout << std::right << std::setw(11) << "inf"
 			          << std::right << std::setw(8)  << "ref";
 		} else {
@@ -302,17 +315,8 @@ void scan_adc_bit_depths(std::vector<AcquisitionPrecisionRow>& rows) {
 	for (int bits : {8, 12, 14, 16}) {
 		auto adc_in = simulate_adc(bits);
 		auto out_d = run_ddc_pipeline<double, double, double>(adc_in);
-		const std::size_t skip = 16;
-		if (out_d.size() != reference_out.size() || out_d.size() <= skip)
-			continue;
-		std::vector<double> ref_mag(out_d.size() - skip);
-		std::vector<double> tst_mag(out_d.size() - skip);
-		for (std::size_t i = skip; i < out_d.size(); ++i) {
-			ref_mag[i - skip] = std::abs(reference_out[i]);
-			tst_mag[i - skip] = std::abs(out_d[i]);
-		}
-		double s = snr_db(std::span<const double>(ref_mag.data(), ref_mag.size()),
-		                   std::span<const double>(tst_mag.data(), tst_mag.size()));
+		const double s = measure_baseband_snr_db(reference_out, out_d);
+		if (std::isnan(s)) continue;
 
 		AcquisitionPrecisionRow row;
 		row.pipeline = "ddc_adc_scan";

--- a/applications/acquisition_demo/acquisition_demo.cpp
+++ b/applications/acquisition_demo/acquisition_demo.cpp
@@ -242,28 +242,40 @@ run_pipeline(const mtl::vec::dense_vector<double>& adc_in_double) {
 
 // ============================================================================
 // Measurement: run reference (uniform double) and a test configuration; compute
-// SNR/ENOB on the magnitude streams.
+// SNR/ENOB on the complex residual.
 // ============================================================================
 
-// Compare two complex baseband streams' magnitude envelopes after skipping
-// `skip` transient samples (the polyphase delay line takes ~num_taps/decim
-// samples to fill — using 16 to be safe). Returns NaN if sizes mismatch or
-// there aren't enough samples; NaN unambiguously says "no measurement",
-// distinguishing it from a legitimate poor SNR (e.g., 0 dB or -3 dB).
+// Compare two complex baseband streams via the complex error after skipping
+// `skip` transient samples (the multistage chain delay line takes ~30 output
+// samples to fill — using 40 to be safe).
+//
+// Power is computed on the complex signal directly:
+//   signal_power = sum |reference[i]|^2
+//   noise_power  = sum |reference[i] - test[i]|^2
+// This captures both magnitude AND phase errors. An earlier version reduced
+// each stream to its magnitude envelope before comparison, which silently
+// masked any pure-phase error (the magnitudes can be identical even when the
+// I/Q vectors point in different directions).
+//
+// Returns NaN if sizes mismatch or there aren't enough samples; NaN
+// unambiguously says "no measurement", distinguishing it from a legitimate
+// poor SNR (e.g., 0 dB or -3 dB). Clamps at 300 dB on noise underflow to
+// match snr_db's behavior for bit-identical matches.
 double measure_baseband_snr_db(
 		const std::vector<std::complex<double>>& reference_out,
 		const std::vector<std::complex<double>>& test_out,
-		std::size_t skip = 40) {  // multistage chain transient is ~30 outputs
+		std::size_t skip = 40) {
 	if (test_out.size() != reference_out.size() || test_out.size() <= skip)
 		return std::numeric_limits<double>::quiet_NaN();
-	std::vector<double> ref_mag(test_out.size() - skip);
-	std::vector<double> tst_mag(test_out.size() - skip);
+	double signal_power = 0.0;
+	double noise_power  = 0.0;
 	for (std::size_t i = skip; i < test_out.size(); ++i) {
-		ref_mag[i - skip] = std::abs(reference_out[i]);
-		tst_mag[i - skip] = std::abs(test_out[i]);
+		signal_power += std::norm(reference_out[i]);                 // |r|^2
+		noise_power  += std::norm(reference_out[i] - test_out[i]);   // |r-t|^2
 	}
-	return snr_db(std::span<const double>(ref_mag.data(), ref_mag.size()),
-	              std::span<const double>(tst_mag.data(), tst_mag.size()));
+	if (signal_power <= 0.0) return 0.0;
+	if (noise_power < 1e-300) return 300.0;
+	return 10.0 * std::log10(signal_power / noise_power);
 }
 
 template <class CoeffScalar, class StateScalar, class SampleScalar>
@@ -450,23 +462,67 @@ void print_usage(const char* prog) {
 		<< "  -h, --help              This message\n";
 }
 
-// Parse a comma-separated list of ints. Throws std::invalid_argument
-// with a clear message identifying the offending token, instead of
-// letting std::stoi's bare exceptions propagate up to terminate().
+// Strict numeric parsers: each one throws std::invalid_argument with a clear
+// message naming the offending token, and rejects partial parses (e.g.,
+// "12abc" → just 12) by checking that std::sto* consumed the entire token.
+// parse_uint additionally rejects leading '+' or '-' since std::stoull
+// silently wraps negatives to huge unsigned values.
+int parse_int(const std::string& tok, const char* flag = "value") {
+	std::size_t idx = 0;
+	int v = 0;
+	try {
+		v = std::stoi(tok, &idx);
+	} catch (const std::exception&) {
+		throw std::invalid_argument(
+			std::string(flag) + ": could not parse '" + tok + "' as an integer");
+	}
+	if (idx != tok.size())
+		throw std::invalid_argument(
+			std::string(flag) + ": trailing characters in '" + tok + "'");
+	return v;
+}
+
+double parse_double(const std::string& tok, const char* flag = "value") {
+	std::size_t idx = 0;
+	double v = 0.0;
+	try {
+		v = std::stod(tok, &idx);
+	} catch (const std::exception&) {
+		throw std::invalid_argument(
+			std::string(flag) + ": could not parse '" + tok + "' as a number");
+	}
+	if (idx != tok.size())
+		throw std::invalid_argument(
+			std::string(flag) + ": trailing characters in '" + tok + "'");
+	return v;
+}
+
+unsigned long long parse_uint(const std::string& tok, const char* flag = "value") {
+	if (tok.empty() || tok.front() == '-' || tok.front() == '+')
+		throw std::invalid_argument(
+			std::string(flag) + ": '" + tok + "' must be a non-negative integer");
+	std::size_t idx = 0;
+	unsigned long long v = 0;
+	try {
+		v = std::stoull(tok, &idx);
+	} catch (const std::exception&) {
+		throw std::invalid_argument(
+			std::string(flag) + ": could not parse '" + tok + "' as an integer");
+	}
+	if (idx != tok.size())
+		throw std::invalid_argument(
+			std::string(flag) + ": trailing characters in '" + tok + "'");
+	return v;
+}
+
+// Parse a comma-separated list of ints, rejecting partial parses.
 std::vector<int> parse_int_list(const std::string& s) {
 	std::vector<int> out;
 	std::size_t pos = 0;
 	while (pos < s.size()) {
 		const std::size_t comma = s.find(',', pos);
 		const std::string tok = s.substr(pos, comma - pos);
-		if (!tok.empty()) {
-			try {
-				out.push_back(std::stoi(tok));
-			} catch (const std::exception&) {
-				throw std::invalid_argument(
-					"could not parse '" + tok + "' as an integer");
-			}
-		}
+		if (!tok.empty()) out.push_back(parse_int(tok, "--adc-bits"));
 		if (comma == std::string::npos) break;
 		pos = comma + 1;
 	}
@@ -483,13 +539,14 @@ int main(int argc, char** argv) {
 				return 0;
 			}
 			if (arg.rfind("--if-freq=", 0) == 0) {
-				params.if_frequency_hz = std::stod(arg.substr(10));
+				params.if_frequency_hz = parse_double(arg.substr(10), "--if-freq");
 			} else if (arg.rfind("--sample-rate=", 0) == 0) {
-				params.sample_rate_hz = std::stod(arg.substr(14));
+				params.sample_rate_hz = parse_double(arg.substr(14), "--sample-rate");
 			} else if (arg.rfind("--adc-bits=", 0) == 0) {
 				params.adc_scan_bits = parse_int_list(arg.substr(11));
 			} else if (arg.rfind("--num-samples=", 0) == 0) {
-				params.num_samples = static_cast<std::size_t>(std::stoull(arg.substr(14)));
+				params.num_samples = static_cast<std::size_t>(
+					parse_uint(arg.substr(14), "--num-samples"));
 			} else if (arg.rfind("--csv=", 0) == 0) {
 				csv_path = arg.substr(6);
 			} else if (arg.rfind("--", 0) == 0) {

--- a/applications/acquisition_demo/acquisition_demo.cpp
+++ b/applications/acquisition_demo/acquisition_demo.cpp
@@ -1,0 +1,372 @@
+// acquisition_demo.cpp: end-to-end acquisition pipeline mixed-precision sweep
+//
+// Simulates an IF-sampling receiver:
+//   - real ADC stream at f_s (configurable bit depth)
+//   - Digital Down-Converter (NCO + complex mixer + polyphase decimation)
+//   - quality measured via the analysis/acquisition_precision.hpp primitives
+//
+// Sweeps across number-system configurations and ADC bit depths, writing
+// per-configuration quality metrics to stdout (Pareto-style summary table)
+// and to acquisition_demo.csv (schema-compatible with precision_sweep.csv
+// and acquisition_precision.csv at the identifier columns).
+//
+// Capstone for the High-Rate Data Acquisition Pipeline epic (#84).
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/acquisition/ddc.hpp>
+#include <sw/dsp/analysis/acquisition_precision.hpp>
+#include <sw/dsp/filter/fir/fir_design.hpp>
+#include <sw/dsp/filter/fir/polyphase.hpp>
+#include <sw/dsp/math/constants.hpp>
+#include <sw/dsp/windows/hamming.hpp>
+
+#if __has_include(<bit>)
+#include <bit>
+#endif
+#include <sw/universal/number/posit/posit.hpp>
+#include <sw/universal/number/cfloat/cfloat.hpp>
+#include <sw/universal/number/fixpnt/fixpnt.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+using namespace sw::dsp;
+using sw::dsp::analysis::AcquisitionPrecisionRow;
+using sw::dsp::analysis::write_acquisition_csv;
+using sw::dsp::analysis::snr_db;
+using sw::dsp::analysis::enob_from_snr_db;
+
+// ============================================================================
+// Type aliases for the sweep
+// ============================================================================
+
+using p32  = sw::universal::posit<32, 2>;
+using p16  = sw::universal::posit<16, 2>;
+using cf32 = sw::universal::cfloat<32, 8, std::uint32_t, true, false, false>;
+// Q4.28: 4 integer bits (signal range ±8 — ample headroom for the
+// post-mixer/FIR baseband) and 28 fractional bits (~28 ENOB ceiling).
+// fixpnt<32,16> would give Q16.16 — vastly more integer headroom than the
+// signal needs and only 16 fractional bits, which collapses to ~0 ENOB.
+using fx32 = sw::universal::fixpnt<32, 28>;
+
+// ============================================================================
+// Pipeline parameters — fixed for all configurations
+// ============================================================================
+
+namespace params {
+constexpr double      kSampleRateHz   = 1e6;     // simulated ADC rate (1 MHz)
+constexpr double      kIfFrequencyHz  = 100e3;   // tone we want to capture
+constexpr double      kSignalAmp      = 0.5;     // peak signal amplitude
+constexpr double      kNoiseRms       = 0.005;   // additive AWGN
+constexpr std::size_t kNumSamples     = 4096;    // input length
+constexpr std::size_t kDecimation     = 8;       // DDC output rate = fs / 8
+constexpr std::size_t kFirTaps        = 65;      // anti-alias FIR length
+}  // namespace params
+
+// ============================================================================
+// ADC simulation: a real cosine + AWGN, quantized to N bits
+// ============================================================================
+
+mtl::vec::dense_vector<double> simulate_adc(int adc_bits, unsigned seed = 0xACDC) {
+	mtl::vec::dense_vector<double> samples(params::kNumSamples);
+	std::mt19937 rng(seed);
+	std::normal_distribution<double> noise(0.0, params::kNoiseRms);
+
+	const double full_scale = 1.0;
+	const double levels = static_cast<double>(1 << (adc_bits - 1));
+	const double q_step = full_scale / levels;
+
+	for (std::size_t n = 0; n < params::kNumSamples; ++n) {
+		const double t = static_cast<double>(n) / params::kSampleRateHz;
+		const double clean = params::kSignalAmp *
+		                      std::cos(2.0 * pi * params::kIfFrequencyHz * t);
+		double noisy = clean + noise(rng);
+		// Clamp to [-1, 1] full-scale, then quantize
+		noisy = std::clamp(noisy, -full_scale, full_scale);
+		const double quantized = std::round(noisy / q_step) * q_step;
+		samples[n] = quantized;
+	}
+	return samples;
+}
+
+// ============================================================================
+// Run the DDC pipeline at a given (CoeffScalar, StateScalar, SampleScalar)
+// configuration. Returns the complex baseband output cast back to double for
+// quality comparison against the reference.
+// ============================================================================
+
+template <class CoeffScalar, class StateScalar, class SampleScalar>
+std::vector<std::complex<double>>
+run_ddc_pipeline(const mtl::vec::dense_vector<double>& adc_in_double) {
+	using DDC_t = DDC<CoeffScalar, StateScalar, SampleScalar,
+	                   PolyphaseDecimator<CoeffScalar, StateScalar, SampleScalar>>;
+
+	// Design taps in double, project to CoeffScalar.
+	auto win = hamming_window<double>(params::kFirTaps);
+	auto taps_d = design_fir_lowpass<double>(
+		params::kFirTaps,
+		0.45 / static_cast<double>(params::kDecimation),
+		win);
+	mtl::vec::dense_vector<CoeffScalar> taps(taps_d.size());
+	for (std::size_t i = 0; i < taps_d.size(); ++i)
+		taps[i] = static_cast<CoeffScalar>(taps_d[i]);
+
+	PolyphaseDecimator<CoeffScalar, StateScalar, SampleScalar> decim(
+		taps, params::kDecimation);
+	// DDC only needs the IF / fs ratio. Pass normalized rates so that
+	// narrow-integer-range StateScalars (e.g., fixpnt<32,28> with only
+	// ±8 representable) don't saturate trying to hold MHz-scale values.
+	const double f_norm = params::kIfFrequencyHz / params::kSampleRateHz;
+	DDC_t ddc(static_cast<StateScalar>(f_norm),
+	          static_cast<StateScalar>(1.0),
+	          decim);
+
+	// Project ADC samples into SampleScalar for streaming.
+	mtl::vec::dense_vector<SampleScalar> adc_in(adc_in_double.size());
+	for (std::size_t i = 0; i < adc_in_double.size(); ++i)
+		adc_in[i] = static_cast<SampleScalar>(adc_in_double[i]);
+
+	auto out = ddc.process_block(adc_in);
+
+	// Cast back to double for cross-precision comparison.
+	std::vector<std::complex<double>> out_d(out.size());
+	for (std::size_t i = 0; i < out.size(); ++i) {
+		out_d[i] = std::complex<double>(static_cast<double>(out[i].real()),
+		                                 static_cast<double>(out[i].imag()));
+	}
+	return out_d;
+}
+
+// ============================================================================
+// Measurement: run reference (uniform double) and a test configuration; compute
+// SNR/ENOB on the magnitude streams.
+// ============================================================================
+
+template <class CoeffScalar, class StateScalar, class SampleScalar>
+AcquisitionPrecisionRow measure_config(
+		const std::string& config_name,
+		const std::string& coeff_label,
+		const std::string& state_label,
+		const std::string& sample_label,
+		int total_bits,
+		const mtl::vec::dense_vector<double>& adc_in,
+		const std::vector<std::complex<double>>& reference_out) {
+	AcquisitionPrecisionRow row;
+	row.pipeline    = "ddc_acquisition";
+	row.config_name = config_name;
+	row.coeff_type  = coeff_label;
+	row.state_type  = state_label;
+	row.sample_type = sample_label;
+	row.total_bits  = total_bits;
+	row.nco_sfdr_db = -1.0;                  // not measured per config here
+	row.cic_overflow_margin_bits = -1.0;     // CIC not used in this pipeline
+
+	auto test_out = run_ddc_pipeline<CoeffScalar, StateScalar, SampleScalar>(adc_in);
+
+	// Compare magnitude envelopes — they're the meaningful baseband output of a
+	// real-IF DDC. Skip the first few samples to let the polyphase delay line
+	// fill (roughly num_taps / decimation = 65/8 ≈ 8 samples).
+	const std::size_t skip = 16;
+	if (test_out.size() != reference_out.size() || test_out.size() <= skip) {
+		row.output_snr_db = 0.0;
+		row.output_enob   = 0.0;
+		return row;
+	}
+	std::vector<double> ref_mag(test_out.size() - skip);
+	std::vector<double> tst_mag(test_out.size() - skip);
+	for (std::size_t i = skip; i < test_out.size(); ++i) {
+		ref_mag[i - skip] = std::abs(reference_out[i]);
+		tst_mag[i - skip] = std::abs(test_out[i]);
+	}
+	const double s = snr_db(std::span<const double>(ref_mag.data(), ref_mag.size()),
+	                         std::span<const double>(tst_mag.data(), tst_mag.size()));
+	row.output_snr_db = s;
+	row.output_enob   = enob_from_snr_db(s);
+	return row;
+}
+
+// ============================================================================
+// Sweep across configurations
+// ============================================================================
+
+std::vector<AcquisitionPrecisionRow> sweep_configurations(
+		const mtl::vec::dense_vector<double>& adc_in) {
+	std::vector<AcquisitionPrecisionRow> rows;
+
+	// Reference (uniform double) — also the comparison baseline. Result is
+	// trivially +inf SNR but gives the row a place in the table.
+	auto reference_out = run_ddc_pipeline<double, double, double>(adc_in);
+
+	// Helper bit-width totals
+	auto total = [](int a, int b, int c) { return a + b + c; };
+
+	// Uniform configurations
+	rows.push_back(measure_config<double, double, double>(
+		"uniform_double", "double", "double", "double",
+		total(64, 64, 64), adc_in, reference_out));
+	rows.push_back(measure_config<float, float, float>(
+		"uniform_float", "float", "float", "float",
+		total(32, 32, 32), adc_in, reference_out));
+	rows.push_back(measure_config<p32, p32, p32>(
+		"uniform_posit32", "posit<32,2>", "posit<32,2>", "posit<32,2>",
+		total(32, 32, 32), adc_in, reference_out));
+	rows.push_back(measure_config<p16, p16, p16>(
+		"uniform_posit16", "posit<16,2>", "posit<16,2>", "posit<16,2>",
+		total(16, 16, 16), adc_in, reference_out));
+	rows.push_back(measure_config<cf32, cf32, cf32>(
+		"uniform_cfloat32", "cfloat<32,8>", "cfloat<32,8>", "cfloat<32,8>",
+		total(32, 32, 32), adc_in, reference_out));
+	rows.push_back(measure_config<fx32, fx32, fx32>(
+		"uniform_fixpnt32", "fixpnt<32,28>", "fixpnt<32,28>", "fixpnt<32,28>",
+		total(32, 32, 32), adc_in, reference_out));
+
+	// Mixed-precision: high-precision design / coefficients, narrower runtime
+	rows.push_back(measure_config<double, p32, p16>(
+		"mixed_double_p32_p16", "double", "posit<32,2>", "posit<16,2>",
+		total(64, 32, 16), adc_in, reference_out));
+	rows.push_back(measure_config<double, double, float>(
+		"mixed_double_double_float", "double", "double", "float",
+		total(64, 64, 32), adc_in, reference_out));
+	rows.push_back(measure_config<double, p32, float>(
+		"mixed_double_p32_float", "double", "posit<32,2>", "float",
+		total(64, 32, 32), adc_in, reference_out));
+	rows.push_back(measure_config<double, float, float>(
+		"mixed_double_float_float", "double", "float", "float",
+		total(64, 32, 32), adc_in, reference_out));
+	rows.push_back(measure_config<double, fx32, fx32>(
+		"mixed_double_fx32_fx32", "double", "fixpnt<32,28>", "fixpnt<32,28>",
+		total(64, 32, 32), adc_in, reference_out));
+
+	return rows;
+}
+
+// ============================================================================
+// Console summary table
+// ============================================================================
+
+void print_sweep_table(const std::vector<AcquisitionPrecisionRow>& rows) {
+	std::cout << std::left  << std::setw(28) << "Configuration"
+	          << std::right << std::setw(8)  << "Bits"
+	          << std::right << std::setw(11) << "SNR(dB)"
+	          << std::right << std::setw(8)  << "ENOB"
+	          << "\n";
+	std::cout << std::string(28 + 8 + 11 + 8, '-') << "\n";
+	for (const auto& r : rows) {
+		std::cout << std::left  << std::setw(28) << r.config_name
+		          << std::right << std::setw(8)  << r.total_bits;
+		if (r.output_snr_db >= 299.0) {
+			std::cout << std::right << std::setw(11) << "inf"
+			          << std::right << std::setw(8)  << "ref";
+		} else {
+			std::cout << std::right << std::setw(11) << std::fixed
+			          << std::setprecision(2) << r.output_snr_db
+			          << std::right << std::setw(8)  << std::fixed
+			          << std::setprecision(2) << r.output_enob;
+		}
+		std::cout << "\n";
+	}
+	std::cout << std::flush;
+}
+
+// ============================================================================
+// ADC bit-depth scan: sanity check that quantization noise dominates correctly
+// ============================================================================
+
+void print_adc_scan_header() {
+	std::cout << "\n=== ADC bit-depth scan (uniform-double pipeline) ===\n";
+	std::cout << std::left  << std::setw(12) << "ADC bits"
+	          << std::right << std::setw(11) << "SNR(dB)"
+	          << std::right << std::setw(8)  << "ENOB"
+	          << "\n";
+	std::cout << std::string(12 + 11 + 8, '-') << "\n";
+}
+
+void scan_adc_bit_depths(std::vector<AcquisitionPrecisionRow>& rows) {
+	// For each ADC bit depth, compare the quantized ADC pipeline output
+	// against an unquantized (full-precision) reference. Demonstrates the
+	// 6.02*N + 1.76 SNR ceiling from the ADC stage propagating end-to-end.
+	auto ideal_in = simulate_adc(64);  // effectively unquantized (q ~ 1e-19)
+	auto reference_out = run_ddc_pipeline<double, double, double>(ideal_in);
+
+	print_adc_scan_header();
+	for (int bits : {8, 12, 14, 16}) {
+		auto adc_in = simulate_adc(bits);
+		auto out_d = run_ddc_pipeline<double, double, double>(adc_in);
+		const std::size_t skip = 16;
+		if (out_d.size() != reference_out.size() || out_d.size() <= skip)
+			continue;
+		std::vector<double> ref_mag(out_d.size() - skip);
+		std::vector<double> tst_mag(out_d.size() - skip);
+		for (std::size_t i = skip; i < out_d.size(); ++i) {
+			ref_mag[i - skip] = std::abs(reference_out[i]);
+			tst_mag[i - skip] = std::abs(out_d[i]);
+		}
+		double s = snr_db(std::span<const double>(ref_mag.data(), ref_mag.size()),
+		                   std::span<const double>(tst_mag.data(), tst_mag.size()));
+
+		AcquisitionPrecisionRow row;
+		row.pipeline = "ddc_adc_scan";
+		row.config_name = "adc_" + std::to_string(bits) + "bit";
+		row.coeff_type = "double";
+		row.state_type = "double";
+		row.sample_type = "double";
+		row.total_bits = bits;
+		row.output_snr_db = s;
+		row.output_enob = enob_from_snr_db(s);
+		row.nco_sfdr_db = -1.0;
+		row.cic_overflow_margin_bits = -1.0;
+		rows.push_back(row);
+
+		std::cout << std::left  << std::setw(12) << (std::to_string(bits) + "-bit")
+		          << std::right << std::setw(11) << std::fixed
+		          << std::setprecision(2) << s
+		          << std::right << std::setw(8)  << std::fixed
+		          << std::setprecision(2) << row.output_enob
+		          << "\n";
+	}
+	std::cout << std::flush;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char** argv) {
+	std::cout << "=== Acquisition Pipeline Demo (Issue #93) ===\n";
+	std::cout << "Pipeline: real ADC -> DDC(NCO + mixer + polyphase decim x"
+	          << params::kDecimation << ")\n";
+	std::cout << "Sample rate:    " << params::kSampleRateHz / 1e6 << " MHz\n";
+	std::cout << "IF frequency:   " << params::kIfFrequencyHz / 1e3 << " kHz\n";
+	std::cout << "Output rate:    "
+	          << params::kSampleRateHz / params::kDecimation / 1e3 << " kHz\n";
+	std::cout << "Block length:   " << params::kNumSamples << " input samples\n";
+	std::cout << "FIR taps:       " << params::kFirTaps << "\n\n";
+
+	// Sweep across number-system configurations at 16-bit ADC
+	std::cout << "=== Number-system sweep (16-bit ADC) ===\n";
+	auto adc_in = simulate_adc(16);
+	auto rows = sweep_configurations(adc_in);
+	print_sweep_table(rows);
+
+	// ADC bit-depth scan with the uniform-double pipeline
+	scan_adc_bit_depths(rows);
+
+	// CSV export
+	const std::string csv_path = (argc > 1)
+		? std::string(argv[1])
+		: std::string("acquisition_demo.csv");
+	write_acquisition_csv(csv_path, rows);
+	std::cout << "\nCSV: " << csv_path << " (" << rows.size() << " rows)\n";
+
+	return 0;
+}

--- a/applications/acquisition_demo/acquisition_demo.cpp
+++ b/applications/acquisition_demo/acquisition_demo.cpp
@@ -15,7 +15,10 @@
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <sw/dsp/acquisition/cic.hpp>
 #include <sw/dsp/acquisition/ddc.hpp>
+#include <sw/dsp/acquisition/decimation_chain.hpp>
+#include <sw/dsp/acquisition/halfband.hpp>
 #include <sw/dsp/analysis/acquisition_precision.hpp>
 #include <sw/dsp/filter/fir/fir_design.hpp>
 #include <sw/dsp/filter/fir/polyphase.hpp>
@@ -64,41 +67,59 @@ using fx32 = sw::universal::fixpnt<32, 28>;
 // Pipeline parameters — fixed for all configurations
 // ============================================================================
 
-namespace params {
-constexpr double      kSampleRateHz   = 1e6;     // simulated ADC rate (1 MHz)
-constexpr double      kIfFrequencyHz  = 100e3;   // tone we want to capture
-constexpr double      kSignalAmp      = 0.5;     // peak signal amplitude
-constexpr double      kNoiseRms       = 0.005;   // additive AWGN
-constexpr std::size_t kNumSamples     = 4096;    // input length
-constexpr std::size_t kDecimation     = 8;       // DDC output rate = fs / 8
-constexpr std::size_t kFirTaps        = 65;      // anti-alias FIR length
-}  // namespace params
+// Pipeline parameters are now mutable so they can be overridden from the
+// command line. Defaults are 1 MHz sample rate, 100 kHz IF, total
+// decimation 16, with the chain breaking down as DDC↓2 then a CIC↓2 →
+// HalfBand↓2 → Polyphase↓2 chain on each I/Q stream — exercising all
+// three multistage primitives the issue lists.
+struct PipelineParams {
+	double      sample_rate_hz     = 1e6;       // simulated ADC rate
+	double      if_frequency_hz    = 100e3;     // tone we want to capture
+	double      signal_amp         = 0.5;       // peak signal amplitude
+	double      noise_rms          = 0.005;     // additive AWGN
+	std::size_t num_samples        = 4096;      // input length
+	std::size_t ddc_decimation     = 2;         // DDC's internal polyphase decim
+	std::size_t cic_ratio          = 2;         // first stage of post-DDC chain
+	int         cic_stages         = 2;
+	std::size_t poly_decimation    = 2;         // last stage
+	std::size_t fir_taps           = 65;        // DDC's anti-alias FIR length
+	std::size_t hb_taps            = 11;        // half-band length (4K+3)
+	std::size_t chain_fir_taps     = 17;        // post-DDC polyphase FIR length
+	std::vector<int> adc_scan_bits = {8, 12, 14, 16};
+};
+inline PipelineParams params;
 
 // ============================================================================
 // ADC simulation: a real cosine + AWGN, quantized to N bits
 // ============================================================================
 
 mtl::vec::dense_vector<double> simulate_adc(int adc_bits, unsigned seed = 0xACDC) {
-	mtl::vec::dense_vector<double> samples(params::kNumSamples);
+	mtl::vec::dense_vector<double> samples(params.num_samples);
 	std::mt19937 rng(seed);
-	std::normal_distribution<double> noise(0.0, params::kNoiseRms);
+	std::normal_distribution<double> noise(0.0, params.noise_rms);
 
-	const double full_scale = 1.0;
+	// Standard 2's-complement N-bit ADC: codes range [-2^(N-1), 2^(N-1)-1],
+	// giving exactly 2^N distinct codes (e.g., 65536 for a 16-bit ADC).
+	// Earlier formulation used round-to-nearest with codes [-2^(N-1),
+	// +2^(N-1)] which produced 2^N+1 codes (off by one).
 	// std::ldexp(1.0, n) computes 2^n as a double for any non-negative n,
-	// avoiding the UB of `1 << 63` (the literal `1` is a 32-bit int) when
-	// the ADC scan calls simulate_adc(64) for the unquantized reference.
-	const double levels = std::ldexp(1.0, adc_bits - 1);
-	const double q_step = full_scale / levels;
+	// avoiding the UB of `1 << 63` when the ADC scan calls simulate_adc(64).
+	const double half_levels = std::ldexp(1.0, adc_bits - 1);
+	const double q_step      = 1.0 / half_levels;
+	const double code_max    = half_levels - 1.0;
+	const double code_min    = -half_levels;
 
-	for (std::size_t n = 0; n < params::kNumSamples; ++n) {
-		const double t = static_cast<double>(n) / params::kSampleRateHz;
-		const double clean = params::kSignalAmp *
-		                      std::cos(2.0 * pi * params::kIfFrequencyHz * t);
-		double noisy = clean + noise(rng);
-		// Clamp to [-1, 1] full-scale, then quantize
-		noisy = std::clamp(noisy, -full_scale, full_scale);
-		const double quantized = std::round(noisy / q_step) * q_step;
-		samples[n] = quantized;
+	for (std::size_t n = 0; n < params.num_samples; ++n) {
+		const double t = static_cast<double>(n) / params.sample_rate_hz;
+		const double clean = params.signal_amp *
+		                      std::cos(2.0 * pi * params.if_frequency_hz * t);
+		const double noisy = clean + noise(rng);
+		// Use floor (truncate-toward-negative) on (x / q_step) to mirror
+		// real ADC behavior: the asymmetry [-2^(N-1), 2^(N-1)-1] is
+		// preserved and we get exactly 2^N codes.
+		double code = std::floor(noisy / q_step);
+		code = std::clamp(code, code_min, code_max);
+		samples[n] = code * q_step;
 	}
 	return samples;
 }
@@ -109,47 +130,110 @@ mtl::vec::dense_vector<double> simulate_adc(int adc_bits, unsigned seed = 0xACDC
 // quality comparison against the reference.
 // ============================================================================
 
+// Full multistage acquisition pipeline:
+//   ADC (real)
+//     -> DDC{NCO + complex mixer + polyphase ↓2}   produces I/Q
+//     -> for each of I, Q stream:
+//          DecimationChain<CIC ↓2 → HalfBand ↓2 → Polyphase ↓2>
+//     -> baseband I/Q at fs / 16
+//
+// All filter design is done at CoeffScalar precision (T-parameterized
+// per the library's design-time-precision invariant).
 template <class CoeffScalar, class StateScalar, class SampleScalar>
 std::vector<std::complex<double>>
-run_ddc_pipeline(const mtl::vec::dense_vector<double>& adc_in_double) {
+run_pipeline(const mtl::vec::dense_vector<double>& adc_in_double) {
 	using DDC_t = DDC<CoeffScalar, StateScalar, SampleScalar,
 	                   PolyphaseDecimator<CoeffScalar, StateScalar, SampleScalar>>;
 
-	// Design taps in double, project to CoeffScalar.
-	auto win = hamming_window<double>(params::kFirTaps);
-	auto taps_d = design_fir_lowpass<double>(
-		params::kFirTaps,
-		0.45 / static_cast<double>(params::kDecimation),
-		win);
-	mtl::vec::dense_vector<CoeffScalar> taps(taps_d.size());
-	std::transform(taps_d.begin(), taps_d.end(), taps.begin(),
+	// --- Stage 1: design DDC anti-alias FIR ---
+	//
+	// All three filter designs (DDC anti-alias, half-band, polyphase) are
+	// done in double and projected to CoeffScalar. The library DOES support
+	// design at T (see the T-parameterization audit, issues #111-#116) —
+	// but for THIS demo we want the SNR measurement to isolate
+	// streaming-arithmetic precision from filter-design precision. If we
+	// designed taps at CoeffScalar, the test and the double reference would
+	// run through different taps (Remez at posit converges to slightly
+	// different values than at double), so SNR would conflate
+	// filter-design variance with the arithmetic quality we're trying to
+	// measure. fixpnt is a stronger example: design_halfband<fixpnt> trips
+	// divide-by-zero in the Remez iteration because fixpnt doesn't have
+	// the dynamic range Remez assumes. Design once in double, project for
+	// each test config.
+	const auto win_d = hamming_window<double>(params.fir_taps);
+	const auto ddc_taps_d = design_fir_lowpass<double>(
+		params.fir_taps,
+		0.45 / static_cast<double>(params.ddc_decimation),
+		win_d);
+	mtl::vec::dense_vector<CoeffScalar> ddc_taps(ddc_taps_d.size());
+	std::transform(ddc_taps_d.begin(), ddc_taps_d.end(), ddc_taps.begin(),
 	               [](double d) { return static_cast<CoeffScalar>(d); });
+	PolyphaseDecimator<CoeffScalar, StateScalar, SampleScalar> ddc_decim(
+		ddc_taps, params.ddc_decimation);
 
-	PolyphaseDecimator<CoeffScalar, StateScalar, SampleScalar> decim(
-		taps, params::kDecimation);
 	// DDC only needs the IF / fs ratio. Pass normalized rates so that
 	// narrow-integer-range StateScalars (e.g., fixpnt<32,28> with only
 	// ±8 representable) don't saturate trying to hold MHz-scale values.
-	const double f_norm = params::kIfFrequencyHz / params::kSampleRateHz;
+	const double f_norm = params.if_frequency_hz / params.sample_rate_hz;
 	DDC_t ddc(static_cast<StateScalar>(f_norm),
 	          static_cast<StateScalar>(1.0),
-	          decim);
+	          ddc_decim);
 
-	// Project ADC samples into SampleScalar for streaming.
+	// Project ADC samples into SampleScalar and run the DDC.
 	mtl::vec::dense_vector<SampleScalar> adc_in(adc_in_double.size());
 	std::transform(adc_in_double.begin(), adc_in_double.end(), adc_in.begin(),
 	               [](double d) { return static_cast<SampleScalar>(d); });
+	const auto ddc_out = ddc.process_block(adc_in);
 
-	auto out = ddc.process_block(adc_in);
+	// --- Stage 2: build CIC → HalfBand → Polyphase chain ---
+	// Both I and Q streams need their own chain instance running in
+	// lockstep. Build a "prototype" we can copy.
+	using HalfBand_t  = HalfBandFilter<CoeffScalar, StateScalar, SampleScalar>;
+	using Poly_t      = PolyphaseDecimator<CoeffScalar, StateScalar, SampleScalar>;
+	using CIC_t       = CICDecimator<StateScalar, SampleScalar>;
+	using Chain_t     = DecimationChain<SampleScalar, CIC_t, HalfBand_t, Poly_t>;
 
-	// Cast back to double for cross-precision comparison.
-	std::vector<std::complex<double>> out_d(out.size());
-	std::transform(out.begin(), out.end(), out_d.begin(),
-	               [](const auto& z) {
-	                   return std::complex<double>(
-	                       static_cast<double>(z.real()),
-	                       static_cast<double>(z.imag()));
-	               });
+	const auto hb_taps_d = design_halfband<double>(params.hb_taps, 0.1);
+	mtl::vec::dense_vector<CoeffScalar> hb_taps(hb_taps_d.size());
+	std::transform(hb_taps_d.begin(), hb_taps_d.end(), hb_taps.begin(),
+	               [](double d) { return static_cast<CoeffScalar>(d); });
+
+	const auto poly_win_d  = hamming_window<double>(params.chain_fir_taps);
+	const auto poly_taps_d = design_fir_lowpass<double>(
+		params.chain_fir_taps,
+		0.45 / static_cast<double>(params.poly_decimation),
+		poly_win_d);
+	mtl::vec::dense_vector<CoeffScalar> poly_taps(poly_taps_d.size());
+	std::transform(poly_taps_d.begin(), poly_taps_d.end(), poly_taps.begin(),
+	               [](double d) { return static_cast<CoeffScalar>(d); });
+
+	auto build_chain = [&]() {
+		CIC_t      cic(static_cast<int>(params.cic_ratio), params.cic_stages);
+		HalfBand_t hb(hb_taps);
+		Poly_t     poly(poly_taps, params.poly_decimation);
+		return Chain_t(static_cast<SampleScalar>(1.0),
+		               std::move(cic), std::move(hb), std::move(poly));
+	};
+	auto chain_i = build_chain();
+	auto chain_q = build_chain();
+
+	// --- Stage 3: split DDC output into I/Q streams, decimate each ---
+	mtl::vec::dense_vector<SampleScalar> i_stream(ddc_out.size());
+	mtl::vec::dense_vector<SampleScalar> q_stream(ddc_out.size());
+	for (std::size_t n = 0; n < ddc_out.size(); ++n) {
+		i_stream[n] = ddc_out[n].real();
+		q_stream[n] = ddc_out[n].imag();
+	}
+	const auto i_out = chain_i.process_block(i_stream);
+	const auto q_out = chain_q.process_block(q_stream);
+
+	// --- Stage 4: cast back to std::complex<double> for SNR comparison ---
+	const std::size_t n_out = std::min(i_out.size(), q_out.size());
+	std::vector<std::complex<double>> out_d(n_out);
+	for (std::size_t n = 0; n < n_out; ++n) {
+		out_d[n] = std::complex<double>(static_cast<double>(i_out[n]),
+		                                 static_cast<double>(q_out[n]));
+	}
 	return out_d;
 }
 
@@ -166,7 +250,7 @@ run_ddc_pipeline(const mtl::vec::dense_vector<double>& adc_in_double) {
 double measure_baseband_snr_db(
 		const std::vector<std::complex<double>>& reference_out,
 		const std::vector<std::complex<double>>& test_out,
-		std::size_t skip = 16) {
+		std::size_t skip = 40) {  // multistage chain transient is ~30 outputs
 	if (test_out.size() != reference_out.size() || test_out.size() <= skip)
 		return std::numeric_limits<double>::quiet_NaN();
 	std::vector<double> ref_mag(test_out.size() - skip);
@@ -198,7 +282,7 @@ AcquisitionPrecisionRow measure_config(
 	row.nco_sfdr_db = -1.0;                  // not measured per config here
 	row.cic_overflow_margin_bits = -1.0;     // CIC not used in this pipeline
 
-	auto test_out = run_ddc_pipeline<CoeffScalar, StateScalar, SampleScalar>(adc_in);
+	auto test_out = run_pipeline<CoeffScalar, StateScalar, SampleScalar>(adc_in);
 	const double s = measure_baseband_snr_db(reference_out, test_out);
 	row.output_snr_db = s;
 	row.output_enob   = std::isnan(s)
@@ -217,7 +301,7 @@ std::vector<AcquisitionPrecisionRow> sweep_configurations(
 
 	// Reference (uniform double) — also the comparison baseline. Result is
 	// trivially +inf SNR but gives the row a place in the table.
-	auto reference_out = run_ddc_pipeline<double, double, double>(adc_in);
+	auto reference_out = run_pipeline<double, double, double>(adc_in);
 
 	// Helper bit-width totals
 	auto total = [](int a, int b, int c) { return a + b + c; };
@@ -311,12 +395,12 @@ void scan_adc_bit_depths(std::vector<AcquisitionPrecisionRow>& rows) {
 	// against an unquantized (full-precision) reference. Demonstrates the
 	// 6.02*N + 1.76 SNR ceiling from the ADC stage propagating end-to-end.
 	auto ideal_in = simulate_adc(64);  // effectively unquantized (q ~ 1e-19)
-	auto reference_out = run_ddc_pipeline<double, double, double>(ideal_in);
+	auto reference_out = run_pipeline<double, double, double>(ideal_in);
 
 	print_adc_scan_header();
-	for (int bits : {8, 12, 14, 16}) {
+	for (int bits : params.adc_scan_bits) {
 		auto adc_in = simulate_adc(bits);
-		auto out_d = run_ddc_pipeline<double, double, double>(adc_in);
+		auto out_d = run_pipeline<double, double, double>(adc_in);
 		const double s = measure_baseband_snr_db(reference_out, out_d);
 		if (std::isnan(s)) continue;
 
@@ -347,16 +431,80 @@ void scan_adc_bit_depths(std::vector<AcquisitionPrecisionRow>& rows) {
 // Main
 // ============================================================================
 
+// Parse `--key=value` style flags. Unknown flags are reported and ignored.
+// Recognized: --if-freq=<Hz>, --sample-rate=<Hz>, --adc-bits=<comma list>,
+// --num-samples=<N>, --csv=<path>. Anything else is treated as the CSV path
+// (legacy positional argument) for backwards compatibility.
+void print_usage(const char* prog) {
+	std::cout
+		<< "Usage: " << prog << " [OPTIONS] [csv_path]\n\n"
+		<< "Options:\n"
+		<< "  --if-freq=<Hz>          IF frequency (default: 100000)\n"
+		<< "  --sample-rate=<Hz>      ADC sample rate (default: 1000000)\n"
+		<< "  --adc-bits=8,12,14,16   Comma-separated bit depths for the ADC scan\n"
+		<< "  --num-samples=<N>       Input block length (default: 4096)\n"
+		<< "  --csv=<path>            Output CSV path (default: acquisition_demo.csv)\n"
+		<< "  -h, --help              This message\n";
+}
+
+std::vector<int> parse_int_list(const std::string& s) {
+	std::vector<int> out;
+	std::size_t pos = 0;
+	while (pos < s.size()) {
+		const std::size_t comma = s.find(',', pos);
+		const std::string tok = s.substr(pos, comma - pos);
+		if (!tok.empty()) out.push_back(std::stoi(tok));
+		if (comma == std::string::npos) break;
+		pos = comma + 1;
+	}
+	return out;
+}
+
 int main(int argc, char** argv) {
+	std::string csv_path = "acquisition_demo.csv";
+	for (int i = 1; i < argc; ++i) {
+		const std::string arg = argv[i];
+		if (arg == "-h" || arg == "--help") {
+			print_usage(argv[0]);
+			return 0;
+		}
+		if (arg.rfind("--if-freq=", 0) == 0) {
+			params.if_frequency_hz = std::stod(arg.substr(10));
+		} else if (arg.rfind("--sample-rate=", 0) == 0) {
+			params.sample_rate_hz = std::stod(arg.substr(14));
+		} else if (arg.rfind("--adc-bits=", 0) == 0) {
+			params.adc_scan_bits = parse_int_list(arg.substr(11));
+		} else if (arg.rfind("--num-samples=", 0) == 0) {
+			params.num_samples = static_cast<std::size_t>(std::stoull(arg.substr(14)));
+		} else if (arg.rfind("--csv=", 0) == 0) {
+			csv_path = arg.substr(6);
+		} else if (arg.rfind("--", 0) == 0) {
+			std::cerr << "Unknown flag: " << arg << "\n";
+			print_usage(argv[0]);
+			return 1;
+		} else {
+			// Positional CSV path (legacy)
+			csv_path = arg;
+		}
+	}
+
+	const std::size_t total_decim =
+		params.ddc_decimation * params.cic_ratio * 2 * params.poly_decimation;
+
 	std::cout << "=== Acquisition Pipeline Demo (Issue #93) ===\n";
-	std::cout << "Pipeline: real ADC -> DDC(NCO + mixer + polyphase decim x"
-	          << params::kDecimation << ")\n";
-	std::cout << "Sample rate:    " << params::kSampleRateHz / 1e6 << " MHz\n";
-	std::cout << "IF frequency:   " << params::kIfFrequencyHz / 1e3 << " kHz\n";
+	std::cout << "Pipeline: ADC -> DDC(NCO + mixer + polyphase ↓"
+	          << params.ddc_decimation << ") -> [I/Q parallel] CIC↓"
+	          << params.cic_ratio << " -> HB↓2 -> Poly↓"
+	          << params.poly_decimation << "  (total ↓" << total_decim << ")\n";
+	std::cout << "Sample rate:    " << params.sample_rate_hz / 1e6 << " MHz\n";
+	std::cout << "IF frequency:   " << params.if_frequency_hz / 1e3 << " kHz\n";
 	std::cout << "Output rate:    "
-	          << params::kSampleRateHz / params::kDecimation / 1e3 << " kHz\n";
-	std::cout << "Block length:   " << params::kNumSamples << " input samples\n";
-	std::cout << "FIR taps:       " << params::kFirTaps << "\n\n";
+	          << params.sample_rate_hz / static_cast<double>(total_decim) / 1e3
+	          << " kHz\n";
+	std::cout << "Block length:   " << params.num_samples << " input samples\n";
+	std::cout << "DDC FIR taps:   " << params.fir_taps << "\n";
+	std::cout << "Half-band taps: " << params.hb_taps << "\n";
+	std::cout << "Chain FIR taps: " << params.chain_fir_taps << "\n\n";
 
 	// Sweep across number-system configurations at 16-bit ADC
 	std::cout << "=== Number-system sweep (16-bit ADC) ===\n";
@@ -368,9 +516,6 @@ int main(int argc, char** argv) {
 	scan_adc_bit_depths(rows);
 
 	// CSV export
-	const std::string csv_path = (argc > 1)
-		? std::string(argv[1])
-		: std::string("acquisition_demo.csv");
 	write_acquisition_csv(csv_path, rows);
 	std::cout << "\nCSV: " << csv_path << " (" << rows.size() << " rows)\n";
 

--- a/applications/acquisition_demo/acquisition_demo.cpp
+++ b/applications/acquisition_demo/acquisition_demo.cpp
@@ -122,8 +122,8 @@ run_ddc_pipeline(const mtl::vec::dense_vector<double>& adc_in_double) {
 		0.45 / static_cast<double>(params::kDecimation),
 		win);
 	mtl::vec::dense_vector<CoeffScalar> taps(taps_d.size());
-	for (std::size_t i = 0; i < taps_d.size(); ++i)
-		taps[i] = static_cast<CoeffScalar>(taps_d[i]);
+	std::transform(taps_d.begin(), taps_d.end(), taps.begin(),
+	               [](double d) { return static_cast<CoeffScalar>(d); });
 
 	PolyphaseDecimator<CoeffScalar, StateScalar, SampleScalar> decim(
 		taps, params::kDecimation);
@@ -137,17 +137,19 @@ run_ddc_pipeline(const mtl::vec::dense_vector<double>& adc_in_double) {
 
 	// Project ADC samples into SampleScalar for streaming.
 	mtl::vec::dense_vector<SampleScalar> adc_in(adc_in_double.size());
-	for (std::size_t i = 0; i < adc_in_double.size(); ++i)
-		adc_in[i] = static_cast<SampleScalar>(adc_in_double[i]);
+	std::transform(adc_in_double.begin(), adc_in_double.end(), adc_in.begin(),
+	               [](double d) { return static_cast<SampleScalar>(d); });
 
 	auto out = ddc.process_block(adc_in);
 
 	// Cast back to double for cross-precision comparison.
 	std::vector<std::complex<double>> out_d(out.size());
-	for (std::size_t i = 0; i < out.size(); ++i) {
-		out_d[i] = std::complex<double>(static_cast<double>(out[i].real()),
-		                                 static_cast<double>(out[i].imag()));
-	}
+	std::transform(out.begin(), out.end(), out_d.begin(),
+	               [](const auto& z) {
+	                   return std::complex<double>(
+	                       static_cast<double>(z.real()),
+	                       static_cast<double>(z.imag()));
+	               });
 	return out_d;
 }
 

--- a/applications/acquisition_demo/acquisition_demo.cpp
+++ b/applications/acquisition_demo/acquisition_demo.cpp
@@ -137,8 +137,11 @@ mtl::vec::dense_vector<double> simulate_adc(int adc_bits, unsigned seed = 0xACDC
 //          DecimationChain<CIC ↓2 → HalfBand ↓2 → Polyphase ↓2>
 //     -> baseband I/Q at fs / 16
 //
-// All filter design is done at CoeffScalar precision (T-parameterized
-// per the library's design-time-precision invariant).
+// All filter design is done in double and projected to CoeffScalar
+// (see the comment block in Stage 1 below). This deliberately
+// deviates from the library's design-time-precision invariant so
+// that cross-configuration SNR isolates streaming-arithmetic
+// precision from filter-design variance.
 template <class CoeffScalar, class StateScalar, class SampleScalar>
 std::vector<std::complex<double>>
 run_pipeline(const mtl::vec::dense_vector<double>& adc_in_double) {
@@ -280,7 +283,7 @@ AcquisitionPrecisionRow measure_config(
 	row.sample_type = sample_label;
 	row.total_bits  = total_bits;
 	row.nco_sfdr_db = -1.0;                  // not measured per config here
-	row.cic_overflow_margin_bits = -1.0;     // CIC not used in this pipeline
+	row.cic_overflow_margin_bits = -1.0;     // CIC metric not measured per config
 
 	auto test_out = run_pipeline<CoeffScalar, StateScalar, SampleScalar>(adc_in);
 	const double s = measure_baseband_snr_db(reference_out, test_out);
@@ -447,13 +450,23 @@ void print_usage(const char* prog) {
 		<< "  -h, --help              This message\n";
 }
 
+// Parse a comma-separated list of ints. Throws std::invalid_argument
+// with a clear message identifying the offending token, instead of
+// letting std::stoi's bare exceptions propagate up to terminate().
 std::vector<int> parse_int_list(const std::string& s) {
 	std::vector<int> out;
 	std::size_t pos = 0;
 	while (pos < s.size()) {
 		const std::size_t comma = s.find(',', pos);
 		const std::string tok = s.substr(pos, comma - pos);
-		if (!tok.empty()) out.push_back(std::stoi(tok));
+		if (!tok.empty()) {
+			try {
+				out.push_back(std::stoi(tok));
+			} catch (const std::exception&) {
+				throw std::invalid_argument(
+					"could not parse '" + tok + "' as an integer");
+			}
+		}
 		if (comma == std::string::npos) break;
 		pos = comma + 1;
 	}
@@ -462,34 +475,64 @@ std::vector<int> parse_int_list(const std::string& s) {
 
 int main(int argc, char** argv) {
 	std::string csv_path = "acquisition_demo.csv";
-	for (int i = 1; i < argc; ++i) {
-		const std::string arg = argv[i];
-		if (arg == "-h" || arg == "--help") {
-			print_usage(argv[0]);
-			return 0;
+	try {
+		for (int i = 1; i < argc; ++i) {
+			const std::string arg = argv[i];
+			if (arg == "-h" || arg == "--help") {
+				print_usage(argv[0]);
+				return 0;
+			}
+			if (arg.rfind("--if-freq=", 0) == 0) {
+				params.if_frequency_hz = std::stod(arg.substr(10));
+			} else if (arg.rfind("--sample-rate=", 0) == 0) {
+				params.sample_rate_hz = std::stod(arg.substr(14));
+			} else if (arg.rfind("--adc-bits=", 0) == 0) {
+				params.adc_scan_bits = parse_int_list(arg.substr(11));
+			} else if (arg.rfind("--num-samples=", 0) == 0) {
+				params.num_samples = static_cast<std::size_t>(std::stoull(arg.substr(14)));
+			} else if (arg.rfind("--csv=", 0) == 0) {
+				csv_path = arg.substr(6);
+			} else if (arg.rfind("--", 0) == 0) {
+				std::cerr << "Unknown flag: " << arg << "\n";
+				print_usage(argv[0]);
+				return 1;
+			} else {
+				// Positional CSV path (legacy)
+				csv_path = arg;
+			}
 		}
-		if (arg.rfind("--if-freq=", 0) == 0) {
-			params.if_frequency_hz = std::stod(arg.substr(10));
-		} else if (arg.rfind("--sample-rate=", 0) == 0) {
-			params.sample_rate_hz = std::stod(arg.substr(14));
-		} else if (arg.rfind("--adc-bits=", 0) == 0) {
-			params.adc_scan_bits = parse_int_list(arg.substr(11));
-		} else if (arg.rfind("--num-samples=", 0) == 0) {
-			params.num_samples = static_cast<std::size_t>(std::stoull(arg.substr(14)));
-		} else if (arg.rfind("--csv=", 0) == 0) {
-			csv_path = arg.substr(6);
-		} else if (arg.rfind("--", 0) == 0) {
-			std::cerr << "Unknown flag: " << arg << "\n";
-			print_usage(argv[0]);
-			return 1;
-		} else {
-			// Positional CSV path (legacy)
-			csv_path = arg;
-		}
+	} catch (const std::exception& ex) {
+		std::cerr << "Error parsing arguments: " << ex.what() << "\n";
+		print_usage(argv[0]);
+		return 1;
+	}
+
+	// Validate parameters before doing any pipeline math. Catches the
+	// obvious failure modes (zero sample rate, IF outside Nyquist,
+	// empty bit-scan list) early with a clear error.
+	auto fail = [&](const std::string& msg) {
+		std::cerr << "Invalid parameter: " << msg << "\n";
+		print_usage(argv[0]);
+		return 1;
+	};
+	if (!(params.sample_rate_hz > 0.0))
+		return fail("--sample-rate must be positive");
+	if (!(params.if_frequency_hz >= 0.0 &&
+	      params.if_frequency_hz < params.sample_rate_hz / 2.0))
+		return fail("--if-freq must satisfy 0 <= IF < sample_rate/2 (Nyquist)");
+	if (params.num_samples == 0)
+		return fail("--num-samples must be > 0");
+	if (params.adc_scan_bits.empty())
+		return fail("--adc-bits must list at least one bit depth");
+	for (int b : params.adc_scan_bits) {
+		if (b < 1 || b > 64)
+			return fail("--adc-bits values must be in [1, 64]");
 	}
 
 	const std::size_t total_decim =
 		params.ddc_decimation * params.cic_ratio * 2 * params.poly_decimation;
+	if (total_decim == 0)
+		return fail("internal: total decimation factor is 0 (check PipelineParams)");
 
 	std::cout << "=== Acquisition Pipeline Demo (Issue #93) ===\n";
 	std::cout << "Pipeline: ADC -> DDC(NCO + mixer + polyphase ↓"

--- a/docs-site/src/content/docs/acquisition/demo.md
+++ b/docs-site/src/content/docs/acquisition/demo.md
@@ -48,7 +48,7 @@ out of mixed-precision constraints, and how to read the output.
                                             |
                                             v
                                 +------------------------+
-                                | snr_db / enob / SFDR   |
+                                | snr_db / enob          |
                                 | vs uniform-double ref  |
                                 +------------------------+
                                             |

--- a/docs-site/src/content/docs/acquisition/demo.md
+++ b/docs-site/src/content/docs/acquisition/demo.md
@@ -6,7 +6,9 @@ description: Capstone walkthrough composing NCO, mixer, polyphase decimation, an
 The library ships a runnable demo at
 [`applications/acquisition_demo/`](https://github.com/stillwater-sc/mixed-precision-dsp/tree/main/applications/acquisition_demo)
 that ties the entire data-acquisition stack together: a simulated ADC,
-a DDC composing NCO + complex mixer + polyphase decimation, and the
+a DDC composing NCO + complex mixer + polyphase decimation, two
+parallel `DecimationChain` instances handling the I and Q baseband
+streams, and the
 [`acquisition_precision`](../../analysis/acquisition-precision/)
 analysis primitives — all swept across a representative range of
 number-system configurations.
@@ -17,22 +19,49 @@ out of mixed-precision constraints, and how to read the output.
 ## Pipeline
 
 ```text
-+------------------------+    +-----------------------------+    +-----------+
-| simulate_adc(N_bits)   | -> | DDC<Coeff,State,Sample> {   | -> | I/Q       |
-|   real cosine + noise  |    |   NCO at f_IF / f_S         |    | baseband  |
-|   N-bit uniform quant  |    |   complex mixer (×conj)     |    |           |
-+------------------------+    |   PolyphaseDecimator ×8     |    +-----------+
-                              | }                           |          |
-                              +-----------------------------+          |
-                                                                       v
-                                                       +------------------------+
-                                                       | snr_db / enob / SFDR   |
-                                                       | vs uniform-double ref  |
-                                                       +------------------------+
-                                                                       |
-                                                                       v
-                                                          acquisition_demo.csv
++------------------------+    +-----------------------------+
+| simulate_adc(N_bits)   | -> | DDC<Coeff,State,Sample> {   |
+|   real cosine + noise  |    |   NCO at f_IF / f_S         |
+|   N-bit uniform quant  |    |   complex mixer (×conj)     |
++------------------------+    |   PolyphaseDecimator ↓2     |
+                              | }                           |
+                              +-----------------------------+
+                                            |
+                                  split into I, Q streams
+                                            |
+                              +-------------+-------------+
+                              v                           v
+              +-----------------------+   +-----------------------+
+              | DecimationChain {     |   | DecimationChain {     |
+              |   CICDecimator ↓2     |   |   CICDecimator ↓2     |
+              |   HalfBandFilter ↓2   |   |   HalfBandFilter ↓2   |
+              |   PolyphaseDecimator  |   |   PolyphaseDecimator  |
+              |     ↓2                |   |     ↓2                |
+              | }                     |   | }                     |
+              +-----------------------+   +-----------------------+
+                              |                           |
+                              +-------------+-------------+
+                                            v
+                                +------------------------+
+                                | I/Q baseband at fs/16  |
+                                +------------------------+
+                                            |
+                                            v
+                                +------------------------+
+                                | snr_db / enob / SFDR   |
+                                | vs uniform-double ref  |
+                                +------------------------+
+                                            |
+                                            v
+                                  acquisition_demo.csv
 ```
+
+The DDC handles the first ↓2 (anti-alias + complex baseband
+conversion). The post-DDC `DecimationChain` does the remaining ↓8 in
+three Hogenauer-classic stages: CIC for the bulk rate change, half-band
+for transition-band shaping, and a polyphase FIR for the final
+channel-defining decimation. Total decimation is ↓16, exercising every
+multistage primitive in the acquisition module.
 
 Each row in the CSV captures one (CoeffScalar, StateScalar,
 SampleScalar) configuration's quality against the reference. The
@@ -52,24 +81,52 @@ uniform quantization to `adc_bits` levels across full scale. The
 quantization step is `1 / 2^(adc_bits-1)` so the SNR floor follows the
 classic $6.02 N + 1.76$ dB ceiling for any later stage downstream.
 
-## DDC composition
+## Pipeline composition
 
 ```cpp
 template <class CoeffScalar, class StateScalar, class SampleScalar>
 std::vector<std::complex<double>>
-run_ddc_pipeline(const mtl::vec::dense_vector<double>& adc_in_double);
+run_pipeline(const mtl::vec::dense_vector<double>& adc_in_double);
 ```
 
 The pipeline projects ADC samples into `SampleScalar`, runs them
-through a `DDC<CoeffScalar, StateScalar, SampleScalar>` with a
-polyphase FIR decimator (decimation factor 8), and casts the complex
-output back to `double` for cross-precision comparison.
+through a `DDC<CoeffScalar, StateScalar, SampleScalar>` (NCO + mixer
++ ↓2 polyphase), splits the complex output into separate I and Q
+real-valued streams, then feeds each stream through its own
+`DecimationChain<SampleScalar, CICDecimator, HalfBandFilter,
+PolyphaseDecimator>` for an additional ↓8. Recombines I and Q at the
+output and casts to `std::complex<double>` for cross-precision
+comparison.
 
-The DDC class itself does the work — see the [DDC reference](./ddc/) for
-the math. The demo's contribution is the configuration sweep
-infrastructure around it.
+Each component does its own work — see the [DDC](./ddc/),
+[Polyphase Decimator](./polyphase-decimator/),
+[CIC](./cic/), [Half-Band](./halfband/), and
+[DecimationChain](./decimation-chain/) references for the math. The
+demo's contribution is the configuration sweep infrastructure that
+threads `(CoeffScalar, StateScalar, SampleScalar)` through every
+stage uniformly.
 
-## Two mixed-precision design decisions
+### Filter design: in `double`, projected to `CoeffScalar`
+
+All three filter designs (DDC anti-alias FIR, half-band, post-DDC
+polyphase) are computed in `double` and then projected to
+`CoeffScalar` via `static_cast`. This deliberately deviates from the
+T-parameterized design pattern the rest of the library follows
+(see the
+[T-parameterization audit](https://github.com/stillwater-sc/mixed-precision-dsp/issues/111))
+because we want the SNR measurement to isolate **streaming
+arithmetic** precision from **filter-design** precision. If we
+designed taps at `CoeffScalar`, the test and the `double` reference
+would run through different taps (Remez at `posit` converges to
+slightly different values than at `double`), so SNR would conflate
+filter-design variance with the arithmetic quality we're trying to
+measure. `fixpnt` is a stronger example: `design_halfband<fixpnt>`
+trips divide-by-zero in the Remez iteration because `fixpnt` doesn't
+have the dynamic range Remez assumes. Design once in `double`,
+project for each test config — every configuration runs through
+identical taps.
+
+## Three mixed-precision design decisions
 
 These come up the moment you try to instantiate the pipeline at
 non-IEEE precision. They're worth understanding because they recur in
@@ -118,70 +175,118 @@ some abstract "32-bit fixed-point". The demo uses `fixpnt<32, 28>`
 - 28 fractional bits → precision $2^{-28} \approx 4 \times 10^{-9}$,
   competitive with IEEE float
 
-Result: Q4.28 fixpnt measures ~24 ENOB through this pipeline, the
-same neighborhood as IEEE float. The lesson is that fixpnt is a
+Result: Q4.28 fixpnt measures ~25 ENOB through this pipeline, the
+best of any configuration. The lesson is that fixpnt is a
 *format choice*, not a number system; pick the integer/fractional
 split based on the signal you'll actually run through it.
 
+### 3. CIC requires fixed-point (or any wrapping) state
+
+The biggest surprise of this demo: with a CIC decimator in the chain,
+**`uniform_fixpnt32` beats every floating-point configuration by
+~100 dB**, and `uniform_posit16` collapses to negative SNR.
+
+The cause is a structural property of CIC. A CIC integrator is
+`y[n] = y[n-1] + x[n]` — an unbounded accumulator. The classical
+Hogenauer derivation works only because **the accumulator wraps in
+two's-complement modular arithmetic**, and the matching comb stage
+subtracts the same wrapped value to recover the bounded result. Any
+state representation that doesn't wrap modularly — `float`, `double`,
+`posit` — accumulates round-off on every DC-bias sample, and that
+error never gets cancelled by the comb. The integrator slowly drifts.
+
+You can see this directly in the table below: float, posit32, and
+cfloat32 (all with ~24 bits of mantissa precision) cluster around
+54 dB SNR — that's the integrator drift floor, not the arithmetic
+ceiling. fixpnt32, with hardware-level two's-complement wrap,
+recovers the full 153 dB the rest of the chain can deliver. posit16's
+4 mantissa bits aren't enough to keep the integrator stable at all,
+hence the -30 dB collapse.
+
+The lesson: **if you have a CIC stage, use fixed-point (or any
+wrapping integer-like type) for the integrator state.** The
+[CIC reference](./cic/) covers the math; this demo is the empirical
+evidence.
+
 ## Reading the output
 
-A clean run with a 16-bit ADC at 1 MHz, IF at 100 kHz, decimating to
-125 kHz:
+A clean run with a 16-bit ADC at 1 MHz, IF at 100 kHz, decimating
+↓16 to a 62.5 kHz baseband:
 
 ```text
 === Number-system sweep (16-bit ADC) ===
 Configuration                   Bits    SNR(dB)    ENOB
 -------------------------------------------------------
 uniform_double                   192        inf     ref
-uniform_float                     96     144.62   23.73
-uniform_posit32                   96     167.60   27.55
-uniform_posit16                   48      71.30   11.55
-uniform_cfloat32                  96     144.68   23.74
-uniform_fixpnt32                  96     147.56   24.22
-mixed_double_p32_p16             112      76.68   12.45
-mixed_double_double_float        160     150.63   24.73
-mixed_double_p32_float           128     150.59   24.72
-mixed_double_float_float         128     144.62   23.73
-mixed_double_fx32_fx32           128     147.56   24.22
+uniform_float                     96      54.48    8.76
+uniform_posit32                   96      54.46    8.75
+uniform_posit16                   48     -29.99   -5.27
+uniform_cfloat32                  96      54.48    8.76
+uniform_fixpnt32                  96     152.67   25.07
+mixed_double_p32_p16             112      53.03    8.52
+mixed_double_double_float        160     147.16   24.15
+mixed_double_p32_float           128      54.46    8.75
+mixed_double_float_float         128      54.48    8.76
+mixed_double_fx32_fx32           128     152.67   25.07
 
 === ADC bit-depth scan (uniform-double pipeline) ===
 ADC bits        SNR(dB)    ENOB
 -------------------------------
-8-bit             54.00    8.68
-12-bit            77.98   12.66
-14-bit            89.49   14.57
-16-bit           101.75   16.61
+8-bit             51.78    8.31
+12-bit            75.60   12.27
+14-bit            87.59   14.26
+16-bit           100.20   16.35
 ```
 
 A few patterns to note:
 
-- **`uniform_posit32` wins on raw quality at 96 bits/config**, beating
-  `uniform_float` by about 23 dB. Posit's tapered precision concentrates
-  precision near unity, exactly where a normalized baseband signal lives
-  after mixing — float spreads its precision across a much wider exponent
-  range that the signal never visits.
-- **`uniform_fixpnt32` (Q4.28) is competitive with float**. With the
-  format chosen for the signal's actual dynamic range, fixpnt is a
-  perfectly reasonable choice for embedded DSP.
-- **The mixed-precision row `mixed_double_p32_p16`** keeps high-precision
-  coefficients but runs state and samples narrower. SNR drops to ~77 dB
-  (~12 ENOB) — that's the floor any 16-bit-streaming pipeline can
-  reach, regardless of how much you spend on the coefficients.
+- **`uniform_fixpnt32` (Q4.28) wins by ~100 dB.** This is the CIC
+  state-precision lesson described above. The Q4.28 format gives
+  enough fractional precision (~28 bits) to match the post-DDC
+  signal range, and the hardware-level two's-complement wrap is
+  exactly what the CIC integrator needs.
+- **All three 32-bit floating-point options cluster at ~54 dB SNR.**
+  `uniform_float`, `uniform_posit32`, and `uniform_cfloat32` are
+  all bounded by the same physics: float-state CIC integrators drift
+  on DC bias, regardless of mantissa precision. This is *not* a flaw
+  in float or posit; it's a CIC design constraint that the demo
+  surfaces empirically.
+- **`uniform_posit16` collapses to negative SNR (-30 dB).** Posit16
+  has 4 mantissa bits at unity. That's nowhere near enough to keep
+  the integrator stable, so the output is dominated by drift noise.
+  This is a useful warning: narrow floating-point types in CIC chains
+  do not gracefully degrade — they fall off a cliff.
+- **`mixed_double_double_float`** keeps state in `double` but samples
+  in `float`. Double-precision integrator state is enough to suppress
+  the drift floor by ~93 dB compared to all-`float`, recovering ~24
+  ENOB. If you must use floating-point, this is the right precision
+  split.
 - **The ADC scan** confirms the textbook $\text{SNR} \approx 6.02 N + 1.76$ dB
-  ceiling propagates end-to-end: the FIR decimation gains a few dB of
-  averaging beyond the raw ADC ceiling, but the slope and intercept
-  match.
+  ceiling propagates end-to-end: the multistage decimation gains a
+  few dB of averaging beyond the raw ADC ceiling, but the slope and
+  intercept match.
 
 ## Running it
 
 ```bash
 cmake -B build
 cmake --build build --target acquisition_demo
-./build/applications/acquisition_demo/acquisition_demo [output.csv]
+./build/applications/acquisition_demo/acquisition_demo [OPTIONS] [csv_path]
 ```
 
-The CSV path is optional; default is `acquisition_demo.csv` in the
-working directory. The console table is printed regardless.
+Options (all are key=value):
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--if-freq=<Hz>` | `100000` | IF frequency of the simulated tone |
+| `--sample-rate=<Hz>` | `1000000` | ADC sample rate |
+| `--adc-bits=8,12,14,16` | `8,12,14,16` | Comma-separated bit depths for the ADC scan |
+| `--num-samples=<N>` | `4096` | Input block length |
+| `--csv=<path>` | `acquisition_demo.csv` | Output CSV path |
+| `-h`, `--help` | — | Print usage |
+
+The CSV path may also be passed positionally for backwards
+compatibility. The console table is printed regardless.
 
 ## Extending the sweep
 
@@ -206,7 +311,9 @@ what makes the SNR column meaningful as a cross-row metric.
 
 ## See also
 
-- [DDC](./ddc/) — the pipeline's core component
-- [Polyphase Decimator](./polyphase-decimator/) — channel-shaping stage
-- [Decimation Chain](./decimation-chain/) — multi-stage rate reduction (alternative to a single-stage polyphase)
+- [DDC](./ddc/) — front-end mixer + polyphase decimator
+- [CIC](./cic/) — first stage of the post-DDC chain
+- [Half-Band Filter](./halfband/) — second stage; transition-band shaping
+- [Polyphase Decimator](./polyphase-decimator/) — channel-defining final stage
+- [Decimation Chain](./decimation-chain/) — variadic-tuple multistage composition used twice (one I, one Q)
 - [Acquisition Precision Analysis](../../analysis/acquisition-precision/) — the SNR/ENOB primitives the demo measures with

--- a/docs-site/src/content/docs/acquisition/demo.md
+++ b/docs-site/src/content/docs/acquisition/demo.md
@@ -1,0 +1,212 @@
+---
+title: End-to-End Demo
+description: Capstone walkthrough composing NCO, mixer, polyphase decimation, and the precision-analysis primitives into a configurable IF receiver
+---
+
+The library ships a runnable demo at
+[`applications/acquisition_demo/`](https://github.com/stillwater-sc/mixed-precision-dsp/tree/main/applications/acquisition_demo)
+that ties the entire data-acquisition stack together: a simulated ADC,
+a DDC composing NCO + complex mixer + polyphase decimation, and the
+[`acquisition_precision`](../../analysis/acquisition-precision/)
+analysis primitives — all swept across a representative range of
+number-system configurations.
+
+This page walks through the topology, the design decisions that fall
+out of mixed-precision constraints, and how to read the output.
+
+## Pipeline
+
+```text
++------------------------+    +-----------------------------+    +-----------+
+| simulate_adc(N_bits)   | -> | DDC<Coeff,State,Sample> {   | -> | I/Q       |
+|   real cosine + noise  |    |   NCO at f_IF / f_S         |    | baseband  |
+|   N-bit uniform quant  |    |   complex mixer (×conj)     |    |           |
++------------------------+    |   PolyphaseDecimator ×8     |    +-----------+
+                              | }                           |          |
+                              +-----------------------------+          |
+                                                                       v
+                                                       +------------------------+
+                                                       | snr_db / enob / SFDR   |
+                                                       | vs uniform-double ref  |
+                                                       +------------------------+
+                                                                       |
+                                                                       v
+                                                          acquisition_demo.csv
+```
+
+Each row in the CSV captures one (CoeffScalar, StateScalar,
+SampleScalar) configuration's quality against the reference. The
+schema matches the
+[`AcquisitionPrecisionRow`](../../analysis/acquisition-precision/#csv-export)
+format from the analysis module, so the same Python tooling that
+reads `precision_sweep.csv` reads this file's identifier columns.
+
+## ADC simulation
+
+```cpp
+mtl::vec::dense_vector<double> simulate_adc(int adc_bits, unsigned seed = 0xACDC);
+```
+
+A real-valued cosine at the IF frequency, plus low-level AWGN, then
+uniform quantization to `adc_bits` levels across full scale. The
+quantization step is `1 / 2^(adc_bits-1)` so the SNR floor follows the
+classic $6.02 N + 1.76$ dB ceiling for any later stage downstream.
+
+## DDC composition
+
+```cpp
+template <class CoeffScalar, class StateScalar, class SampleScalar>
+std::vector<std::complex<double>>
+run_ddc_pipeline(const mtl::vec::dense_vector<double>& adc_in_double);
+```
+
+The pipeline projects ADC samples into `SampleScalar`, runs them
+through a `DDC<CoeffScalar, StateScalar, SampleScalar>` with a
+polyphase FIR decimator (decimation factor 8), and casts the complex
+output back to `double` for cross-precision comparison.
+
+The DDC class itself does the work — see the [DDC reference](./ddc/) for
+the math. The demo's contribution is the configuration sweep
+infrastructure around it.
+
+## Two mixed-precision design decisions
+
+These come up the moment you try to instantiate the pipeline at
+non-IEEE precision. They're worth understanding because they recur in
+any real embedded DSP design.
+
+### 1. Normalized rates
+
+The `DDC` constructor takes a `StateScalar sample_rate` argument, but
+the NCO inside only ever uses `frequency / sample_rate`. If you pass
+absolute Hz (say `1.0e6`) and the StateScalar is a narrow type (e.g.,
+`fixpnt<32, 28>` with range $\pm 8$), construction throws because the
+sample rate saturates.
+
+The fix is mathematically trivial:
+
+```cpp
+const double f_norm = params::kIfFrequencyHz / params::kSampleRateHz;
+DDC_t ddc(static_cast<StateScalar>(f_norm),
+          static_cast<StateScalar>(1.0),
+          decim);
+```
+
+Pass `(IF/fs, 1.0)` instead of `(IF, fs)`. The phase increment ends up
+identical (`f_norm / 1.0 == IF / fs`), and the StateScalar values stay
+in $[0, 1]$ where every sane scalar type can represent them.
+
+This is a general principle for embedded DSP: parameterize on
+dimensionless ratios, not absolute units, whenever the underlying math
+only needs the ratio.
+
+### 2. Q4.28 (not Q16.16) for fixpnt
+
+A first attempt at fixpnt parameterization picked `fixpnt<32, 16>`
+(Q16.16 — 16 integer bits, 16 fractional). That gives ample integer
+range ($\pm 32{,}768$) but only $2^{-16} \approx 1.5 \times 10^{-5}$
+precision. The post-mixer baseband signal lives in $[-0.5, +0.5]$
+where 16 fractional bits is poor. The configuration measured **0
+ENOB**.
+
+The fix is to choose the Q-format for the *signal range*, not for
+some abstract "32-bit fixed-point". The demo uses `fixpnt<32, 28>`
+(Q4.28):
+
+- 4 integer bits → range $\pm 8$, comfortable for the post-mixer
+  $[-0.5, 0.5]$ signal even after a few decibels of FIR-stage gain
+- 28 fractional bits → precision $2^{-28} \approx 4 \times 10^{-9}$,
+  competitive with IEEE float
+
+Result: Q4.28 fixpnt measures ~24 ENOB through this pipeline, the
+same neighborhood as IEEE float. The lesson is that fixpnt is a
+*format choice*, not a number system; pick the integer/fractional
+split based on the signal you'll actually run through it.
+
+## Reading the output
+
+A clean run with a 16-bit ADC at 1 MHz, IF at 100 kHz, decimating to
+125 kHz:
+
+```text
+=== Number-system sweep (16-bit ADC) ===
+Configuration                   Bits    SNR(dB)    ENOB
+-------------------------------------------------------
+uniform_double                   192        inf     ref
+uniform_float                     96     144.62   23.73
+uniform_posit32                   96     167.60   27.55
+uniform_posit16                   48      71.30   11.55
+uniform_cfloat32                  96     144.68   23.74
+uniform_fixpnt32                  96     147.56   24.22
+mixed_double_p32_p16             112      76.68   12.45
+mixed_double_double_float        160     150.63   24.73
+mixed_double_p32_float           128     150.59   24.72
+mixed_double_float_float         128     144.62   23.73
+mixed_double_fx32_fx32           128     147.56   24.22
+
+=== ADC bit-depth scan (uniform-double pipeline) ===
+ADC bits        SNR(dB)    ENOB
+-------------------------------
+8-bit             54.00    8.68
+12-bit            77.98   12.66
+14-bit            89.49   14.57
+16-bit           101.75   16.61
+```
+
+A few patterns to note:
+
+- **`uniform_posit32` wins on raw quality at 96 bits/config**, beating
+  `uniform_float` by about 23 dB. Posit's tapered precision concentrates
+  precision near unity, exactly where a normalized baseband signal lives
+  after mixing — float spreads its precision across a much wider exponent
+  range that the signal never visits.
+- **`uniform_fixpnt32` (Q4.28) is competitive with float**. With the
+  format chosen for the signal's actual dynamic range, fixpnt is a
+  perfectly reasonable choice for embedded DSP.
+- **The mixed-precision row `mixed_double_p32_p16`** keeps high-precision
+  coefficients but runs state and samples narrower. SNR drops to ~77 dB
+  (~12 ENOB) — that's the floor any 16-bit-streaming pipeline can
+  reach, regardless of how much you spend on the coefficients.
+- **The ADC scan** confirms the textbook $\text{SNR} \approx 6.02 N + 1.76$ dB
+  ceiling propagates end-to-end: the FIR decimation gains a few dB of
+  averaging beyond the raw ADC ceiling, but the slope and intercept
+  match.
+
+## Running it
+
+```bash
+cmake -B build
+cmake --build build --target acquisition_demo
+./build/applications/acquisition_demo/acquisition_demo [output.csv]
+```
+
+The CSV path is optional; default is `acquisition_demo.csv` in the
+working directory. The console table is printed regardless.
+
+## Extending the sweep
+
+The demo's structure is intentionally flat — a single
+`sweep_configurations()` function holds all the rows. To add a
+configuration:
+
+```cpp
+rows.push_back(measure_config<MyCoeff, MyState, MySample>(
+    "config_label",
+    "MyCoeff",      // for the CSV
+    "MyState",
+    "MySample",
+    coeff_bits + state_bits + sample_bits,
+    adc_in,
+    reference_out));
+```
+
+The reference is always uniform-double, computed once at the top of
+the sweep. Every row is compared against the same reference, which is
+what makes the SNR column meaningful as a cross-row metric.
+
+## See also
+
+- [DDC](./ddc/) — the pipeline's core component
+- [Polyphase Decimator](./polyphase-decimator/) — channel-shaping stage
+- [Decimation Chain](./decimation-chain/) — multi-stage rate reduction (alternative to a single-stage polyphase)
+- [Acquisition Precision Analysis](../../analysis/acquisition-precision/) — the SNR/ENOB primitives the demo measures with

--- a/docs-site/src/content/docs/acquisition/demo.md
+++ b/docs-site/src/content/docs/acquisition/demo.md
@@ -77,9 +77,11 @@ mtl::vec::dense_vector<double> simulate_adc(int adc_bits, unsigned seed = 0xACDC
 ```
 
 A real-valued cosine at the IF frequency, plus low-level AWGN, then
-uniform quantization to `adc_bits` levels across full scale. The
-quantization step is `1 / 2^(adc_bits-1)` so the SNR floor follows the
-classic $6.02 N + 1.76$ dB ceiling for any later stage downstream.
+uniform quantization to a signed N-bit ADC's $2^N$ codes (range
+$[-2^{N-1}, 2^{N-1}-1]$ — the standard two's-complement layout). The
+quantization step is $1 / 2^{N-1}$, the full-scale signed step for
+N-bit signed representation, so the SNR floor follows the classic
+$6.02 N + 1.76$ dB ceiling for any later stage downstream.
 
 ## Pipeline composition
 
@@ -143,10 +145,10 @@ sample rate saturates.
 The fix is mathematically trivial:
 
 ```cpp
-const double f_norm = params::kIfFrequencyHz / params::kSampleRateHz;
+const double f_norm = params.if_frequency_hz / params.sample_rate_hz;
 DDC_t ddc(static_cast<StateScalar>(f_norm),
           static_cast<StateScalar>(1.0),
-          decim);
+          ddc_decim);
 ```
 
 Pass `(IF/fs, 1.0)` instead of `(IF, fs)`. The phase increment ends up
@@ -175,16 +177,16 @@ some abstract "32-bit fixed-point". The demo uses `fixpnt<32, 28>`
 - 28 fractional bits → precision $2^{-28} \approx 4 \times 10^{-9}$,
   competitive with IEEE float
 
-Result: Q4.28 fixpnt measures ~25 ENOB through this pipeline, the
-best of any configuration. The lesson is that fixpnt is a
-*format choice*, not a number system; pick the integer/fractional
+Result: Q4.28 fixpnt measures ~15 ENOB through this pipeline, the
+best of any non-double configuration. The lesson is that fixpnt is
+a *format choice*, not a number system; pick the integer/fractional
 split based on the signal you'll actually run through it.
 
 ### 3. CIC requires fixed-point (or any wrapping) state
 
 The biggest surprise of this demo: with a CIC decimator in the chain,
 **`uniform_fixpnt32` beats every floating-point configuration by
-~100 dB**, and `uniform_posit16` collapses to negative SNR.
+~40 dB**, and `uniform_posit16` collapses to negative SNR.
 
 The cause is a structural property of CIC. A CIC integrator is
 `y[n] = y[n-1] + x[n]` — an unbounded accumulator. The classical
@@ -199,9 +201,8 @@ You can see this directly in the table below: float, posit32, and
 cfloat32 (all with ~24 bits of mantissa precision) cluster around
 54 dB SNR — that's the integrator drift floor, not the arithmetic
 ceiling. fixpnt32, with hardware-level two's-complement wrap,
-recovers the full 153 dB the rest of the chain can deliver. posit16's
-4 mantissa bits aren't enough to keep the integrator stable at all,
-hence the -30 dB collapse.
+recovers ~93 dB. posit16's 4 mantissa bits aren't enough to keep
+the integrator stable at all, hence the -30 dB collapse.
 
 The lesson: **if you have a CIC stage, use fixed-point (or any
 wrapping integer-like type) for the integrator state.** The
@@ -218,29 +219,38 @@ A clean run with a 16-bit ADC at 1 MHz, IF at 100 kHz, decimating
 Configuration                   Bits    SNR(dB)    ENOB
 -------------------------------------------------------
 uniform_double                   192        inf     ref
-uniform_float                     96      54.48    8.76
+uniform_float                     96      54.44    8.75
 uniform_posit32                   96      54.46    8.75
-uniform_posit16                   48     -29.99   -5.27
-uniform_cfloat32                  96      54.48    8.76
-uniform_fixpnt32                  96     152.67   25.07
+uniform_posit16                   48     -30.06   -5.29
+uniform_cfloat32                  96      54.44    8.75
+uniform_fixpnt32                  96      92.76   15.12
 mixed_double_p32_p16             112      53.03    8.52
-mixed_double_double_float        160     147.16   24.15
+mixed_double_double_float        160     146.95   24.12
 mixed_double_p32_float           128      54.46    8.75
-mixed_double_float_float         128      54.48    8.76
-mixed_double_fx32_fx32           128     152.67   25.07
+mixed_double_float_float         128      54.44    8.75
+mixed_double_fx32_fx32           128      92.76   15.12
 
 === ADC bit-depth scan (uniform-double pipeline) ===
 ADC bits        SNR(dB)    ENOB
 -------------------------------
-8-bit             51.78    8.31
-12-bit            75.60   12.27
-14-bit            87.59   14.26
-16-bit           100.20   16.35
+8-bit             48.72    7.80
+12-bit            72.57   11.76
+14-bit            84.75   13.79
+16-bit            96.99   15.82
 ```
+
+These numbers measure the **complex-residual SNR** between the test
+configuration's I/Q output and the uniform-double reference's I/Q
+output (i.e., the demo computes
+$10 \log_{10} \frac{\sum |r_i|^2}{\sum |r_i - t_i|^2}$ on the
+complex baseband stream). That captures both magnitude and phase
+errors. An earlier version reduced each stream to its magnitude
+envelope before comparison, which silently masked phase-only error
+and over-stated `fixpnt32` quality by ~60 dB.
 
 A few patterns to note:
 
-- **`uniform_fixpnt32` (Q4.28) wins by ~100 dB.** This is the CIC
+- **`uniform_fixpnt32` (Q4.28) wins by ~40 dB.** This is the CIC
   state-precision lesson described above. The Q4.28 format gives
   enough fractional precision (~28 bits) to match the post-DDC
   signal range, and the hardware-level two's-complement wrap is


### PR DESCRIPTION
## Summary
Capstone demonstration for the High-Rate Data Acquisition Pipeline epic ([#84](https://github.com/stillwater-sc/mixed-precision-dsp/issues/84)). Ties together NCO, polyphase decimation, DDC, and the acquisition_precision analysis primitives into a single end-to-end sweep that exercises the realistic IF-receiver topology under a range of number-system configurations.

## Pipeline
```
simulated ADC (configurable bit depth)
  -> DDC { NCO + complex mixer + polyphase decim ×8 }
  -> complex baseband
  -> SNR / ENOB measurement vs uniform-double reference
```

## Configurations (16-bit ADC, 11 number-system configs + 4-row ADC scan)
**Uniform:** double, float, posit<32,2>, posit<16,2>, cfloat<32,8>, fixpnt<32,28>
**Mixed:**   double/p32/p16, double/double/float, double/p32/float, double/float/float, double/fx32/fx32

15 rows total, well over the issue's "10+ configurations" / "4+ number systems" thresholds.

## Sample numbers from a clean run

| Configuration | Total bits | SNR (dB) | ENOB |
|---|---|---|---|
| uniform_double | 192 | inf | ref |
| uniform_posit32 | 96 | **167.6** | **27.5** |
| uniform_fixpnt32 (Q4.28) | 96 | 147.6 | 24.2 |
| uniform_cfloat32 | 96 | 144.7 | 23.7 |
| uniform_float | 96 | 144.6 | 23.7 |
| mixed_double_double_float | 160 | 150.6 | 24.7 |
| mixed_double_p32_p16 | 112 | 76.7 | 12.4 |
| uniform_posit16 | 48 | 71.3 | 11.6 |

Posit<32,2> wins on raw quality at 96 bits/config, beating IEEE float by ~23 dB thanks to its tapered precision near unity (where the mixed/decimated baseband signal lives).

ADC scan demonstrates the textbook $6.02N + 1.76$ dB ceiling propagating end-to-end:

| ADC bits | SNR (dB) | ENOB |
|---|---|---|
| 8 | 54.0 | 8.7 |
| 12 | 78.0 | 12.7 |
| 14 | 89.5 | 14.6 |
| 16 | 101.8 | 16.6 |

## Implementation notes
- **DDC sample_rate normalization.** The DDC's StateScalar must hold the sample rate, and the NCO only uses the freq/fs ratio internally. Passing `fs=1.0, freq=IF/fs` instead of absolute Hz is mathematically identical and prevents narrow-integer-range types like fixpnt<32,28> (range ±8) from saturating on MHz values.
- **Q4.28 fixpnt format.** Originally tried Q16.16 (`fixpnt<32,16>`) which collapsed to ~0 ENOB because the post-mixer baseband signal sits in [-0.5, +0.5] with 16 fractional bits providing only 1.5e-5 precision. Q4.28 has ample range with 2^-28 ≈ 4e-9 precision, making fixpnt competitive.
- **CSV schema.** Uses `AcquisitionPrecisionRow` / `write_acquisition_csv` from PR #127, sharing identifier columns with `applications/precision_sweep/precision_sweep.csv` per the conventions documented in `docs/analysis/acquisition-precision.md`.

## Changes
- `applications/acquisition_demo/acquisition_demo.cpp` — NEW (~370 lines)
- `applications/acquisition_demo/CMakeLists.txt` — NEW
- `applications/CMakeLists.txt` — register acquisition_demo

## Test Results
| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| acquisition_demo | OK | PASS | OK | PASS |

Full gcc ctest: 32/32 pass (no regressions in the library tests).

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Resolves #93

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new acquisition demo app: simulates ADC capture and downconversion, runs precision sweeps across number systems and ADC bit depths, prints a formatted SNR/ENOB table, scans per-bit ADC performance, and exports results to CSV.
  * Demo is included in the project build and can be built and run locally.

* **Documentation**
  * Added an End-to-End Demo guide with usage, example output, configuration options, CLI flags, and CSV output details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->