### PR TITLE
feat(instrument): trigger primitive library (#140)

### DIFF
--- a/include/sw/dsp/instrument/trigger.hpp
+++ b/include/sw/dsp/instrument/trigger.hpp
@@ -1,0 +1,342 @@
+#pragma once
+// trigger.hpp: Trigger primitives for instrument-style data acquisition.
+//
+// A composable library of streaming primitives that turn a stream of samples
+// into a stream of trigger events. Foundational building block for both
+// the digital oscilloscope (#133) and the spectrum analyzer (#134, zero-span
+// mode and sweep-control gating) demonstrators.
+//
+// Primitives:
+//   EdgeTrigger     — rising / falling / either crossing of a level
+//                     with optional hysteresis to suppress noise re-triggers
+//   LevelTrigger    — convenience for EdgeTrigger with Slope::Either
+//   SlopeTrigger    — fires when |x[n] - x[n-1]| exceeds a threshold
+//                     with a sign (positive / negative / either)
+//   HoldoffWrapper  — wraps any trigger and suppresses re-triggering for
+//                     N samples after a fire (the inner trigger is still
+//                     driven during the holdoff so its state stays sane)
+//   QualifierAnd    — fires when two triggers both fire within a window
+//   QualifierOr     — fires when either of two triggers fires
+//
+// All primitives are parameterized on a single SampleScalar type. Comparisons
+// are precision-sensitive at low signal amplitudes — narrow types may
+// quantize the comparison threshold below the smallest detectable edge.
+// The tests exercise this characterization explicitly.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp::instrument {
+
+// Direction of a trigger fire.
+//
+// `Rising`  fires only when the signal crosses up through the level
+// `Falling` fires only when the signal crosses down through the level
+// `Either`  fires on both directions
+enum class Slope { Rising, Falling, Either };
+
+// =============================================================================
+// EdgeTrigger
+//
+// Tracks whether the signal is currently in the "above" or "below" region,
+// where the boundary is `level ± hysteresis/2`. A fire happens when the signal
+// crosses out of one region and into the other (with the slope filter applied).
+// Hysteresis = 0 means the level itself is the boundary.
+// =============================================================================
+template <DspScalar SampleScalar>
+class EdgeTrigger {
+public:
+	using sample_scalar = SampleScalar;
+
+	EdgeTrigger(SampleScalar level,
+	            Slope        slope     = Slope::Rising,
+	            SampleScalar hysteresis = SampleScalar{0})
+		: level_(level),
+		  slope_(slope),
+		  hysteresis_(hysteresis),
+		  upper_(level + half(hysteresis)),
+		  lower_(level - half(hysteresis)),
+		  state_(Region::Unknown),
+		  samples_since_(0) {
+		if (hysteresis < SampleScalar{0})
+			throw std::invalid_argument("EdgeTrigger: hysteresis must be >= 0");
+	}
+
+	// Push one sample. Returns true on this sample if it caused a trigger event.
+	bool process(SampleScalar x) {
+		++samples_since_;
+
+		// Determine which side of the hysteresis band we're in.
+		Region next = state_;
+		if (x > upper_)       next = Region::Above;
+		else if (x < lower_)  next = Region::Below;
+		// If we're inside the band, state is unchanged (this is the
+		// hysteresis behavior — small noise excursions don't flip state).
+
+		const bool rose  = (state_ == Region::Below)   && (next == Region::Above);
+		const bool fell  = (state_ == Region::Above)   && (next == Region::Below);
+		state_ = next;
+
+		bool fire = false;
+		switch (slope_) {
+			case Slope::Rising:  fire = rose;          break;
+			case Slope::Falling: fire = fell;          break;
+			case Slope::Either:  fire = rose || fell;  break;
+		}
+		if (fire) samples_since_ = 0;
+		return fire;
+	}
+
+	// Number of samples processed since the last fire (or since construction
+	// if no fires yet). Reset to 0 when a fire occurs.
+	std::size_t samples_since_trigger() const { return samples_since_; }
+
+	void reset() {
+		state_ = Region::Unknown;
+		samples_since_ = 0;
+	}
+
+private:
+	enum class Region { Unknown, Above, Below };
+
+	// Compute hysteresis/2 in SampleScalar without requiring division
+	// (DspScalar doesn't include /). Multiplication by 0.5 works through
+	// the SampleScalar(double) ctor for every supported numeric type.
+	static SampleScalar half(SampleScalar h) {
+		return h * static_cast<SampleScalar>(0.5);
+	}
+
+	SampleScalar level_;
+	Slope        slope_;
+	SampleScalar hysteresis_;
+	SampleScalar upper_;
+	SampleScalar lower_;
+	Region       state_;
+	std::size_t  samples_since_;
+};
+
+// =============================================================================
+// LevelTrigger — EdgeTrigger with Slope::Either, named for ergonomics
+// =============================================================================
+template <DspScalar SampleScalar>
+class LevelTrigger {
+public:
+	using sample_scalar = SampleScalar;
+
+	LevelTrigger(SampleScalar level,
+	             SampleScalar hysteresis = SampleScalar{0})
+		: edge_(level, Slope::Either, hysteresis) {}
+
+	bool        process(SampleScalar x)         { return edge_.process(x); }
+	std::size_t samples_since_trigger() const   { return edge_.samples_since_trigger(); }
+	void        reset()                         { edge_.reset(); }
+
+private:
+	EdgeTrigger<SampleScalar> edge_;
+};
+
+// =============================================================================
+// SlopeTrigger
+//
+// Fires when the first difference x[n] - x[n-1] exceeds threshold in magnitude
+// with the requested sign. Useful for detecting fast transitions independent
+// of absolute level.
+// =============================================================================
+template <DspScalar SampleScalar>
+class SlopeTrigger {
+public:
+	using sample_scalar = SampleScalar;
+
+	SlopeTrigger(SampleScalar threshold, Slope sign = Slope::Rising)
+		: threshold_(threshold),
+		  sign_(sign),
+		  prev_(SampleScalar{0}),
+		  has_prev_(false),
+		  samples_since_(0) {
+		if (threshold < SampleScalar{0})
+			throw std::invalid_argument("SlopeTrigger: threshold must be >= 0");
+	}
+
+	bool process(SampleScalar x) {
+		++samples_since_;
+		if (!has_prev_) {
+			prev_     = x;
+			has_prev_ = true;
+			return false;
+		}
+		const SampleScalar diff = x - prev_;
+		prev_ = x;
+
+		const bool pos_fire = (diff >  threshold_);
+		const bool neg_fire = (diff < -threshold_);
+
+		bool fire = false;
+		switch (sign_) {
+			case Slope::Rising:  fire = pos_fire;            break;
+			case Slope::Falling: fire = neg_fire;            break;
+			case Slope::Either:  fire = pos_fire || neg_fire; break;
+		}
+		if (fire) samples_since_ = 0;
+		return fire;
+	}
+
+	std::size_t samples_since_trigger() const { return samples_since_; }
+
+	void reset() {
+		has_prev_      = false;
+		prev_          = SampleScalar{0};
+		samples_since_ = 0;
+	}
+
+private:
+	SampleScalar threshold_;
+	Slope        sign_;
+	SampleScalar prev_;
+	bool         has_prev_;
+	std::size_t  samples_since_;
+};
+
+// =============================================================================
+// HoldoffWrapper
+//
+// Wraps any trigger primitive and suppresses re-triggering for `holdoff`
+// samples after a fire. The inner trigger is STILL driven during the holdoff
+// window so its internal state (e.g., the prev-sample for SlopeTrigger or the
+// region state for EdgeTrigger) stays consistent — otherwise the very next
+// sample after holdoff would see a stale internal state and potentially fire
+// spuriously.
+// =============================================================================
+template <class Inner>
+class HoldoffWrapper {
+public:
+	using sample_scalar = typename Inner::sample_scalar;
+
+	HoldoffWrapper(Inner inner, std::size_t holdoff_samples)
+		: inner_(std::move(inner)),
+		  holdoff_(holdoff_samples),
+		  remaining_(0),
+		  samples_since_(0) {}
+
+	bool process(sample_scalar x) {
+		++samples_since_;
+
+		// During holdoff: drive inner for state continuity, suppress fire.
+		if (remaining_ > 0) {
+			--remaining_;
+			(void)inner_.process(x);
+			return false;
+		}
+
+		if (inner_.process(x)) {
+			remaining_     = holdoff_;
+			samples_since_ = 0;
+			return true;
+		}
+		return false;
+	}
+
+	std::size_t samples_since_trigger() const { return samples_since_; }
+
+	void reset() {
+		inner_.reset();
+		remaining_     = 0;
+		samples_since_ = 0;
+	}
+
+private:
+	Inner       inner_;
+	std::size_t holdoff_;
+	std::size_t remaining_;
+	std::size_t samples_since_;
+};
+
+// =============================================================================
+// QualifierAnd
+//
+// Fires when both wrapped triggers have fired within `window` samples of
+// each other. The window is the maximum age (in samples) of an A fire that
+// can still be "joined" by a fresh B fire (or vice versa).
+//
+// On an AND fire, both triggers' age counters reset, so the same coincidence
+// can't fire twice.
+// =============================================================================
+template <class TrigA, class TrigB>
+class QualifierAnd {
+public:
+	using sample_a = typename TrigA::sample_scalar;
+	using sample_b = typename TrigB::sample_scalar;
+
+	QualifierAnd(TrigA a, TrigB b, std::size_t window_samples = 1)
+		: a_(std::move(a)),
+		  b_(std::move(b)),
+		  window_(window_samples),
+		  since_a_(kInf),
+		  since_b_(kInf) {}
+
+	bool process(sample_a xa, sample_b xb) {
+		if (since_a_ != kInf && since_a_ < kInf - 1) ++since_a_;
+		if (since_b_ != kInf && since_b_ < kInf - 1) ++since_b_;
+
+		if (a_.process(xa)) since_a_ = 0;
+		if (b_.process(xb)) since_b_ = 0;
+
+		if (since_a_ <= window_ && since_b_ <= window_) {
+			since_a_ = kInf;
+			since_b_ = kInf;
+			return true;
+		}
+		return false;
+	}
+
+	void reset() {
+		a_.reset();
+		b_.reset();
+		since_a_ = kInf;
+		since_b_ = kInf;
+	}
+
+private:
+	static constexpr std::size_t kInf = std::numeric_limits<std::size_t>::max();
+	TrigA       a_;
+	TrigB       b_;
+	std::size_t window_;
+	std::size_t since_a_;
+	std::size_t since_b_;
+};
+
+// =============================================================================
+// QualifierOr — fires whenever either inner trigger fires on the same sample.
+// =============================================================================
+template <class TrigA, class TrigB>
+class QualifierOr {
+public:
+	using sample_a = typename TrigA::sample_scalar;
+	using sample_b = typename TrigB::sample_scalar;
+
+	QualifierOr(TrigA a, TrigB b)
+		: a_(std::move(a)), b_(std::move(b)) {}
+
+	bool process(sample_a xa, sample_b xb) {
+		const bool fa = a_.process(xa);
+		const bool fb = b_.process(xb);
+		return fa || fb;
+	}
+
+	void reset() {
+		a_.reset();
+		b_.reset();
+	}
+
+private:
+	TrigA a_;
+	TrigB b_;
+};
+
+} // namespace sw::dsp::instrument

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,3 +102,6 @@ dsp_add_test(test_decimation_chain)
 
 # Acquisition pipeline precision analysis (Issue #92)
 dsp_add_test(test_acquisition_precision)
+
+# Instrument trigger primitives (Issue #140)
+dsp_add_test(test_instrument_trigger)

--- a/tests/test_instrument_trigger.cpp
+++ b/tests/test_instrument_trigger.cpp
@@ -1,0 +1,403 @@
+// test_instrument_trigger.cpp: tests for the trigger primitive library.
+//
+// Coverage:
+//   - EdgeTrigger: rising / falling / either, hysteresis, samples_since_trigger
+//   - LevelTrigger: ergonomic alias for EdgeTrigger w/ Slope::Either
+//   - SlopeTrigger: positive / negative / either signs, threshold gating
+//   - HoldoffWrapper: suppresses fires within window; inner state stays sane
+//   - QualifierAnd: coincidence within window; non-coincidence stays silent
+//   - QualifierOr: per-sample disjunction
+//   - Precision sweep: minimum-detectable-edge degradation as SampleScalar
+//                       narrows (double / float / posit32 / posit16)
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)` rather
+// than assert(); CI runs in Release where assert is stripped.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <sw/dsp/instrument/trigger.hpp>
+#include <sw/universal/number/posit/posit.hpp>
+
+using namespace sw::dsp::instrument;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+// ============================================================================
+// EdgeTrigger — basic rising / falling / either
+// ============================================================================
+
+void test_edge_rising() {
+	EdgeTrigger<double> t(/*level=*/0.5, Slope::Rising);
+	// Below the level — no fires
+	REQUIRE(!t.process(0.0));
+	REQUIRE(!t.process(0.2));
+	REQUIRE(!t.process(0.4));
+	// Cross up — fires
+	REQUIRE(t.process(0.7));
+	// Stay above — no re-fire
+	REQUIRE(!t.process(0.8));
+	REQUIRE(!t.process(1.0));
+	// Cross back down — no fire (Rising slope only)
+	REQUIRE(!t.process(0.3));
+	// Cross up again — fires
+	REQUIRE(t.process(0.6));
+	std::cout << "  edge_rising: passed\n";
+}
+
+void test_edge_falling() {
+	EdgeTrigger<double> t(/*level=*/0.5, Slope::Falling);
+	// Start above — no fire on entry (state was Unknown, transitioning to Above)
+	REQUIRE(!t.process(0.7));
+	// Cross down — fires
+	REQUIRE(t.process(0.3));
+	// Stay below — no re-fire
+	REQUIRE(!t.process(0.0));
+	// Cross up — no fire (Falling slope only)
+	REQUIRE(!t.process(0.8));
+	// Cross down again — fires
+	REQUIRE(t.process(0.2));
+	std::cout << "  edge_falling: passed\n";
+}
+
+void test_edge_either() {
+	EdgeTrigger<double> t(/*level=*/0.5, Slope::Either);
+	REQUIRE(!t.process(0.0));   // Below
+	REQUIRE(t.process(0.7));    // Up — fires
+	REQUIRE(t.process(0.2));    // Down — fires
+	REQUIRE(t.process(0.8));    // Up — fires
+	REQUIRE(!t.process(0.9));   // Stay above — no fire
+	std::cout << "  edge_either: passed\n";
+}
+
+// ============================================================================
+// EdgeTrigger — hysteresis
+// ============================================================================
+
+void test_edge_hysteresis() {
+	// Hysteresis = 0.2 means: upper boundary = 0.6, lower = 0.4.
+	// Signal must cross OUT of one band and INTO the other; samples in
+	// [0.4, 0.6] don't change the region.
+	EdgeTrigger<double> t(/*level=*/0.5, Slope::Either, /*hysteresis=*/0.2);
+	REQUIRE(!t.process(0.0));   // Below
+	REQUIRE(!t.process(0.45));  // Inside band — state stays Below
+	REQUIRE(!t.process(0.55));  // Inside band — state still Below
+	REQUIRE(t.process(0.7));    // Out the top — fires (Below -> Above)
+	REQUIRE(!t.process(0.55));  // Inside band — state stays Above
+	REQUIRE(!t.process(0.45));  // Inside band — still Above
+	REQUIRE(t.process(0.3));    // Out the bottom — fires (Above -> Below)
+	std::cout << "  edge_hysteresis: passed\n";
+}
+
+void test_edge_hysteresis_suppresses_noise() {
+	// Without hysteresis, repeated noise around level fires every crossing.
+	// With hysteresis, dwell within the band is silent.
+	EdgeTrigger<double> nonoise(/*level=*/0.5, Slope::Either, /*hyst=*/0.0);
+	EdgeTrigger<double> hyst(/*level=*/0.5, Slope::Either,    /*hyst=*/0.2);
+	const std::vector<double> noisy = {0.0, 0.51, 0.49, 0.51, 0.49, 0.51, 1.0};
+	int nonoise_fires = 0;
+	int hyst_fires    = 0;
+	for (double x : noisy) {
+		if (nonoise.process(x)) ++nonoise_fires;
+		if (hyst.process(x))    ++hyst_fires;
+	}
+	REQUIRE(nonoise_fires >= 4);   // every noise wiggle counts
+	REQUIRE(hyst_fires == 1);      // only the final clean cross matters
+	std::cout << "  edge_hysteresis_suppresses_noise: passed\n";
+}
+
+void test_edge_negative_hysteresis_throws() {
+	bool threw = false;
+	try { EdgeTrigger<double>(0.5, Slope::Rising, -0.1); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  edge_negative_hysteresis_throws: passed\n";
+}
+
+// ============================================================================
+// EdgeTrigger — samples_since_trigger
+// ============================================================================
+
+void test_samples_since() {
+	EdgeTrigger<double> t(0.5, Slope::Rising);
+	REQUIRE(t.samples_since_trigger() == 0);
+	t.process(0.0);  // 1
+	t.process(0.0);  // 2
+	t.process(0.0);  // 3
+	REQUIRE(t.samples_since_trigger() == 3);
+	t.process(0.7);  // fires; counter resets
+	REQUIRE(t.samples_since_trigger() == 0);
+	t.process(0.8);  // 1
+	t.process(0.9);  // 2
+	REQUIRE(t.samples_since_trigger() == 2);
+	std::cout << "  samples_since: passed\n";
+}
+
+// ============================================================================
+// LevelTrigger
+// ============================================================================
+
+void test_level_trigger() {
+	LevelTrigger<double> t(0.5);
+	REQUIRE(!t.process(0.0));
+	REQUIRE(t.process(0.7));   // up
+	REQUIRE(t.process(0.3));   // down
+	REQUIRE(t.process(0.7));   // up
+	std::cout << "  level_trigger: passed\n";
+}
+
+// ============================================================================
+// SlopeTrigger
+// ============================================================================
+
+void test_slope_positive() {
+	SlopeTrigger<double> t(/*threshold=*/0.5, Slope::Rising);
+	t.process(0.0);            // first sample, no fire
+	REQUIRE(!t.process(0.3));  // diff = +0.3, below threshold
+	REQUIRE(t.process(0.9));   // diff = +0.6, above threshold, positive — fires
+	REQUIRE(t.process(1.5));   // diff = +0.6 again — independent step, fires too
+	REQUIRE(!t.process(1.7));  // diff = +0.2, below threshold
+	REQUIRE(!t.process(0.5));  // diff = -1.2, large but Rising slope only
+	std::cout << "  slope_positive: passed\n";
+}
+
+void test_slope_negative() {
+	SlopeTrigger<double> t(0.5, Slope::Falling);
+	t.process(1.0);
+	REQUIRE(!t.process(0.7));  // diff = -0.3
+	REQUIRE(t.process(0.0));   // diff = -0.7 — fires
+	REQUIRE(!t.process(0.5));  // diff = +0.5, but Falling slope ignores positives
+	std::cout << "  slope_negative: passed\n";
+}
+
+void test_slope_either() {
+	SlopeTrigger<double> t(0.5, Slope::Either);
+	t.process(0.0);
+	REQUIRE(t.process(0.7));   // +0.7 — fires
+	REQUIRE(t.process(0.0));   // -0.7 — fires
+	REQUIRE(!t.process(0.2));  // +0.2 — below threshold
+	std::cout << "  slope_either: passed\n";
+}
+
+void test_slope_negative_threshold_throws() {
+	bool threw = false;
+	try { SlopeTrigger<double>(-0.1); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  slope_negative_threshold_throws: passed\n";
+}
+
+// ============================================================================
+// HoldoffWrapper
+// ============================================================================
+
+void test_holdoff_basic() {
+	// Edge-rising-trigger that would otherwise fire on every up-crossing,
+	// wrapped with a 5-sample holdoff.
+	using Inner = EdgeTrigger<double>;
+	HoldoffWrapper<Inner> t(Inner(/*level=*/0.5, Slope::Either), /*holdoff=*/5);
+
+	REQUIRE(!t.process(0.0));
+	REQUIRE(t.process(0.7));        // first fire
+	// Next 5 samples: any crossings should NOT fire
+	REQUIRE(!t.process(0.3));       // would normally fire (Either)
+	REQUIRE(!t.process(0.8));       // would normally fire
+	REQUIRE(!t.process(0.2));
+	REQUIRE(!t.process(0.9));
+	REQUIRE(!t.process(0.0));
+	// 6th sample after fire — holdoff expired, fire is allowed again
+	REQUIRE(t.process(0.7));
+	std::cout << "  holdoff_basic: passed\n";
+}
+
+void test_holdoff_drives_inner() {
+	// Critical: the inner trigger MUST be driven during holdoff so its
+	// state (region for EdgeTrigger) is current. If we skipped, the very
+	// first sample after holdoff would see a stale Region and could fire
+	// spuriously.
+	using Inner = EdgeTrigger<double>;
+	HoldoffWrapper<Inner> t(Inner(0.5, Slope::Rising), /*holdoff=*/3);
+
+	REQUIRE(!t.process(0.0));
+	REQUIRE(t.process(0.7));        // first fire — state goes Above
+	// Inside holdoff: signal goes back below, then up. If we skipped the
+	// inner trigger, the inner's state would still be Above and the next
+	// up-crossing wouldn't register correctly.
+	REQUIRE(!t.process(0.0));  // 1: drives inner -> Below
+	REQUIRE(!t.process(0.7));  // 2: drives inner -> Above (would have been a fire if not in holdoff)
+	REQUIRE(!t.process(0.0));  // 3: drives inner -> Below
+	// Holdoff expired. Now an up-cross should fire normally.
+	REQUIRE(t.process(0.7));
+	std::cout << "  holdoff_drives_inner: passed\n";
+}
+
+// ============================================================================
+// QualifierAnd
+// ============================================================================
+
+void test_qualifier_and_coincidence() {
+	using TA = EdgeTrigger<double>;
+	using TB = EdgeTrigger<double>;
+	QualifierAnd<TA, TB> q(TA(0.5, Slope::Rising),
+	                       TB(0.5, Slope::Rising),
+	                       /*window=*/3);
+
+	// Both go up on the SAME sample
+	REQUIRE(!q.process(0.0, 0.0));
+	REQUIRE(q.process(0.7, 0.7));   // both fire same sample, AND fires
+	std::cout << "  qualifier_and_coincidence: passed\n";
+}
+
+void test_qualifier_and_within_window() {
+	using TA = EdgeTrigger<double>;
+	using TB = EdgeTrigger<double>;
+	QualifierAnd<TA, TB> q(TA(0.5, Slope::Rising),
+	                       TB(0.5, Slope::Rising),
+	                       /*window=*/3);
+
+	REQUIRE(!q.process(0.0, 0.0));
+	REQUIRE(!q.process(0.7, 0.0));   // A fires; B has not fired
+	REQUIRE(!q.process(0.8, 0.0));   // 1 sample later
+	REQUIRE(!q.process(0.9, 0.0));   // 2 samples later
+	REQUIRE(q.process(0.9, 0.7));    // 3 samples after A's fire — B fires now, AND fires (A still inside window)
+	std::cout << "  qualifier_and_within_window: passed\n";
+}
+
+void test_qualifier_and_outside_window() {
+	using TA = EdgeTrigger<double>;
+	using TB = EdgeTrigger<double>;
+	QualifierAnd<TA, TB> q(TA(0.5, Slope::Rising),
+	                       TB(0.5, Slope::Rising),
+	                       /*window=*/2);
+
+	REQUIRE(!q.process(0.7, 0.0));   // A fires
+	REQUIRE(!q.process(0.8, 0.0));   // 1
+	REQUIRE(!q.process(0.9, 0.0));   // 2 (still in window)
+	REQUIRE(!q.process(0.9, 0.0));   // 3 (out of window)
+	REQUIRE(!q.process(0.9, 0.7));   // B fires now, but A is outside window
+	std::cout << "  qualifier_and_outside_window: passed\n";
+}
+
+// ============================================================================
+// QualifierOr
+// ============================================================================
+
+void test_qualifier_or() {
+	using TA = EdgeTrigger<double>;
+	using TB = EdgeTrigger<double>;
+	QualifierOr<TA, TB> q(TA(0.5, Slope::Rising),
+	                      TB(0.5, Slope::Rising));
+
+	REQUIRE(!q.process(0.0, 0.0));
+	REQUIRE(q.process(0.7, 0.0));    // A fires
+	REQUIRE(q.process(0.0, 0.7));    // first sample for B; but B was below -> above, fires
+	// After both have fired, neither is currently above on next call
+	REQUIRE(!q.process(0.0, 0.0));   // both below
+	REQUIRE(q.process(0.7, 0.7));    // both fire same sample
+	std::cout << "  qualifier_or: passed\n";
+}
+
+// ============================================================================
+// Precision sweep — minimum-detectable-edge across types
+// ============================================================================
+
+template <class T>
+double measure_min_detectable_edge_near_unity() {
+	// Find the smallest amplitude A such that an EdgeTrigger at level=1.0
+	// fires reliably when the signal swings from (1.0 - A) to (1.0 + A).
+	// Centered at unity to expose the precision differences: every type's
+	// ULP varies by location, and unity is the standard reference point.
+	// (A test centered at zero is too easy — every type has dense precision
+	// near zero, so all types appear identical.)
+	auto fires_at = [](double amplitude) {
+		EdgeTrigger<T> t(static_cast<T>(1.0), Slope::Rising);
+		t.process(static_cast<T>(1.0 - amplitude));  // establish Below
+		return t.process(static_cast<T>(1.0 + amplitude));
+	};
+
+	double lo = 1e-20;
+	double hi = 0.5;
+	for (int i = 0; i < 200; ++i) {
+		double mid = std::sqrt(lo * hi);
+		if (fires_at(mid)) hi = mid;
+		else               lo = mid;
+		if (hi / lo < 1.001) break;
+	}
+	return hi;
+}
+
+void test_precision_sweep_minimum_detectable() {
+	const double me_double = measure_min_detectable_edge_near_unity<double>();
+	const double me_float  = measure_min_detectable_edge_near_unity<float>();
+	const double me_p32    = measure_min_detectable_edge_near_unity<
+		sw::universal::posit<32, 2>>();
+	const double me_p16    = measure_min_detectable_edge_near_unity<
+		sw::universal::posit<16, 2>>();
+
+	std::cout << "  precision sweep: min detectable edge near level=1.0\n";
+	std::cout << "    double:        " << me_double << "\n";
+	std::cout << "    float:         " << me_float  << "\n";
+	std::cout << "    posit<32,2>:   " << me_p32    << "\n";
+	std::cout << "    posit<16,2>:   " << me_p16    << "\n";
+
+	// At level=1.0, the floor is set by each type's ULP near unity:
+	//   double:      2^-52 ≈ 2.2e-16
+	//   float:       2^-23 ≈ 1.2e-7
+	//   posit<32,2>: ~28 mantissa bits near unity → ~3.7e-9
+	//   posit<16,2>: ~12 mantissa bits near unity → ~2.4e-4
+	REQUIRE(me_double < 1e-14);   // close to double ULP at 1.0
+	REQUIRE(me_float  < 1e-6);    // close to float ULP at 1.0
+	REQUIRE(me_p32    < 1e-7);    // posit32 better than float near unity
+	REQUIRE(me_p16    < 1e-2);    // posit16 ~12 mantissa bits → ms-scale floor
+
+	// Confirm the expected ordering: narrower types detect coarser edges.
+	REQUIRE(me_double <= me_float);
+	REQUIRE(me_p32    <= me_float);   // posit32 ties or beats float at unity
+	REQUIRE(me_p16    >  me_float);   // posit16 is meaningfully worse than float
+	std::cout << "  precision_sweep_minimum_detectable: passed\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_instrument_trigger\n";
+
+		test_edge_rising();
+		test_edge_falling();
+		test_edge_either();
+		test_edge_hysteresis();
+		test_edge_hysteresis_suppresses_noise();
+		test_edge_negative_hysteresis_throws();
+		test_samples_since();
+		test_level_trigger();
+		test_slope_positive();
+		test_slope_negative();
+		test_slope_either();
+		test_slope_negative_threshold_throws();
+		test_holdoff_basic();
+		test_holdoff_drives_inner();
+		test_qualifier_and_coincidence();
+		test_qualifier_and_within_window();
+		test_qualifier_and_outside_window();
+		test_qualifier_or();
+		test_precision_sweep_minimum_detectable();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 shared infrastructure for #132 (Instrument Data Acquisition Module). Adds the trigger primitive library — the foundational building block for both the oscilloscope demonstrator (#133) and the spectrum analyzer demonstrator (#134, zero-span / sweep-control modes).

## What's in this PR

**New header** `include/sw/dsp/instrument/trigger.hpp` — six classes in `sw::dsp::instrument`:

| Class | Role |
|---|---|
| `EdgeTrigger<SampleScalar>` | Rising / Falling / Either crossing of a level with optional hysteresis |
| `LevelTrigger<SampleScalar>` | Ergonomic alias for `EdgeTrigger` w/ `Slope::Either` |
| `SlopeTrigger<SampleScalar>` | Fires when `\|x[n] - x[n-1]\|` exceeds threshold with a sign |
| `HoldoffWrapper<Inner>` | Suppresses re-fires for N samples; continues driving inner so state stays sane |
| `QualifierAnd<TrigA, TrigB>` | Coincidence of two trigger streams within a window |
| `QualifierOr<TrigA, TrigB>` | Per-sample disjunction |

All primitives parameterized on a single `SampleScalar` (`DspScalar` concept). No `DspField` requirement — none of these primitives divide.

**New test** `tests/test_instrument_trigger.cpp` — 19 test functions.

## Highlights

### Holdoff drives inner trigger
Easy mistake: skip the inner trigger while in holdoff to "save work". The bug: the inner trigger's region/prev-sample state goes stale, and the very next sample post-holdoff fires spuriously. `test_holdoff_drives_inner` catches this case explicitly.

### Precision sweep that actually discriminates
The first version of the precision sweep tested `SampleScalar` types at level=0. Every type returned ~1e-30 (every type has dense precision near zero). Useless. Revised to center at level=1.0, where each type's ULP is the actual precision floor:

| Type | Min detectable edge near 1.0 |
|---|---|
| `double` | 1.11e-16 (≈ ULP at 1.0) |
| `float` | 5.96e-08 (≈ ULP at 1.0) |
| `posit<32, 2>` | 3.73e-09 (~30× better than float; 28 mantissa bits at unity) |
| `posit<16, 2>` | 2.44e-04 (12 mantissa bits at unity) |

The test asserts both the absolute floors and the expected ordering (narrower types → coarser edges). This actually demonstrates the precision-floor degradation the issue's acceptance criterion calls for.

## Files changed

| File | Change |
|---|---|
| `include/sw/dsp/instrument/trigger.hpp` | NEW — 6 classes, ~290 lines |
| `tests/test_instrument_trigger.cpp` | NEW — 19 test functions, ~330 lines |
| `tests/CMakeLists.txt` | +3 lines (new test entry) |

## Test results

| Compiler | Build | Test |
|---|---|---|
| gcc 13 | OK | 19/19 PASS |
| clang | OK | 19/19 PASS, identical numeric output |

## Test plan
- [x] Fast CI passes (gcc + clang)
- [x] CodeRabbit review
- [x] Promote to ready when satisfied: \`gh pr ready 143\` (replace with actual PR#)

Resolves #140

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added composable trigger primitives for digital signal instrumentation: level triggers detect threshold crossings with configurable hysteresis, edge triggers track rising/falling signal transitions, slope triggers respond to sample-to-sample magnitude changes, holdoff wrappers suppress repeated triggers, and qualifier combinators detect coincident or disjunct trigger events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->