### PR TITLE
feat(instrument): pre/post-trigger ring buffer + segmented capture (#141)

### DIFF
--- a/include/sw/dsp/instrument/ring_buffer.hpp
+++ b/include/sw/dsp/instrument/ring_buffer.hpp
@@ -1,0 +1,313 @@
+#pragma once
+// ring_buffer.hpp: Pre/post-trigger ring buffer + segmented memory capture
+// for instrument-style data acquisition.
+//
+// `TriggerRingBuffer<SampleScalar>`
+//   A circular sample buffer that captures `pre_trigger_samples` of context
+//   before a trigger event, the event sample itself, and
+//   `post_trigger_samples` after. The captured segment is available via
+//   `captured_segment()` once `capture_complete()` returns true.
+//
+// `SegmentedCapture<SampleScalar>`
+//   Stores up to `max_segments` consecutive captures back-to-back without
+//   re-arm dead time. Used by oscilloscopes for capturing rare events at
+//   high duty cycle.
+//
+// Both classes integrate with the trigger primitives from
+// `<sw/dsp/instrument/trigger.hpp>`: a typical pipeline calls
+// `trigger.process(x)` first, then either `buf.push(x)` or
+// `buf.push_trigger(x)` based on whether the trigger fired.
+//
+// The buffer is precision-insensitive (it only stores and returns samples,
+// no arithmetic). The `SampleScalar` parameter exists for type-homogeneity
+// with the upstream stream and downstream consumers.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp::instrument {
+
+// =============================================================================
+// TriggerRingBuffer
+//
+// Lifecycle (state machine):
+//
+//   ┌─────────────┐   push() x pre_size      ┌────────────────┐
+//   │  PreFill    │ ───────────────────────► │  Armed         │
+//   │             │                          │  (waiting for  │
+//   │  Building   │                          │   trigger)     │
+//   │  pre-trigger│                          │                │
+//   │  context    │                          │                │
+//   └─────────────┘                          └────────────────┘
+//                                                    │
+//                                            push_trigger(x)
+//                                                    │
+//                                                    ▼
+//                                     ┌──────────────────────────────┐
+//                                     │  Capturing                   │
+//                                     │  Filling post_size samples   │
+//                                     │  after the trigger event     │
+//                                     └──────────────────────────────┘
+//                                                    │
+//                                              post_size pushes later
+//                                                    │
+//                                                    ▼
+//                                          ┌────────────────────┐
+//                                          │  Complete          │
+//                                          │  captured_segment  │
+//                                          │  is available      │
+//                                          └────────────────────┘
+//                                                    │
+//                                                  rearm()
+//                                                    │
+//                                                    ▼
+//                                            (back to PreFill)
+//
+// Notes:
+//   - During PreFill, push() simply rotates the pre-trigger ring; once
+//     pre_size samples have been pushed, the next call to push_trigger()
+//     can capture full context.
+//   - Calling push_trigger() during PreFill is allowed: the captured
+//     segment will be shorter than the maximum (it just contains whatever
+//     pre-context has been accumulated so far). This corresponds to
+//     "trigger arrived before pre-trigger buffer was full" in real scopes.
+//   - The captured segment is returned in time order: oldest pre-trigger
+//     sample first, then the trigger sample, then the post-trigger samples.
+// =============================================================================
+template <DspScalar SampleScalar>
+class TriggerRingBuffer {
+public:
+	using sample_scalar = SampleScalar;
+
+	// pre_trigger_samples: capacity of the pre-trigger context buffer
+	// post_trigger_samples: number of samples to capture after the trigger
+	//
+	// Either may be zero (a "trigger-only" capture sets pre=0; a
+	// "pre-history-only" capture sets post=0). Both being zero is allowed
+	// but unusual — captured_segment() will contain just the trigger sample.
+	TriggerRingBuffer(std::size_t pre_trigger_samples,
+	                  std::size_t post_trigger_samples)
+		: pre_size_(pre_trigger_samples),
+		  post_size_(post_trigger_samples) {
+		// Pre-allocate the ring (size = pre_size_ + 1 + post_size_) so
+		// captured_segment() can hand back a contiguous span.
+		segment_.resize(pre_size_ + 1 + post_size_);
+		ring_.resize(pre_size_);
+		reset_state();
+	}
+
+	// Push a non-trigger sample. The sample joins the pre-trigger ring.
+	// During Capturing, the sample joins the post-trigger region instead.
+	// During Complete, additional pushes are silently dropped (caller
+	// should rearm() before continuing).
+	void push(SampleScalar x) {
+		switch (state_) {
+			case State::PreFill:
+			case State::Armed:
+				push_to_ring(x);
+				break;
+			case State::Capturing:
+				segment_[segment_pos_++] = x;
+				if (segment_pos_ >= target_length_) {
+					captured_length_ = segment_pos_;
+					state_ = State::Complete;
+				}
+				break;
+			case State::Complete:
+				// dropped; caller should rearm before pushing more
+				break;
+		}
+	}
+
+	// Push the sample that caused the trigger. Subsequent post_trigger_samples
+	// pushes will be captured before capture_complete() returns true.
+	//
+	// If called during PreFill (pre-trigger buffer not yet full), the
+	// captured segment will start with however many pre-context samples
+	// have been accumulated so far. The total length of captured_segment()
+	// reflects the actual capture, not the maximum.
+	//
+	// Calling push_trigger() during Capturing or Complete is silently
+	// ignored (the trigger is already past); rearm first if you want to
+	// capture again.
+	void push_trigger(SampleScalar x) {
+		if (state_ == State::Capturing || state_ == State::Complete) return;
+
+		// Drain the ring into the segment in time order (oldest first).
+		// The ring's logical content is `pre_count_` samples ending at
+		// (write_pos_ - 1) mod pre_size_. We unwind that into segment_[0..].
+		segment_pos_ = 0;
+		if (pre_size_ > 0 && pre_count_ > 0) {
+			std::size_t start = (write_pos_ + pre_size_ - pre_count_) % pre_size_;
+			for (std::size_t i = 0; i < pre_count_; ++i) {
+				segment_[segment_pos_++] = ring_[(start + i) % pre_size_];
+			}
+		}
+		// Trigger sample
+		segment_[segment_pos_++] = x;
+
+		// Compute the target length for THIS capture: it depends on how
+		// much pre-context we actually had, which may be less than
+		// pre_size_ when the trigger arrived during PreFill.
+		target_length_ = segment_pos_ + post_size_;
+
+		// If post_size_ is zero, we're complete immediately.
+		if (post_size_ == 0) {
+			captured_length_ = segment_pos_;
+			state_ = State::Complete;
+		} else {
+			state_ = State::Capturing;
+		}
+	}
+
+	// True once the post-trigger region is full (or zero).
+	bool capture_complete() const {
+		return state_ == State::Complete;
+	}
+
+	// Returns the captured pre+trigger+post segment. Only valid when
+	// capture_complete() is true; otherwise returns an empty span.
+	std::span<const SampleScalar> captured_segment() const {
+		if (state_ != State::Complete)
+			return std::span<const SampleScalar>{};
+		return std::span<const SampleScalar>(segment_.data(), captured_length_);
+	}
+
+	// Discard the captured segment and resume PreFill. The pre-trigger ring
+	// retains its content so a near-immediate re-trigger doesn't lose
+	// pre-context. (Real scopes work this way too: rearm doesn't blank the
+	// front-end memory.)
+	void rearm() {
+		state_       = pre_count_ >= pre_size_ ? State::Armed : State::PreFill;
+		segment_pos_ = 0;
+		captured_length_ = 0;
+	}
+
+	// Discard everything (ring, captured segment) and return to a fresh
+	// PreFill state. Useful for resetting between unrelated test scenarios.
+	void reset() {
+		reset_state();
+	}
+
+	// Capacity getters (mostly for tests / introspection)
+	std::size_t pre_trigger_capacity()  const { return pre_size_; }
+	std::size_t post_trigger_capacity() const { return post_size_; }
+
+private:
+	enum class State { PreFill, Armed, Capturing, Complete };
+
+	void push_to_ring(SampleScalar x) {
+		if (pre_size_ == 0) {
+			// degenerate: no pre-trigger history requested
+			return;
+		}
+		ring_[write_pos_] = x;
+		write_pos_ = (write_pos_ + 1) % pre_size_;
+		if (pre_count_ < pre_size_) ++pre_count_;
+		if (state_ == State::PreFill && pre_count_ == pre_size_) {
+			state_ = State::Armed;
+		}
+	}
+
+	void reset_state() {
+		state_       = pre_size_ == 0 ? State::Armed : State::PreFill;
+		write_pos_   = 0;
+		pre_count_   = 0;
+		segment_pos_ = 0;
+		target_length_   = 0;
+		captured_length_ = 0;
+	}
+
+	std::size_t              pre_size_;
+	std::size_t              post_size_;
+	std::vector<SampleScalar> ring_;       // size == pre_size_
+	std::vector<SampleScalar> segment_;    // size == pre_size_+1+post_size_
+	std::size_t              write_pos_   = 0;  // ring write head
+	std::size_t              pre_count_   = 0;  // valid samples in ring
+	std::size_t              segment_pos_ = 0;  // next write index in segment_
+	std::size_t              target_length_   = 0;  // pre-actual + 1 + post
+	std::size_t              captured_length_ = 0;
+	State                    state_ = State::PreFill;
+};
+
+// =============================================================================
+// SegmentedCapture
+//
+// Stores up to max_segments consecutive triggered captures back-to-back.
+// Each segment has the same pre/post sizes as a TriggerRingBuffer.
+//
+// Use case: an oscilloscope capturing rare events at high duty cycle
+// (e.g., bus errors) without losing triggers to re-arm dead time.
+//
+// API mirrors TriggerRingBuffer's push() / push_trigger() but accumulates
+// segments instead of stopping after one. capture_complete() returns true
+// once max_segments have been captured.
+// =============================================================================
+template <DspScalar SampleScalar>
+class SegmentedCapture {
+public:
+	using sample_scalar = SampleScalar;
+
+	SegmentedCapture(std::size_t pre_trigger_samples,
+	                 std::size_t post_trigger_samples,
+	                 std::size_t max_segments)
+		: max_segments_(max_segments),
+		  buf_(pre_trigger_samples, post_trigger_samples) {
+		if (max_segments == 0)
+			throw std::invalid_argument(
+				"SegmentedCapture: max_segments must be >= 1");
+	}
+
+	void push(SampleScalar x) {
+		if (capture_complete()) return;
+		buf_.push(x);
+		harvest_if_complete();
+	}
+
+	void push_trigger(SampleScalar x) {
+		if (capture_complete()) return;
+		buf_.push_trigger(x);
+		harvest_if_complete();
+	}
+
+	bool capture_complete() const {
+		return segments_.size() >= max_segments_;
+	}
+
+	std::size_t segment_count() const { return segments_.size(); }
+	std::size_t max_segments()  const { return max_segments_; }
+
+	std::span<const SampleScalar> segment(std::size_t i) const {
+		if (i >= segments_.size())
+			throw std::out_of_range("SegmentedCapture::segment: index out of range");
+		const auto& seg = segments_[i];
+		return std::span<const SampleScalar>(seg.data(), seg.size());
+	}
+
+	void reset() {
+		buf_.reset();
+		segments_.clear();
+	}
+
+private:
+	void harvest_if_complete() {
+		if (buf_.capture_complete()) {
+			auto seg = buf_.captured_segment();
+			segments_.emplace_back(seg.begin(), seg.end());
+			buf_.rearm();
+		}
+	}
+
+	std::size_t                            max_segments_;
+	TriggerRingBuffer<SampleScalar>        buf_;
+	std::vector<std::vector<SampleScalar>> segments_;
+};
+
+} // namespace sw::dsp::instrument

--- a/include/sw/dsp/instrument/ring_buffer.hpp
+++ b/include/sw/dsp/instrument/ring_buffer.hpp
@@ -30,6 +30,7 @@
 #include <stdexcept>
 #include <utility>
 #include <vector>
+#include <mtl/vec/dense_vector.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
 
 namespace sw::dsp::instrument {
@@ -95,11 +96,12 @@ public:
 	TriggerRingBuffer(std::size_t pre_trigger_samples,
 	                  std::size_t post_trigger_samples)
 		: pre_size_(pre_trigger_samples),
-		  post_size_(post_trigger_samples) {
-		// Pre-allocate the ring (size = pre_size_ + 1 + post_size_) so
-		// captured_segment() can hand back a contiguous span.
-		segment_.resize(pre_size_ + 1 + post_size_);
-		ring_.resize(pre_size_);
+		  post_size_(post_trigger_samples),
+		  // Pre-allocate the ring and segment buffers via the size ctor
+		  // (mtl::vec::dense_vector does not support .resize() — fixed
+		  // dimension sizes are decided at construction).
+		  ring_(pre_size_),
+		  segment_(pre_size_ + 1 + post_size_) {
 		reset_state();
 	}
 
@@ -225,10 +227,10 @@ private:
 		captured_length_ = 0;
 	}
 
-	std::size_t              pre_size_;
-	std::size_t              post_size_;
-	std::vector<SampleScalar> ring_;       // size == pre_size_
-	std::vector<SampleScalar> segment_;    // size == pre_size_+1+post_size_
+	std::size_t                          pre_size_;
+	std::size_t                          post_size_;
+	mtl::vec::dense_vector<SampleScalar> ring_;     // size == pre_size_
+	mtl::vec::dense_vector<SampleScalar> segment_;  // size == pre_size_+1+post_size_
 	std::size_t              write_pos_   = 0;  // ring write head
 	std::size_t              pre_count_   = 0;  // valid samples in ring
 	std::size_t              segment_pos_ = 0;  // next write index in segment_
@@ -263,6 +265,7 @@ public:
 		if (max_segments == 0)
 			throw std::invalid_argument(
 				"SegmentedCapture: max_segments must be >= 1");
+		segments_.reserve(max_segments_);
 	}
 
 	void push(SampleScalar x) {
@@ -300,14 +303,16 @@ private:
 	void harvest_if_complete() {
 		if (buf_.capture_complete()) {
 			auto seg = buf_.captured_segment();
-			segments_.emplace_back(seg.begin(), seg.end());
+			mtl::vec::dense_vector<SampleScalar> copy(seg.size());
+			for (std::size_t i = 0; i < seg.size(); ++i) copy[i] = seg[i];
+			segments_.emplace_back(std::move(copy));
 			buf_.rearm();
 		}
 	}
 
-	std::size_t                            max_segments_;
-	TriggerRingBuffer<SampleScalar>        buf_;
-	std::vector<std::vector<SampleScalar>> segments_;
+	std::size_t                                       max_segments_;
+	TriggerRingBuffer<SampleScalar>                   buf_;
+	std::vector<mtl::vec::dense_vector<SampleScalar>> segments_;
 };
 
 } // namespace sw::dsp::instrument

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,3 +105,6 @@ dsp_add_test(test_acquisition_precision)
 
 # Instrument trigger primitives (Issue #140)
 dsp_add_test(test_instrument_trigger)
+
+# Instrument trigger ring buffer + segmented capture (Issue #141)
+dsp_add_test(test_instrument_ring_buffer)

--- a/tests/test_instrument_ring_buffer.cpp
+++ b/tests/test_instrument_ring_buffer.cpp
@@ -14,10 +14,11 @@
 // SPDX-License-Identifier: MIT
 
 #include <array>
+#include <initializer_list>
 #include <iostream>
+#include <span>
 #include <stdexcept>
 #include <string>
-#include <vector>
 
 #include <sw/dsp/instrument/ring_buffer.hpp>
 #include <sw/dsp/instrument/trigger.hpp>
@@ -33,22 +34,26 @@ using namespace sw::dsp::instrument;
 // Helpers
 // ============================================================================
 
-// Compare a captured span to an expected vector.
+// Compare a captured span to an expected sequence. Takes the expected
+// sequence as a std::initializer_list so brace-init call sites stay
+// concise without forcing std::vector heap allocations.
 template <class T>
 void require_segment_equals(std::span<const T> got,
-                            const std::vector<T>& expected,
+                            std::initializer_list<T> expected,
                             const char* tag) {
 	if (got.size() != expected.size())
 		throw std::runtime_error(std::string(tag) +
 			": segment size mismatch, got=" +
 			std::to_string(got.size()) + " want=" +
 			std::to_string(expected.size()));
-	for (std::size_t i = 0; i < expected.size(); ++i) {
-		if (got[i] != expected[i])
+	std::size_t i = 0;
+	for (const T& want : expected) {
+		if (got[i] != want)
 			throw std::runtime_error(std::string(tag) +
 				": segment[" + std::to_string(i) + "] = " +
 				std::to_string(got[i]) + " want " +
-				std::to_string(expected[i]));
+				std::to_string(want));
+		++i;
 	}
 }
 

--- a/tests/test_instrument_ring_buffer.cpp
+++ b/tests/test_instrument_ring_buffer.cpp
@@ -199,11 +199,9 @@ void test_rearm_preserves_ring() {
 	REQUIRE(buf.capture_complete());
 	buf.rearm();
 	REQUIRE(!buf.capture_complete());
-	// Trigger again WITHOUT new push() calls — pre-ring should still have
-	// the post-trigger samples that flowed through it (100, 101) plus the
-	// trigger sample that was rotated into the ring? No — the ring is only
-	// fed by push(), not by post-trigger samples in the segment buffer.
-	// So after the first capture, the ring still has 1,2,3.
+	// Trigger again WITHOUT new push() calls. The ring is only fed by
+	// push() while armed/prefill, so after the first capture it still
+	// contains the originally pushed 1, 2, 3.
 	buf.push_trigger(200);
 	buf.push(201); buf.push(202);
 	REQUIRE(buf.capture_complete());

--- a/tests/test_instrument_ring_buffer.cpp
+++ b/tests/test_instrument_ring_buffer.cpp
@@ -1,0 +1,388 @@
+// test_instrument_ring_buffer.cpp: tests for the trigger ring buffer +
+// segmented capture primitives.
+//
+// Coverage:
+//   - TriggerRingBuffer: basic capture, partial pre-fill, post=0, pre=0,
+//     ring wrap-around, late trigger after long pre-fill, drop-after-complete,
+//     rearm preserves ring, multiple sequential captures
+//   - SegmentedCapture: back-to-back captures, max_segments cap,
+//     accessor bounds checking, integration with the trigger primitives
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <sw/dsp/instrument/ring_buffer.hpp>
+#include <sw/dsp/instrument/trigger.hpp>
+
+using namespace sw::dsp::instrument;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// Compare a captured span to an expected vector.
+template <class T>
+void require_segment_equals(std::span<const T> got,
+                            const std::vector<T>& expected,
+                            const char* tag) {
+	if (got.size() != expected.size())
+		throw std::runtime_error(std::string(tag) +
+			": segment size mismatch, got=" +
+			std::to_string(got.size()) + " want=" +
+			std::to_string(expected.size()));
+	for (std::size_t i = 0; i < expected.size(); ++i) {
+		if (got[i] != expected[i])
+			throw std::runtime_error(std::string(tag) +
+				": segment[" + std::to_string(i) + "] = " +
+				std::to_string(got[i]) + " want " +
+				std::to_string(expected[i]));
+	}
+}
+
+// ============================================================================
+// TriggerRingBuffer — happy path
+// ============================================================================
+
+void test_basic_capture() {
+	// pre=4, post=3 — total segment = 4+1+3 = 8
+	TriggerRingBuffer<int> buf(4, 3);
+	for (int i = 1; i <= 4; ++i) buf.push(i);  // ring fills with 1,2,3,4
+	REQUIRE(!buf.capture_complete());
+	buf.push_trigger(99);                       // segment so far: 1,2,3,4,99
+	REQUIRE(!buf.capture_complete());
+	buf.push(100);
+	buf.push(101);
+	REQUIRE(!buf.capture_complete());
+	buf.push(102);                              // post-trigger now full
+	REQUIRE(buf.capture_complete());
+	require_segment_equals<int>(buf.captured_segment(),
+	                            {1, 2, 3, 4, 99, 100, 101, 102},
+	                            "basic_capture");
+	std::cout << "  basic_capture: passed\n";
+}
+
+void test_ring_wraparound() {
+	// pre=3 — push 7 samples then trigger; ring should hold the last 3.
+	TriggerRingBuffer<int> buf(3, 2);
+	for (int i = 1; i <= 7; ++i) buf.push(i);   // ring: 5,6,7
+	buf.push_trigger(99);
+	buf.push(100);
+	buf.push(101);
+	REQUIRE(buf.capture_complete());
+	require_segment_equals<int>(buf.captured_segment(),
+	                            {5, 6, 7, 99, 100, 101},
+	                            "ring_wraparound");
+	std::cout << "  ring_wraparound: passed\n";
+}
+
+// ============================================================================
+// Partial pre-fill: trigger arrives before pre-trigger buffer is full
+// ============================================================================
+
+void test_partial_prefill() {
+	TriggerRingBuffer<int> buf(5, 2);
+	buf.push(10);
+	buf.push(20);
+	// Only 2 pre-trigger samples accumulated; trigger arrives early.
+	buf.push_trigger(99);
+	buf.push(100);
+	buf.push(101);
+	REQUIRE(buf.capture_complete());
+	// Captured segment: 2 pre-trigger + trigger + 2 post = 5 total
+	require_segment_equals<int>(buf.captured_segment(),
+	                            {10, 20, 99, 100, 101},
+	                            "partial_prefill");
+	std::cout << "  partial_prefill: passed\n";
+}
+
+void test_immediate_trigger() {
+	// Trigger on the very first sample — no pre-context at all.
+	TriggerRingBuffer<int> buf(8, 3);
+	buf.push_trigger(42);
+	buf.push(1);
+	buf.push(2);
+	buf.push(3);
+	REQUIRE(buf.capture_complete());
+	require_segment_equals<int>(buf.captured_segment(),
+	                            {42, 1, 2, 3},
+	                            "immediate_trigger");
+	std::cout << "  immediate_trigger: passed\n";
+}
+
+// ============================================================================
+// Edge cases: zero-size pre or post
+// ============================================================================
+
+void test_post_zero() {
+	// post_size=0: capture completes immediately on push_trigger.
+	TriggerRingBuffer<int> buf(3, 0);
+	buf.push(1);
+	buf.push(2);
+	buf.push(3);
+	buf.push_trigger(99);
+	REQUIRE(buf.capture_complete());
+	require_segment_equals<int>(buf.captured_segment(),
+	                            {1, 2, 3, 99},
+	                            "post_zero");
+	std::cout << "  post_zero: passed\n";
+}
+
+void test_pre_zero() {
+	// pre_size=0: trigger is the first sample of every capture.
+	TriggerRingBuffer<int> buf(0, 3);
+	buf.push(1);   // dropped — no ring
+	buf.push(2);   // dropped
+	buf.push_trigger(99);
+	buf.push(100);
+	buf.push(101);
+	buf.push(102);
+	REQUIRE(buf.capture_complete());
+	require_segment_equals<int>(buf.captured_segment(),
+	                            {99, 100, 101, 102},
+	                            "pre_zero");
+	std::cout << "  pre_zero: passed\n";
+}
+
+void test_pre_zero_post_zero() {
+	// degenerate: capture is just the trigger sample
+	TriggerRingBuffer<int> buf(0, 0);
+	buf.push_trigger(42);
+	REQUIRE(buf.capture_complete());
+	require_segment_equals<int>(buf.captured_segment(), {42}, "pre_zero_post_zero");
+	std::cout << "  pre_zero_post_zero: passed\n";
+}
+
+// ============================================================================
+// Drop-after-complete and rearm semantics
+// ============================================================================
+
+void test_drop_after_complete() {
+	TriggerRingBuffer<int> buf(2, 1);
+	buf.push(1); buf.push(2);
+	buf.push_trigger(99);
+	buf.push(100);
+	REQUIRE(buf.capture_complete());
+	// Further pushes are silently dropped
+	buf.push(200);
+	buf.push(201);
+	// Captured segment unchanged
+	require_segment_equals<int>(buf.captured_segment(),
+	                            {1, 2, 99, 100},
+	                            "drop_after_complete");
+	std::cout << "  drop_after_complete: passed\n";
+}
+
+void test_rearm_preserves_ring() {
+	// After rearm(), the pre-trigger ring should still contain the previous
+	// content so a near-immediate re-trigger doesn't lose pre-context.
+	TriggerRingBuffer<int> buf(3, 2);
+	buf.push(1); buf.push(2); buf.push(3);
+	buf.push_trigger(99); buf.push(100); buf.push(101);
+	REQUIRE(buf.capture_complete());
+	buf.rearm();
+	REQUIRE(!buf.capture_complete());
+	// Trigger again WITHOUT new push() calls — pre-ring should still have
+	// the post-trigger samples that flowed through it (100, 101) plus the
+	// trigger sample that was rotated into the ring? No — the ring is only
+	// fed by push(), not by post-trigger samples in the segment buffer.
+	// So after the first capture, the ring still has 1,2,3.
+	buf.push_trigger(200);
+	buf.push(201); buf.push(202);
+	REQUIRE(buf.capture_complete());
+	require_segment_equals<int>(buf.captured_segment(),
+	                            {1, 2, 3, 200, 201, 202},
+	                            "rearm_preserves_ring");
+	std::cout << "  rearm_preserves_ring: passed\n";
+}
+
+void test_reset_clears_everything() {
+	TriggerRingBuffer<int> buf(3, 2);
+	buf.push(1); buf.push(2); buf.push(3);
+	buf.push_trigger(99); buf.push(100); buf.push(101);
+	REQUIRE(buf.capture_complete());
+	buf.reset();
+	// Should be back to a fresh PreFill state.
+	REQUIRE(!buf.capture_complete());
+	buf.push_trigger(42);
+	buf.push(43); buf.push(44);
+	REQUIRE(buf.capture_complete());
+	// Only the trigger + post — ring was cleared
+	require_segment_equals<int>(buf.captured_segment(),
+	                            {42, 43, 44},
+	                            "reset_clears_everything");
+	std::cout << "  reset_clears_everything: passed\n";
+}
+
+// ============================================================================
+// Multiple sequential captures
+// ============================================================================
+
+void test_three_sequential_captures() {
+	TriggerRingBuffer<int> buf(2, 1);
+	for (int round = 0; round < 3; ++round) {
+		buf.push(round * 10 + 1);
+		buf.push(round * 10 + 2);
+		buf.push_trigger(round * 10 + 9);
+		buf.push(round * 10 + 3);
+		REQUIRE(buf.capture_complete());
+		auto seg = buf.captured_segment();
+		REQUIRE(seg.size() == 4);
+		REQUIRE(seg[2] == round * 10 + 9);
+		buf.rearm();
+	}
+	std::cout << "  three_sequential_captures: passed\n";
+}
+
+// ============================================================================
+// SegmentedCapture
+// ============================================================================
+
+void test_segmented_three() {
+	SegmentedCapture<int> sc(/*pre=*/2, /*post=*/1, /*max_segments=*/3);
+
+	// Capture 1
+	sc.push(1); sc.push(2);
+	sc.push_trigger(101);
+	sc.push(3);
+	REQUIRE(!sc.capture_complete());
+	REQUIRE(sc.segment_count() == 1);
+
+	// Capture 2 (note: ring still holds [1, 2] -> [2, ?] after the previous
+	// capture's tail; let's just push fresh data)
+	sc.push(4); sc.push(5);
+	sc.push_trigger(102);
+	sc.push(6);
+	REQUIRE(!sc.capture_complete());
+	REQUIRE(sc.segment_count() == 2);
+
+	// Capture 3
+	sc.push(7); sc.push(8);
+	sc.push_trigger(103);
+	sc.push(9);
+	REQUIRE(sc.capture_complete());
+	REQUIRE(sc.segment_count() == 3);
+
+	// Check each segment's trigger sample lives at index 2
+	REQUIRE(sc.segment(0)[2] == 101);
+	REQUIRE(sc.segment(1)[2] == 102);
+	REQUIRE(sc.segment(2)[2] == 103);
+
+	// Subsequent pushes should be ignored
+	sc.push(999);
+	sc.push_trigger(998);
+	REQUIRE(sc.segment_count() == 3);
+
+	std::cout << "  segmented_three: passed\n";
+}
+
+void test_segmented_max_segments_zero_throws() {
+	bool threw = false;
+	try { SegmentedCapture<int>(2, 1, 0); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  segmented_max_segments_zero_throws: passed\n";
+}
+
+void test_segmented_segment_oor_throws() {
+	SegmentedCapture<int> sc(1, 1, 2);
+	sc.push(0); sc.push_trigger(1); sc.push(2);
+	REQUIRE(sc.segment_count() == 1);
+	bool threw = false;
+	try { (void)sc.segment(5); }
+	catch (const std::out_of_range&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  segmented_segment_oor_throws: passed\n";
+}
+
+void test_segmented_reset() {
+	SegmentedCapture<int> sc(1, 1, 2);
+	sc.push(0); sc.push_trigger(1); sc.push(2);
+	REQUIRE(sc.segment_count() == 1);
+	sc.reset();
+	REQUIRE(sc.segment_count() == 0);
+	REQUIRE(!sc.capture_complete());
+	std::cout << "  segmented_reset: passed\n";
+}
+
+// ============================================================================
+// Integration with the trigger primitives (#140)
+// ============================================================================
+
+void test_integration_with_edge_trigger() {
+	// Drive a real EdgeTrigger and a TriggerRingBuffer side by side.
+	// Stream long enough to: build pre-trigger ring, fire the trigger,
+	// fill the post-trigger region.  Pre=8, Post=16 → need at least
+	// (8 + 1 + 16) = 25 samples after some lead-in. 64 is comfortable.
+	EdgeTrigger<float> trig(/*level=*/0.5f, Slope::Rising);
+	TriggerRingBuffer<float> buf(/*pre=*/8, /*post=*/16);
+
+	std::vector<float> stream;
+	for (int i = 0; i < 64; ++i) stream.push_back(i / 64.0f);  // ramp 0 -> ~1
+
+	for (float x : stream) {
+		if (trig.process(x)) {
+			buf.push_trigger(x);
+		} else {
+			buf.push(x);
+		}
+		if (buf.capture_complete()) break;
+	}
+
+	REQUIRE(buf.capture_complete());
+	auto seg = buf.captured_segment();
+	REQUIRE(seg.size() == 25);   // 8 pre + 1 trigger + 16 post
+
+	// The trigger sample sits at index 8 (after 8 pre samples). EdgeTrigger
+	// fires on the first sample > level after at least one sample < level,
+	// so it's the first ramp value strictly greater than 0.5.
+	REQUIRE(seg[8] > 0.5f);
+	REQUIRE(seg[7] <= 0.5f);     // last pre-trigger sample is below threshold
+	std::cout << "  integration_with_edge_trigger: passed\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_instrument_ring_buffer\n";
+
+		test_basic_capture();
+		test_ring_wraparound();
+		test_partial_prefill();
+		test_immediate_trigger();
+		test_post_zero();
+		test_pre_zero();
+		test_pre_zero_post_zero();
+		test_drop_after_complete();
+		test_rearm_preserves_ring();
+		test_reset_clears_everything();
+		test_three_sequential_captures();
+
+		test_segmented_three();
+		test_segmented_max_segments_zero_throws();
+		test_segmented_segment_oor_throws();
+		test_segmented_reset();
+
+		test_integration_with_edge_trigger();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}

--- a/tests/test_instrument_ring_buffer.cpp
+++ b/tests/test_instrument_ring_buffer.cpp
@@ -13,6 +13,7 @@
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <array>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -328,8 +329,10 @@ void test_integration_with_edge_trigger() {
 	EdgeTrigger<float> trig(/*level=*/0.5f, Slope::Rising);
 	TriggerRingBuffer<float> buf(/*pre=*/8, /*post=*/16);
 
-	std::vector<float> stream;
-	for (int i = 0; i < 64; ++i) stream.push_back(i / 64.0f);  // ramp 0 -> ~1
+	std::array<float, 64> stream{};
+	for (std::size_t i = 0; i < stream.size(); ++i) {
+		stream[i] = static_cast<float>(i) / 64.0f;  // ramp 0 -> ~1
+	}
 
 	for (float x : stream) {
 		if (trig.process(x)) {


### PR DESCRIPTION
## Summary

Phase 1 shared infrastructure for #132 (Instrument Data Acquisition Module), second of three Phase 1 building blocks. Builds on the trigger primitives from #140 (just merged) and unblocks the oscilloscope demonstrator (#133).

## What's in this PR

**New header** \`include/sw/dsp/instrument/ring_buffer.hpp\` — two classes in \`sw::dsp::instrument\`:

| Class | Role |
|---|---|
| \`TriggerRingBuffer<SampleScalar>\` | Captures pre_trigger_samples of context + the trigger sample + post_trigger_samples after, returned in time order via \`captured_segment()\` |
| \`SegmentedCapture<SampleScalar>\` | Stores up to max_segments back-to-back captures without re-arm dead time |

**API:**

\`\`\`cpp
EdgeTrigger<float> trig(/*level=*/0.5f, Slope::Rising);
TriggerRingBuffer<float> buf(/*pre=*/1024, /*post=*/3072);

for (float x : adc_stream) {
    if (trig.process(x)) buf.push_trigger(x);
    else                 buf.push(x);
    if (buf.capture_complete()) break;
}
auto segment = buf.captured_segment();   // length 4097
\`\`\`

## Bug caught while implementing

My first draft used \`segment_.size()\` as the completion gate in \`push()\`, which fails for the **trigger-during-PreFill** case (trigger arrives before the pre-trigger ring has fully filled — the actual segment is shorter than the maximum). Fixed by adding an explicit \`target_length_\` field set in \`push_trigger()\` to \`(segment_pos_ + post_size_)\`, so partial-pre-fill captures terminate at the right length. The \`test_partial_prefill\` test covers this case explicitly.

## Files changed

| File | Change |
|---|---|
| \`include/sw/dsp/instrument/ring_buffer.hpp\` | NEW — 2 classes, ~290 lines |
| \`tests/test_instrument_ring_buffer.cpp\` | NEW — 16 test functions, ~370 lines |
| \`tests/CMakeLists.txt\` | +3 lines (new test entry) |

## Test results

| Compiler | Build | Test |
|---|---|---|
| gcc 13 | OK | 16/16 PASS |
| clang | OK | 16/16 PASS, identical output |

Coverage matrix:
- Basic capture, ring wrap-around, partial pre-fill, immediate trigger
- Edge sizes: post=0, pre=0, pre=0+post=0 (degenerate)
- Drop-after-complete, rearm preserves ring, reset clears everything
- Three sequential captures via rearm
- SegmentedCapture: 3-segment capture, max=0 throws, segment(N) OOR throws, reset
- **Integration test** drives a real EdgeTrigger from #140 + the ring buffer on a synthesized ramp, verifies segment length and trigger position

## v0.6 milestone progress

After this lands:

| # | Status |
|---|---|
| #140 trigger primitives | merged ✓ |
| #141 ring buffer + segmented capture | this PR |
| #142 calibration / equalization framework | open (independent of #140/#141) |

#142 is the only remaining Phase 1 work; can be done in parallel with the demonstrator epics (#133, #134) starting work against the trigger + ring buffer APIs.

## Test plan
- [x] Fast CI passes (gcc + clang)
- [x] CodeRabbit review
- [x] Promote to ready when satisfied: \`gh pr ready <#>\`

Resolves #141

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trigger-based ring-buffer capture with configurable pre/post context, rearm/reset behavior, and multi-segment accumulation for consecutive captures.
* **Tests**
  * Added comprehensive tests for capture timing, wraparound, pre/post edge cases, rearm/reset semantics, segment limits and indexing, construction error handling, and integration with edge-trigger behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->