### PR TITLE
docs(multirate): add Multirate Signal Processing section (#130 phases 1+2+4)

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -53,6 +53,10 @@ export default defineConfig({
           autogenerate: { directory: 'filter' },
         },
         {
+          label: 'Multirate Signal Processing',
+          autogenerate: { directory: 'multirate' },
+        },
+        {
           label: 'Software-Defined Radio',
           autogenerate: { directory: 'acquisition' },
         },

--- a/docs-site/src/content/docs/acquisition/cic.md
+++ b/docs-site/src/content/docs/acquisition/cic.md
@@ -3,6 +3,8 @@ title: CIC Filters
 description: Cascaded Integrator-Comb decimation and interpolation filters for high-rate data acquisition
 ---
 
+*Part of the [Multirate Signal Processing](../multirate/overview/) section — see the overview for the broader theory and the [pattern catalog](../multirate/patterns/) for problem→API mapping.*
+
 ## History and Motivation
 
 The Cascaded Integrator-Comb (CIC) filter was introduced by Eugene Hogenauer

--- a/docs-site/src/content/docs/acquisition/ddc.md
+++ b/docs-site/src/content/docs/acquisition/ddc.md
@@ -3,6 +3,8 @@ title: Digital Down-Converter (DDC)
 description: Composing NCO, complex mixer, and decimation filter for band selection at high sample rates
 ---
 
+*Part of the [Multirate Signal Processing](../multirate/overview/) section — see the overview for the broader theory and the [pattern catalog](../multirate/patterns/) for problem→API mapping.*
+
 ## History and Motivation
 
 ### From Superheterodyne to All-Digital Receivers

--- a/docs-site/src/content/docs/acquisition/decimation-chain.md
+++ b/docs-site/src/content/docs/acquisition/decimation-chain.md
@@ -3,6 +3,8 @@ title: Multi-Stage Decimation Chain
 description: Cascading CIC, half-band, and polyphase filters to achieve large decimation ratios efficiently
 ---
 
+*Part of the [Multirate Signal Processing](../multirate/overview/) section — see the overview for the broader theory and the [pattern catalog](../multirate/patterns/) for problem→API mapping.*
+
 ## History and Motivation
 
 ### Why Cascaded Filters?

--- a/docs-site/src/content/docs/acquisition/halfband.md
+++ b/docs-site/src/content/docs/acquisition/halfband.md
@@ -3,6 +3,8 @@ title: Half-Band FIR Filter
 description: Optimized half-band FIR filter for efficient 2x decimation in high-rate acquisition pipelines
 ---
 
+*Part of the [Multirate Signal Processing](../multirate/overview/) section — see the overview for the broader theory and the [pattern catalog](../multirate/patterns/) for problem→API mapping.*
+
 ## History and Motivation
 
 ### The Multirate Revolution

--- a/docs-site/src/content/docs/acquisition/overview.md
+++ b/docs-site/src/content/docs/acquisition/overview.md
@@ -224,6 +224,11 @@ hard ceiling on `posit<32,2>` in this kind of chain.
 
 ## See also
 
+- [Multirate Signal Processing Overview](../../multirate/overview/) —
+  the broader multirate theory (Noble identity, polyphase
+  decomposition theorem) and the pattern catalog mapping multirate
+  problems to library APIs. The SDR primitives in this module are
+  the receiver-specific specialization of those general patterns.
 - [Filter Design Overview](../../filter/overview/) — the three-scalar
   model and FIR/IIR pipelines this module builds on
 - [DFT and FFT](../../spectral/dft-fft/) — what you typically run

--- a/docs-site/src/content/docs/acquisition/polyphase-decimator.md
+++ b/docs-site/src/content/docs/acquisition/polyphase-decimator.md
@@ -3,6 +3,8 @@ title: Polyphase Decimator
 description: Efficient FIR-based decimation through polyphase decomposition for high-rate acquisition pipelines
 ---
 
+*Part of the [Multirate Signal Processing](../multirate/overview/) section — see the overview for the broader theory and the [pattern catalog](../multirate/patterns/) for problem→API mapping.*
+
 ## What and Why
 
 A polyphase decimator implements **decimation by M** with an N-tap FIR

--- a/docs-site/src/content/docs/filter/fir/polyphase.md
+++ b/docs-site/src/content/docs/filter/fir/polyphase.md
@@ -3,6 +3,8 @@ title: Polyphase Decomposition
 description: Efficient multirate filtering via polyphase interpolation and decimation in sw::dsp
 ---
 
+*Part of the [Multirate Signal Processing](../../multirate/overview/) section — see the overview for the broader theory and the [pattern catalog](../../multirate/patterns/) for problem→API mapping.*
+
 **Polyphase decomposition** splits a single FIR filter into a bank of smaller
 sub-filters, enabling multirate operations (interpolation and decimation) at
 dramatically lower computational cost.

--- a/docs-site/src/content/docs/multirate/overview.md
+++ b/docs-site/src/content/docs/multirate/overview.md
@@ -1,0 +1,258 @@
+---
+title: Multirate Signal Processing Overview
+description: The library's multirate primitives — decimation, interpolation, rational rate change, and filter banks — with the historical context and pattern-to-API mapping
+---
+
+Multirate DSP is the body of theory that lets a digital system process
+samples at *different* rates inside the same pipeline — decimation,
+interpolation, rational rate change, channelization. The library
+ships the primitives; this section is the conceptual layer that
+connects them.
+
+If you have a concrete problem in mind ("I need to convert 44.1 kHz
+to 48 kHz audio" or "what's the right pattern for a channelizer?"),
+jump straight to the [Pattern Catalog](./patterns/) — it maps each
+canonical multirate problem to the library's API. This page covers
+the *why* behind those mappings.
+
+## What "multirate" means
+
+Single-rate DSP runs every block of the pipeline at the same sample
+rate. Multirate DSP changes the sample rate between blocks — usually
+to match the bandwidth requirements of each stage. The two atomic
+operations are:
+
+- **Decimation by M** — keep every Mth sample, throwing away the
+  intermediate ones. Output rate = input rate / M.
+- **Interpolation by L** — insert L-1 zero samples between each
+  input sample, then filter to remove the resulting spectral images.
+  Output rate = input rate × L.
+
+Both must be paired with an anti-alias / anti-image filter to avoid
+spectral folding. Decimation needs a lowpass with cutoff at
+$f_s / (2M)$ before downsampling; interpolation needs the same
+lowpass after the upsampling, run at the *higher* rate.
+
+A naive implementation runs the filter at the high rate and then
+discards (decimation) or runs it after zero-stuffing (interpolation).
+Both waste compute on samples that don't matter. The whole point of
+multirate theory is to avoid that waste.
+
+## The historical progression
+
+Multirate DSP came together from a sequence of independent insights,
+each driven by a hardware constraint of its era:
+
+### 1960s–70s: the resampling problem
+
+The earliest multirate work was driven by audio applications: digital
+audio systems needed to convert between 44.1 kHz, 48 kHz, and the
+various intermediate rates that hardware happened to use. The basic
+upsample/filter/downsample structure was understood, but the
+arithmetic cost was prohibitive on the hardware of the day.
+
+### 1976: Bellanger and the polyphase decomposition
+
+Maurice Bellanger's 1976 paper *"Digital Filtering by Polyphase
+Network: Application to Sample-Rate Alteration and Filter Banks"*
+showed that an L-band decimating FIR filter can be decomposed into L
+sub-filters, each operating at the *output* rate, with a commutator
+selecting which sub-filter contributes to each output sample. The
+arithmetic cost drops by a factor of L because no multiplications
+are wasted on samples that will be discarded.
+
+The same decomposition runs in reverse for interpolation, and
+extends naturally to filter banks (see channelization below).
+Polyphase is the foundational structural insight of multirate DSP.
+
+### 1981: Hogenauer's CIC
+
+Eugene Hogenauer's 1981 paper *"An Economical Class of Digital
+Filters for Decimation and Interpolation"* tackled a different
+constraint: at GHz input rates, **any** filter that needed
+multipliers was too expensive. His Cascaded Integrator-Comb (CIC)
+structure uses only adders and subtractors and runs efficiently at
+the highest sample rate. The cost is a non-flat passband response
+(a $\text{sinc}^M$ droop) that downstream stages have to compensate.
+
+CIC made the modern digital receiver chain possible: a CIC handles
+the front-end bulk decimation at the ADC rate, and cheaper-per-sample
+multiplier-based filters take over at lower rates.
+
+### 1982: Mintzer and the half-band filter
+
+Fred Mintzer's 1982 paper *"On Half-Band, Third-Band, and Nth-Band
+FIR Filters and Their Design"* characterized a class of FIR filters
+where roughly $1 - 1/M$ of the coefficients are exactly zero. For
+$M = 2$ — the half-band filter — that's ~75% zero taps, so a length-N
+half-band runs at roughly the cost of a length-$(N/2)$ generic FIR.
+Half-bands are the workhorse 2:1 stage between a CIC and a final
+shaping FIR.
+
+Vaidyanathan's 1993 textbook *Multirate Systems and Filter Banks*
+formalized the M-th band design space and connected half-bands to
+the broader theory of perfect-reconstruction filter banks.
+
+### 1990s: DDC ASICs
+
+Once polyphase + CIC + half-bands were on the table, dedicated
+silicon followed. The Harris HSP50016, Graychip GC4016, and Analog
+Devices AD6620 *Digital Down-Converter* chips of the early 1990s
+implemented the canonical receiver chain — NCO + complex mixer +
+CIC + half-bands + polyphase FIR — in fixed-function hardware. Fred
+Harris's 2004 textbook *Multirate Signal Processing for Communication
+Systems* documented and generalized what those ASIC designers had
+been doing.
+
+### 2000s: SDR and software-only chains
+
+USRP hardware and the GNU Radio framework (early 2000s) moved the
+DDC chain into software. The same polyphase / CIC / half-band
+primitives now ran on general-purpose CPUs and GPUs. The rate-
+reduction stack remained essentially unchanged from the ASIC era;
+only the implementation moved.
+
+### Today: mixed-precision multirate
+
+The library you're reading docs for is in this era. Each multirate
+primitive is parameterized on three independent scalar types:
+
+- `CoeffScalar` — filter coefficients (design precision)
+- `StateScalar` — accumulator state (processing precision)
+- `SampleScalar` — input/output samples (streaming precision)
+
+The compelling cases for non-IEEE types in multirate work:
+
+- **CIC integrators** structurally require two's-complement-wrapping
+  state — `fixpnt` works, `float`/`posit` accumulate uncorrectable
+  drift on DC bias. The [SDR demo](../../acquisition/demo/) measures
+  this empirically.
+- **Posits** concentrate precision near unity, which is exactly where
+  baseband signals live after a DDC mix. Across the band, posit
+  delivers more usable precision per bit than IEEE float.
+- **Half-band and polyphase** stages run at lower rates on
+  bandwidth-reduced signals, so they tolerate narrower types than
+  the front-end CIC.
+
+## The Noble identity
+
+The Noble identity is the algebraic fact that lets all the
+multirate optimizations work. Stated for decimation:
+
+$$
+\text{Filter } H(z) \text{ followed by ↓M} \;\equiv\; ↓M \text{ followed by filter } H(z^M)
+$$
+
+The *picture* is: instead of running a filter at the high rate and
+then throwing samples away, you can throw the samples away first and
+run an "expanded" filter at the low rate. The expanded filter
+$H(z^M)$ has zeros stuffed between its taps; combined with polyphase
+decomposition (next section), this becomes a filter that runs only
+at the output rate.
+
+The dual identity for interpolation:
+
+$$
+↑L \text{ followed by filter } H(z) \;\equiv\; \text{Filter } H(z^L) \text{ followed by ↑L}
+$$
+
+is what makes polyphase interpolation efficient: the filter operates
+at the *input* rate (before upsampling), and the upsampling is just
+a commutator that picks which sub-filter's output goes where.
+
+Combined, the Noble identities are the reason every multirate
+primitive in this library runs at $O(N)$ multiplies per *output*
+sample rather than $O(N \cdot \text{rate change})$.
+
+## The polyphase decomposition theorem
+
+Given a length-$N$ FIR filter $H(z) = \sum_{n=0}^{N-1} h[n] z^{-n}$
+and an integer $M$, define the polyphase components
+
+$$
+E_k(z) = \sum_{n} h[nM + k] z^{-n}, \quad k = 0, 1, \ldots, M-1
+$$
+
+Then
+
+$$
+H(z) = \sum_{k=0}^{M-1} z^{-k} E_k(z^M)
+$$
+
+In words: $H(z)$ factors into $M$ sub-filters, each addressing every
+$M$th tap of the original.
+
+Combine that factorization with the Noble identity for decimation
+and you get the canonical polyphase decimator: the input commutates
+through the $M$ sub-filters round-robin, each running at the output
+rate. The total multiplier budget is $N$ per output sample (vs.
+$N \cdot M$ for filter-then-downsample). The library's
+[`PolyphaseDecimator`](../../acquisition/polyphase-decimator/) is
+exactly this construction.
+
+For interpolation, the dual: $L$ sub-filters each run at the input
+rate, and a commutator at the output picks which sub-filter's output
+to emit. `PolyphaseInterpolator` is this version.
+
+For rational $L/M$ rate change, both are combined: $L$ sub-filters
+at the slow rate, with a time-register that advances by $M$ per
+output and wraps modulo $L$. The library's `RationalResampler` (in
+`sw/dsp/conditioning/src.hpp`) implements this directly.
+
+### Channelization (filter banks)
+
+Bellanger's 1976 paper also showed that an $M$-channel uniform
+filter bank — splitting a wideband signal into $M$ contiguous
+channels — can be implemented as a single polyphase filter followed
+by an inverse FFT. The filter does the rate reduction; the FFT does
+the frequency-domain channel separation.
+
+The library doesn't yet ship a dedicated channelizer class, but the
+construction is straightforward to compose from `PolyphaseDecimator`
+plus the existing `dft` / `fft` primitives. See the
+[Pattern Catalog](./patterns/) for where this is a gap.
+
+## Pattern-to-API mapping
+
+For the full mapping of multirate problems to library APIs, see the
+[Pattern Catalog](./patterns/). The very short version:
+
+| You want to... | Use |
+|---|---|
+| Decimate by integer $M$ | `PolyphaseDecimator` |
+| Interpolate by integer $L$ | `PolyphaseInterpolator` |
+| Convert by rational $L/M$ | `RationalResampler` |
+| Decimate by 2 with sharp transition | `HalfBandFilter` |
+| Decimate by a large factor at the highest rate | `CICDecimator` |
+| Tune a band down to baseband | `DDC` |
+| Cascade multiple decimators | `DecimationChain` |
+
+Each row is covered in detail on the [pattern catalog](./patterns/)
+page, with worked examples and links to the per-component reference
+pages.
+
+## Where to go next
+
+- [Pattern Catalog](./patterns/) — problem→API table with worked examples
+- [Polyphase Decimator](../acquisition/polyphase-decimator/) — the foundational decimating-FIR primitive
+- [CIC](../acquisition/cic/) — Hogenauer's bulk-rate-reduction filter
+- [Half-Band](../acquisition/halfband/) — Mintzer's ↓2 stage with ~75% zero taps
+- [Decimation Chain](../acquisition/decimation-chain/) — composing the above
+- [DDC](../acquisition/ddc/) — receiver-front-end composition
+- [SDR Receiver Front-End Overview](../acquisition/overview/) — the SDR-specific application of these primitives
+
+## References
+
+- M. Bellanger, G. Bonnerot, M. Coudreuse, *"Digital Filtering by
+  Polyphase Network: Application to Sample-Rate Alteration and
+  Filter Banks,"* IEEE Trans. ASSP, 1976
+- E. B. Hogenauer, *"An Economical Class of Digital Filters for
+  Decimation and Interpolation,"* IEEE Trans. ASSP, 1981
+- F. Mintzer, *"On Half-Band, Third-Band, and Nth-Band FIR Filters
+  and Their Design,"* IEEE Trans. ASSP, 1982
+- R. E. Crochiere, L. R. Rabiner, *Multirate Digital Signal
+  Processing*, Prentice Hall, 1983
+- P. P. Vaidyanathan, *Multirate Systems and Filter Banks*,
+  Prentice Hall, 1993
+- F. Harris, *Multirate Signal Processing for Communication
+  Systems*, Prentice Hall, 2004

--- a/docs-site/src/content/docs/multirate/patterns.md
+++ b/docs-site/src/content/docs/multirate/patterns.md
@@ -19,7 +19,7 @@ see the [Multirate Overview](./overview/).
 | [Bulk rate reduction at high rate](#bulk-rate-reduction-cic) | First-stage decimation after a GHz ADC | `CICDecimator` | `acquisition/cic.hpp` |
 | [IF → baseband](#if-to-baseband-ddc) | Pull a band of interest down to 0 Hz | `DDC` | `acquisition/ddc.hpp` |
 | [Multi-stage decimation cascade](#multi-stage-cascade) | CIC → HB → polyphase chain | `DecimationChain` | `acquisition/decimation_chain.hpp` |
-| [Channelizer (M-channel filter bank)](#channelizer) | Split a wideband signal into channels | **gap** — compose from `PolyphaseDecimator` + FFT | `filter/fir/polyphase.hpp` + `spectral/dft.hpp` |
+| [Channelizer (M-channel filter bank)](#channelizer) | Split a wideband signal into channels | **gap** — compose from `PolyphaseDecimator` + FFT | `filter/fir/polyphase.hpp` + `spectral/fft.hpp` |
 
 Every row except the last has a first-class library API. The
 channelizer is a documented composition gap — see that section for
@@ -252,10 +252,14 @@ using Chain = DecimationChain<double,
     HalfBandFilter<double, double, double>,
     PolyphaseDecimator<double, double, double>>;
 
+// Half-band taps must be designed first; see the "Sharp 2:1
+// decimation" section above for design_halfband details.
+auto hb_taps = design_halfband<double>(31, 0.05);
+
 Chain chain(/*sample_rate=*/100e6,
-            CICDecimator<...>(64, 4),
-            HalfBandFilter<...>(31),
-            PolyphaseDecimator<...>(taps, 2));
+            CICDecimator<int64_t, int32_t>(64, 4),
+            HalfBandFilter<double, double, double>(hb_taps),
+            PolyphaseDecimator<double, double, double>(taps, 2));
 
 auto output = chain.process_block(adc_samples);
 ```

--- a/docs-site/src/content/docs/multirate/patterns.md
+++ b/docs-site/src/content/docs/multirate/patterns.md
@@ -19,7 +19,7 @@ see the [Multirate Overview](./overview/).
 | [Bulk rate reduction at high rate](#bulk-rate-reduction-cic) | First-stage decimation after a GHz ADC | `CICDecimator` | `acquisition/cic.hpp` |
 | [IF → baseband](#if-to-baseband-ddc) | Pull a band of interest down to 0 Hz | `DDC` | `acquisition/ddc.hpp` |
 | [Multi-stage decimation cascade](#multi-stage-cascade) | CIC → HB → polyphase chain | `DecimationChain` | `acquisition/decimation_chain.hpp` |
-| [Channelizer (M-channel filter bank)](#channelizer) | Split a wideband signal into channels | **gap** — compose from `PolyphaseDecimator` + FFT |
+| [Channelizer (M-channel filter bank)](#channelizer) | Split a wideband signal into channels | **gap** — compose from `PolyphaseDecimator` + FFT | `filter/fir/polyphase.hpp` + `spectral/dft.hpp` |
 
 Every row except the last has a first-class library API. The
 channelizer is a documented composition gap — see that section for

--- a/docs-site/src/content/docs/multirate/patterns.md
+++ b/docs-site/src/content/docs/multirate/patterns.md
@@ -101,12 +101,18 @@ non-trivial rational number, e.g., 44.1 kHz audio to 48 kHz
 $L \cdot f_s$), then decimate by $M$ (with anti-alias filter). Two
 big filters, both running at the unhelpful $L \cdot f_s$ rate.
 
-**Library solution:** [`RationalResampler<CoeffScalar, StateScalar, SampleScalar>`](https://github.com/stillwater-sc/mixed-precision-dsp/blob/main/include/sw/dsp/conditioning/src.hpp)
-combines polyphase interpolation by $L$ and decimation by $M$ into
-a single time-register pipeline that emits exactly the output samples
-that survive both stages. The shared anti-alias / anti-image filter
-is auto-designed as a Kaiser-windowed sinc of sufficient length to
-suppress aliases below a configurable noise floor.
+**Library solution:** `RationalResampler<CoeffScalar, StateScalar, SampleScalar>`
+(in `sw/dsp/conditioning/src.hpp`) combines polyphase interpolation
+by $L$ and decimation by $M$ into a single time-register pipeline
+that emits exactly the output samples that survive both stages. The
+shared anti-alias / anti-image filter is auto-designed as a
+Kaiser-windowed sinc of sufficient length to suppress aliases below
+a configurable noise floor.
+
+> **Docs gap:** `RationalResampler` doesn't yet have a dedicated
+> reference page under `conditioning/`. The header comments in
+> `sw/dsp/conditioning/src.hpp` are the source of truth until that
+> page is filed as a follow-up.
 
 ```cpp
 #include <sw/dsp/conditioning/src.hpp>
@@ -138,12 +144,21 @@ generic FIR of the same length.
 
 ```cpp
 #include <sw/dsp/acquisition/halfband.hpp>
+using namespace sw::dsp;
 
-// Length-31 half-band filter
-HalfBandFilter<double, double, double> hb(31);
+// Design a length-31 half-band (must be of the form 4K+3 — 31 = 4·7+3).
+// transition_width is normalized to fs (0.05 = 5% of the sample rate).
+auto taps = design_halfband<double>(31, 0.05);
 
-// Decimate by 2
-auto output = hb.process_decimate(input);
+// Construct the filter from the designed taps
+HalfBandFilter<double, double, double> hb(taps);
+
+// Block-decimate-by-2: returns a length-N/2 dense_vector
+auto output = hb.process_block_decimate(input);
+
+// Per-sample streaming variant returns std::pair<bool, SampleScalar>:
+//   auto [ready, y] = hb.process_decimate(x);
+//   if (ready) { /* y is the next decimated output */ }
 ```
 
 Cascade two or three half-bands for ↓4 or ↓8 with a transition that
@@ -204,7 +219,7 @@ the complex baseband for demodulation.
 #include <sw/dsp/acquisition/ddc.hpp>
 
 DDC<double, double, double, PolyphaseDecimator<double, double, double>>
-    ddc(/*f_IF/fs=*/0.1, /*1.0=*/1.0, decim);
+    ddc(/*center_frequency=*/0.1, /*sample_rate=*/1.0, decim);
 auto iq_baseband = ddc.process_block(real_input);
 ```
 

--- a/docs-site/src/content/docs/multirate/patterns.md
+++ b/docs-site/src/content/docs/multirate/patterns.md
@@ -81,9 +81,17 @@ and the outputs are emitted in turn. Cost is $\sim N$ multiplies per
 
 ```cpp
 #include <sw/dsp/filter/fir/polyphase.hpp>
+#include <sw/dsp/filter/fir/fir_design.hpp>
+#include <sw/dsp/windows/hamming.hpp>
+using namespace sw::dsp;
+
+// Design an anti-image lowpass for ↑4 (cutoff at fs_in/2 ≈ fs_out/8)
+auto win  = hamming_window<double>(64);
+auto taps = design_fir_lowpass<double>(64, 0.45 / 4.0, win);
 
 PolyphaseInterpolator<double, double, double> interp(taps, /*L=*/4);
-auto output = interp.process_block(input);   // length 4N
+mtl::vec::dense_vector<double> input = ...;   // length-N input
+auto output = interp.process_block(input);    // length 4N
 ```
 
 The class lives in `sw/dsp/filter/fir/polyphase.hpp` alongside
@@ -245,6 +253,11 @@ flow through the tuple in order.
 
 ```cpp
 #include <sw/dsp/acquisition/decimation_chain.hpp>
+#include <sw/dsp/acquisition/halfband.hpp>
+#include <sw/dsp/filter/fir/polyphase.hpp>
+#include <sw/dsp/filter/fir/fir_design.hpp>
+#include <sw/dsp/windows/hamming.hpp>
+using namespace sw::dsp;
 
 // CIC ↓64 -> HalfBand ↓2 -> Polyphase ↓2 = total ↓256
 using Chain = DecimationChain<double,
@@ -252,14 +265,15 @@ using Chain = DecimationChain<double,
     HalfBandFilter<double, double, double>,
     PolyphaseDecimator<double, double, double>>;
 
-// Half-band taps must be designed first; see the "Sharp 2:1
-// decimation" section above for design_halfband details.
-auto hb_taps = design_halfband<double>(31, 0.05);
+// Design taps for the two FIR-based stages (CIC needs none).
+auto hb_taps   = design_halfband<double>(31, 0.05);
+auto poly_win  = hamming_window<double>(64);
+auto poly_taps = design_fir_lowpass<double>(64, 0.45 / 2.0, poly_win);
 
 Chain chain(/*sample_rate=*/100e6,
             CICDecimator<int64_t, int32_t>(64, 4),
             HalfBandFilter<double, double, double>(hb_taps),
-            PolyphaseDecimator<double, double, double>(taps, 2));
+            PolyphaseDecimator<double, double, double>(poly_taps, 2));
 
 auto output = chain.process_block(adc_samples);
 ```

--- a/docs-site/src/content/docs/multirate/patterns.md
+++ b/docs-site/src/content/docs/multirate/patterns.md
@@ -1,0 +1,318 @@
+---
+title: Multirate Pattern Catalog
+description: Problem-to-API mapping for canonical multirate signal-processing patterns, with worked examples and links to per-component reference pages
+---
+
+This page maps the canonical multirate problems to the library's
+APIs. For the theory behind these mappings — the Noble identity,
+the polyphase decomposition theorem, the historical progression —
+see the [Multirate Overview](./overview/).
+
+## Quick reference
+
+| Pattern | Use case | Library API | Header |
+|---|---|---|---|
+| [Integer decimation by M](#integer-decimation) | Lower the sample rate by an integer factor | `PolyphaseDecimator` | `filter/fir/polyphase.hpp` |
+| [Integer interpolation by L](#integer-interpolation) | Raise the sample rate by an integer factor | `PolyphaseInterpolator` | `filter/fir/polyphase.hpp` |
+| [Rational L/M conversion](#rational-lm-conversion) | e.g. 44.1 kHz ↔ 48 kHz audio | `RationalResampler` | `conditioning/src.hpp` |
+| [Sharp 2:1 decimation](#sharp-21-decimation) | Tight stopband near $f_s/4$ | `HalfBandFilter` | `acquisition/halfband.hpp` |
+| [Bulk rate reduction at high rate](#bulk-rate-reduction-cic) | First-stage decimation after a GHz ADC | `CICDecimator` | `acquisition/cic.hpp` |
+| [IF → baseband](#if-to-baseband-ddc) | Pull a band of interest down to 0 Hz | `DDC` | `acquisition/ddc.hpp` |
+| [Multi-stage decimation cascade](#multi-stage-cascade) | CIC → HB → polyphase chain | `DecimationChain` | `acquisition/decimation_chain.hpp` |
+| [Channelizer (M-channel filter bank)](#channelizer) | Split a wideband signal into channels | **gap** — compose from `PolyphaseDecimator` + FFT |
+
+Every row except the last has a first-class library API. The
+channelizer is a documented composition gap — see that section for
+the construction.
+
+---
+
+## Integer decimation
+
+**Problem:** A signal sampled at $f_s$ contains content only up to
+$f_s / (2M)$, and you want to lower the sample rate by an integer
+factor $M$ to match.
+
+**Naive solution:** Filter the signal with a lowpass at $f_s / (2M)$,
+then keep every $M$th sample. Wastes $M-1$ out of every $M$ filter
+multiplications.
+
+**Library solution:** [`PolyphaseDecimator<CoeffScalar, StateScalar, SampleScalar>`](../../acquisition/polyphase-decimator/)
+implements the polyphase decomposition. A length-$N$ filter
+decimating by $M$ runs at $\sim N/M$ multiplies per *input* sample
+(equivalently, $N$ multiplies per *output* sample) instead of $N$
+per input sample.
+
+```cpp
+#include <sw/dsp/filter/fir/polyphase.hpp>
+using namespace sw::dsp;
+
+// Design an anti-alias lowpass for ↓4 (cutoff just below fs/8)
+auto win = hamming_window<double>(64);
+auto taps = design_fir_lowpass<double>(64, 0.45 / 4.0, win);
+
+// Polyphase decimator with double-precision coefficients/state
+PolyphaseDecimator<double, double, double> decim(taps, 4);
+
+mtl::vec::dense_vector<double> input = ...;     // length-N input
+auto output = decim.process_block(input);       // length-N/4
+```
+
+**See also:** [Polyphase Decimator reference](../../acquisition/polyphase-decimator/).
+
+---
+
+## Integer interpolation
+
+**Problem:** A signal sampled at $f_s$ needs to be expressed at
+$L \cdot f_s$, e.g., for D/A conversion at a higher oversampling
+ratio.
+
+**Naive solution:** Insert $L-1$ zeros between each input sample,
+then run a lowpass at $L \cdot f_s$ to remove the resulting spectral
+images. The filter sees mostly zeros — most of its multiplications
+are wasted.
+
+**Library solution:** `PolyphaseInterpolator<CoeffScalar, StateScalar, SampleScalar>`
+runs the dual of polyphase decimation. The filter coefficients split
+into $L$ sub-filters; each input sample feeds all $L$ sub-filters,
+and the outputs are emitted in turn. Cost is $\sim N$ multiplies per
+*input* sample, distributed evenly across the $L$ output samples.
+
+```cpp
+#include <sw/dsp/filter/fir/polyphase.hpp>
+
+PolyphaseInterpolator<double, double, double> interp(taps, /*L=*/4);
+auto output = interp.process_block(input);   // length 4N
+```
+
+The class lives in `sw/dsp/filter/fir/polyphase.hpp` alongside
+`PolyphaseDecimator`. See the polyphase header for the full API.
+
+---
+
+## Rational L/M conversion
+
+**Problem:** Convert from one rate to another where the ratio is a
+non-trivial rational number, e.g., 44.1 kHz audio to 48 kHz
+($L/M = 160/147$) or vice versa.
+
+**Naive solution:** Interpolate by $L$ (with anti-image filter at
+$L \cdot f_s$), then decimate by $M$ (with anti-alias filter). Two
+big filters, both running at the unhelpful $L \cdot f_s$ rate.
+
+**Library solution:** [`RationalResampler<CoeffScalar, StateScalar, SampleScalar>`](https://github.com/stillwater-sc/mixed-precision-dsp/blob/main/include/sw/dsp/conditioning/src.hpp)
+combines polyphase interpolation by $L$ and decimation by $M$ into
+a single time-register pipeline that emits exactly the output samples
+that survive both stages. The shared anti-alias / anti-image filter
+is auto-designed as a Kaiser-windowed sinc of sufficient length to
+suppress aliases below a configurable noise floor.
+
+```cpp
+#include <sw/dsp/conditioning/src.hpp>
+using namespace sw::dsp;
+
+// 44.1 kHz -> 48 kHz: L=160, M=147
+RationalResampler<double, double, double> rs(/*L=*/160, /*M=*/147);
+auto out_48k = rs.process_block(in_44k1);
+```
+
+The class auto-designs the prototype filter from `(L, M, stopband_dB)`
+parameters; you don't need to design taps yourself. See
+`sw/dsp/conditioning/src.hpp` for the full constructor signature.
+
+---
+
+## Sharp 2:1 decimation
+
+**Problem:** You need to decimate by 2 with a *sharp* transition
+near $f_s / 4$, where a generic FIR would need a long impulse
+response.
+
+**Library solution:** [`HalfBandFilter`](../../acquisition/halfband/)
+exploits the half-band identity (Mintzer 1982): in a properly
+designed half-band filter, every other coefficient (except the
+center tap) is **exactly zero**. So a length-$(4K+3)$ half-band has
+only $K+2$ non-zero taps — the per-output cost is roughly half of a
+generic FIR of the same length.
+
+```cpp
+#include <sw/dsp/acquisition/halfband.hpp>
+
+// Length-31 half-band filter
+HalfBandFilter<double, double, double> hb(31);
+
+// Decimate by 2
+auto output = hb.process_decimate(input);
+```
+
+Cascade two or three half-bands for ↓4 or ↓8 with a transition that
+gets progressively sharper at each stage's reduced rate. The
+[Decimation Chain](#multi-stage-cascade) section shows this pattern.
+
+**See also:** [Half-Band Filter reference](../../acquisition/halfband/).
+
+---
+
+## Bulk rate reduction (CIC)
+
+**Problem:** Your input rate is so high (>>100 MHz) that any FIR
+multiplier-based filter is too expensive for the first decimation
+stage.
+
+**Library solution:** [`CICDecimator`](../../acquisition/cic/)
+implements Hogenauer's 1981 cascaded-integrator-comb structure: $M$
+integrators at the input rate, downsample by $R$, $M$ comb stages at
+the output rate. **No multipliers** — only adders and subtractors.
+
+The cost is a $\text{sinc}^M$ passband droop that downstream stages
+have to compensate (a half-band stage with a slight inverse-sinc
+shape, or a dedicated [droop compensator](../../acquisition/decimation-chain/#cic-droop-compensation)).
+
+```cpp
+#include <sw/dsp/acquisition/cic.hpp>
+
+// 4-stage CIC, decimating by 64
+CICDecimator<int64_t, int32_t> cic(/*R=*/64, /*M=*/4);
+auto coarse_baseband = cic.process_block(adc_samples);
+```
+
+**Important:** the CIC integrator structurally requires
+two's-complement-wrapping state. `fixpnt` works; `float` and `posit`
+accumulate uncorrectable drift on DC bias. See the
+[SDR demo](../../acquisition/demo/) for an empirical demonstration
+of this constraint.
+
+**See also:** [CIC reference](../../acquisition/cic/).
+
+---
+
+## IF to baseband (DDC)
+
+**Problem:** A real-valued ADC stream contains a band of interest
+centered at some intermediate frequency $f_\text{IF}$, and you need
+the complex baseband for demodulation.
+
+**Library solution:** [`DDC`](../../acquisition/ddc/) composes:
+
+1. An [`NCO`](../../acquisition/nco/) at $f_\text{IF} / f_s$ producing
+   $\cos(\omega n) + j\sin(\omega n)$
+2. A complex multiplier (mixer) that shifts the spectrum down by $f_\text{IF}$
+3. A polyphase decimator that anti-alias-filters and reduces the rate
+
+```cpp
+#include <sw/dsp/acquisition/ddc.hpp>
+
+DDC<double, double, double, PolyphaseDecimator<double, double, double>>
+    ddc(/*f_IF/fs=*/0.1, /*1.0=*/1.0, decim);
+auto iq_baseband = ddc.process_block(real_input);
+```
+
+The DDC is the primary front-end of any SDR receiver. See the
+[SDR Receiver Front-End Overview](../../acquisition/overview/) for
+how this composes into a full receiver chain.
+
+**See also:** [DDC reference](../../acquisition/ddc/).
+
+---
+
+## Multi-stage cascade
+
+**Problem:** A single huge decimation factor (say ↓1024 from 100 MHz
+to 100 kHz) won't be efficient as a single filter. Each stage of a
+multistage cascade can target its own bandwidth and arithmetic
+constraints.
+
+**Library solution:** [`DecimationChain<SampleScalar, Stage1, Stage2, ...>`](../../acquisition/decimation-chain/)
+is a variadic-tuple wrapper that composes any sequence of decimators
+into a single pipeline. Each stage operates at its own rate; samples
+flow through the tuple in order.
+
+```cpp
+#include <sw/dsp/acquisition/decimation_chain.hpp>
+
+// CIC ↓64 -> HalfBand ↓2 -> Polyphase ↓2 = total ↓256
+using Chain = DecimationChain<double,
+    CICDecimator<int64_t, int32_t>,
+    HalfBandFilter<double, double, double>,
+    PolyphaseDecimator<double, double, double>>;
+
+Chain chain(/*sample_rate=*/100e6,
+            CICDecimator<...>(64, 4),
+            HalfBandFilter<...>(31),
+            PolyphaseDecimator<...>(taps, 2));
+
+auto output = chain.process_block(adc_samples);
+```
+
+`DecimationChain` accepts any tuple ordering; the ordering shown
+above (CIC at the top to take advantage of multiplier-free bulk
+reduction, half-band in the middle for sharp 2:1, polyphase at the
+bottom for final shaping) is the canonical receiver-chain pattern,
+but is not enforced.
+
+**See also:** [Decimation Chain reference](../../acquisition/decimation-chain/).
+
+---
+
+## Channelizer
+
+**Problem:** A wideband signal contains $M$ contiguous frequency
+channels, and you want each channel separately at its own
+(reduced) rate.
+
+**Naive solution:** Run $M$ independent DDCs, each tuning to one
+channel and decimating by $M$. Cost is $M$× a single DDC.
+
+**Bellanger's solution:** A single polyphase filter followed by an
+inverse FFT can produce all $M$ channel outputs simultaneously, at
+roughly the cost of *one* polyphase filter plus one $M$-point IFFT
+per output sample. This is the polyphase channelizer.
+
+**Library status:** The library doesn't yet ship a dedicated
+`Channelizer` class, but the construction is straightforward from
+existing primitives:
+
+```cpp
+// Sketch — not yet a library class
+// 1. Length-MN polyphase prototype filter, decomposed into M subfilters
+//    each of length N
+// 2. For each output frame:
+//      - Push M new input samples through the M sub-filters in
+//        parallel (each subfilter advances by 1 sample)
+//      - Stack the M sub-filter outputs into a length-M vector
+//      - Take the M-point IFFT of that vector
+//      - Output is M parallel channels, each at fs/M
+```
+
+**This is a documented gap.** Filing a follow-up issue to add either
+a thin `Channelizer` wrapper class or a worked-example demo would be
+appropriate. The polyphase + FFT primitives needed for the
+construction are already in the library
+(`filter/fir/polyphase.hpp` + `spectral/fft.hpp`).
+
+---
+
+## Choosing among similar APIs
+
+A few rules of thumb when more than one API could plausibly apply:
+
+**Decimation by 2:** Use `HalfBandFilter`, not `PolyphaseDecimator`.
+The half-band's ~75% zero coefficients make it cheaper than a
+generic polyphase by 2.
+
+**Decimation by a large factor at the highest rate:** Use
+`CICDecimator` for the bulk reduction, then half-bands and a
+polyphase for shaping. A single polyphase by, say, 64 would need a
+~hundreds-of-taps prototype filter running at the output rate — the
+CIC + cascade is much cheaper.
+
+**Rational L/M with $L$ or $M$ very large:** `RationalResampler`
+auto-designs the prototype filter, but if the ratio is very lopsided
+(e.g., ×100 / ÷1) consider whether a multistage cascade would be
+better. For the typical audio ratios (160/147 etc.) the single
+`RationalResampler` stage is the right answer.
+
+**Mixed integer + rational:** Cascade them. Use `CICDecimator` for
+the first integer ↓R, then `RationalResampler` for the final L/M
+shaping at the much lower rate.

--- a/docs-site/src/content/docs/multirate/patterns.md
+++ b/docs-site/src/content/docs/multirate/patterns.md
@@ -45,6 +45,8 @@ per input sample.
 
 ```cpp
 #include <sw/dsp/filter/fir/polyphase.hpp>
+#include <sw/dsp/filter/fir/fir_design.hpp>
+#include <sw/dsp/windows/hamming.hpp>
 using namespace sw::dsp;
 
 // Design an anti-alias lowpass for ↓4 (cutoff just below fs/8)
@@ -225,9 +227,19 @@ the complex baseband for demodulation.
 
 ```cpp
 #include <sw/dsp/acquisition/ddc.hpp>
+#include <sw/dsp/filter/fir/polyphase.hpp>
+#include <sw/dsp/filter/fir/fir_design.hpp>
+#include <sw/dsp/windows/hamming.hpp>
+using namespace sw::dsp;
+
+// Anti-alias / channel-shaping FIR for the embedded polyphase decimator
+auto win  = hamming_window<double>(32);
+auto taps = design_fir_lowpass<double>(32, 0.2, win);
+PolyphaseDecimator<double, double, double> decim(taps, 2);
 
 DDC<double, double, double, PolyphaseDecimator<double, double, double>>
     ddc(/*center_frequency=*/0.1, /*sample_rate=*/1.0, decim);
+mtl::vec::dense_vector<double> real_input = ...;   // length-N ADC stream
 auto iq_baseband = ddc.process_block(real_input);
 ```
 


### PR DESCRIPTION
## Summary

Resolves the P0 + P2 work from #130: a new \`Multirate Signal Processing\` doc section that fills the gap between the per-component reference pages (CIC, half-band, polyphase, DDC, decimation chain, rational resampler) and the conceptual narrative readers expect when they have a concrete multirate problem in mind.

Phase 3 (worked demo applications under \`applications/multirate_examples/\`) is deliberately **deferred** — issue #130 estimates 2-3 days per demo. Filing a follow-up issue for each demo is appropriate when the user is ready to start that work.

## What landed

### Phase 1 — Landing page (P0)
\`docs-site/src/content/docs/multirate/overview.md\` — frames the multirate landscape, walks the historical progression (Bellanger 1976 → Hogenauer 1981 → Mintzer 1982 → DDC ASICs → SDR → mixed-precision era), states the Noble identity and polyphase decomposition theorem with worked examples, ends with a pattern-to-API table.

### Phase 2 — Pattern catalog (P0)
\`docs-site/src/content/docs/multirate/patterns.md\` — eight canonical multirate problems each get a section with problem statement, naive solution, library API, and worked code example. The channelizer is documented as a composition gap (compose from \`PolyphaseDecimator\` + FFT) — appropriate to file a follow-up issue for a first-class \`Channelizer\` wrapper.

### Phase 4 — Cross-references + sidebar wiring (P2)
- \`astro.config.mjs\`: new sidebar section between \`Filter Design\` and \`Software-Defined Radio\`
- 6 component pages (cic, ddc, decimation-chain, halfband, polyphase-decimator, filter/fir/polyphase) get an italic prefix under the frontmatter pointing back to multirate/overview + multirate/patterns
- \`acquisition/overview.md\` \"See also\" gains a multirate entry as the receiver-specific specialization of multirate

## Files changed

| File | Change |
|---|---|
| \`docs-site/src/content/docs/multirate/overview.md\` | NEW — 220 lines |
| \`docs-site/src/content/docs/multirate/patterns.md\` | NEW — 250 lines |
| \`docs-site/astro.config.mjs\` | +4 lines (new sidebar entry) |
| \`docs-site/src/content/docs/acquisition/overview.md\` | +5 lines (See also entry) |
| \`docs-site/src/content/docs/acquisition/{cic,ddc,decimation-chain,halfband,polyphase-decimator}.md\` | +2 lines each (multirate cross-link prefix) |
| \`docs-site/src/content/docs/filter/fir/polyphase.md\` | +2 lines (multirate cross-link prefix) |

## Verification

- \`npm run build\` in \`docs-site/\` passes
- 58 pages built (was 55, +2 new + 1 sidebar regroup)
- All internal links (\`./patterns/\`, \`../multirate/overview/\`, \`../../multirate/patterns/\` etc.) resolve

## Test plan
- [ ] Fast CI passes
- [ ] CodeRabbit review
- [ ] Visual check on the deployed Starlight site
- [ ] When satisfied: \`gh pr ready <PR#>\` and merge
- [ ] File follow-up issues for the 3-4 Phase 3 demos when ready to start that work

Resolves #130

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "Multirate Signal Processing Overview" covering concepts, theory, and library abstractions.
  * Introduced a Multirate pattern catalog mapping common problems to library APIs with examples and guidance.
  * Added a new sidebar section to surface Multirate Signal Processing docs.
  * Updated multiple existing pages with cross-references to the new overview and pattern catalog for improved navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->