### PR TITLE
feat(instrument): peak-detect (min/max) decimation (#146)

### DIFF
--- a/include/sw/dsp/instrument/peak_detect.hpp
+++ b/include/sw/dsp/instrument/peak_detect.hpp
@@ -39,12 +39,20 @@ namespace sw::dsp::instrument {
 // std::nullopt while accumulating a window and the (min, max) pair on the
 // sample that completes the window.
 //
-// Block APIs `process_block_min/max(input)` are convenience wrappers that
-// return separate min and max vectors of length floor(input.size() / R).
-// Any partial trailing window (input.size() % R != 0) is dropped — the
-// streaming `process()` would still be in the std::nullopt state for those
-// samples. The `process_block(input)` overload returns both vectors as a
-// PeakDetectEnvelope struct in a single call.
+// Block APIs `process_block_min/max(input)` and `process_block(input)`
+// are convenience wrappers around the streaming `process()`. They are
+// **state-aware**: the output vector length is the number of complete
+// windows this call will close given the decimator's current partial-
+// window state, i.e.
+//
+//   n_out = floor((count_ + input.size()) / R)
+//
+// where `count_` is the number of samples already pushed into the
+// current incomplete window via prior streaming calls. Any partial
+// leading or trailing window is left in `count_` for the next call;
+// streaming `process()` would return std::nullopt for those samples
+// until a full window accumulates. The `process_block(input)` overload
+// returns both vectors as a PeakDetectEnvelope struct in a single call.
 // =============================================================================
 
 template <DspScalar SampleScalar>

--- a/include/sw/dsp/instrument/peak_detect.hpp
+++ b/include/sw/dsp/instrument/peak_detect.hpp
@@ -1,0 +1,156 @@
+#pragma once
+// peak_detect.hpp: Min/max peak-detect decimation for instrument-style
+// data acquisition.
+//
+// PeakDetectDecimator emits one (min, max) pair for every R input samples.
+// Both extremes are preserved, so a narrow glitch shorter than the
+// decimation interval still shows up in the output: at any zoom level,
+// the user sees a vertical line bounding the glitch's amplitude rather
+// than the glitch being smoothed or aliased away. This is the defining
+// difference between a scope-style decimator and a generic averaging or
+// polyphase one — a generic decimator throws peaks away; a scope MUST
+// preserve them.
+//
+// Used by both the capture pipeline (initial post-trigger rate reduction)
+// and the display pipeline (final reduction toward N pixels — see
+// display_envelope.hpp / issue #149).
+//
+// Precision-insensitive: min/max are reductions, not arithmetic. The
+// SampleScalar parameter only controls the type of the values being
+// compared and emitted.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <utility>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp::instrument {
+
+// =============================================================================
+// PeakDetectDecimator
+//
+// One (min, max) pair per R input samples. The streaming `process()` returns
+// std::nullopt while accumulating a window and the (min, max) pair on the
+// sample that completes the window.
+//
+// Block APIs `process_block_min/max(input)` are convenience wrappers that
+// return separate min and max vectors of length floor(input.size() / R).
+// Any partial trailing window (input.size() % R != 0) is dropped — the
+// streaming `process()` would still be in the std::nullopt state for those
+// samples. The `process_block(input)` overload returns both vectors as a
+// PeakDetectEnvelope struct in a single call.
+// =============================================================================
+
+template <DspScalar SampleScalar>
+struct PeakDetectEnvelope {
+	mtl::vec::dense_vector<SampleScalar> mins;
+	mtl::vec::dense_vector<SampleScalar> maxs;
+};
+
+template <DspScalar SampleScalar>
+class PeakDetectDecimator {
+public:
+	using sample_scalar = SampleScalar;
+
+	// decimation_factor R: how many input samples per output (min, max)
+	// pair. R=1 is degenerate but valid (passthrough — every sample
+	// becomes a (sample, sample) pair).
+	explicit PeakDetectDecimator(std::size_t decimation_factor)
+		: R_(decimation_factor),
+		  count_(0),
+		  cur_min_(),
+		  cur_max_() {
+		if (R_ == 0)
+			throw std::invalid_argument(
+				"PeakDetectDecimator: decimation_factor must be >= 1");
+	}
+
+	// Push one input sample. Returns std::nullopt while accumulating
+	// within a window; returns the (min, max) pair on the sample that
+	// completes the current window.
+	std::optional<std::pair<SampleScalar, SampleScalar>> process(SampleScalar x) {
+		if (count_ == 0) {
+			// First sample of a new window: seed both extremes.
+			cur_min_ = x;
+			cur_max_ = x;
+		} else {
+			if (x < cur_min_) cur_min_ = x;
+			if (x > cur_max_) cur_max_ = x;
+		}
+		++count_;
+		if (count_ == R_) {
+			count_ = 0;
+			return std::make_pair(cur_min_, cur_max_);
+		}
+		return std::nullopt;
+	}
+
+	// Block APIs. Each returns a vector of length floor(input.size() / R).
+	mtl::vec::dense_vector<SampleScalar>
+	process_block_min(std::span<const SampleScalar> input) {
+		const std::size_t n_out = input.size() / R_;
+		mtl::vec::dense_vector<SampleScalar> out(n_out);
+		std::size_t out_idx = 0;
+		for (auto x : input) {
+			if (auto p = process(x); p.has_value()) {
+				out[out_idx++] = p->first;
+			}
+		}
+		return out;
+	}
+
+	mtl::vec::dense_vector<SampleScalar>
+	process_block_max(std::span<const SampleScalar> input) {
+		const std::size_t n_out = input.size() / R_;
+		mtl::vec::dense_vector<SampleScalar> out(n_out);
+		std::size_t out_idx = 0;
+		for (auto x : input) {
+			if (auto p = process(x); p.has_value()) {
+				out[out_idx++] = p->second;
+			}
+		}
+		return out;
+	}
+
+	// Convenience: return both vectors in one pass.
+	PeakDetectEnvelope<SampleScalar>
+	process_block(std::span<const SampleScalar> input) {
+		const std::size_t n_out = input.size() / R_;
+		PeakDetectEnvelope<SampleScalar> env{
+			mtl::vec::dense_vector<SampleScalar>(n_out),
+			mtl::vec::dense_vector<SampleScalar>(n_out)};
+		std::size_t out_idx = 0;
+		for (auto x : input) {
+			if (auto p = process(x); p.has_value()) {
+				env.mins[out_idx] = p->first;
+				env.maxs[out_idx] = p->second;
+				++out_idx;
+			}
+		}
+		return env;
+	}
+
+	// Re-arm the decimator: drop any partial window in progress.
+	void reset() {
+		count_   = 0;
+		cur_min_ = SampleScalar{};
+		cur_max_ = SampleScalar{};
+	}
+
+	std::size_t decimation_factor()    const { return R_; }
+	std::size_t samples_in_window()    const { return count_; }
+
+private:
+	std::size_t  R_;        // decimation factor
+	std::size_t  count_;    // samples seen in the current window
+	SampleScalar cur_min_;
+	SampleScalar cur_max_;
+};
+
+} // namespace sw::dsp::instrument

--- a/include/sw/dsp/instrument/peak_detect.hpp
+++ b/include/sw/dsp/instrument/peak_detect.hpp
@@ -91,10 +91,15 @@ public:
 		return std::nullopt;
 	}
 
-	// Block APIs. Each returns a vector of length floor(input.size() / R).
+	// Block APIs. Each returns a vector of length equal to the number of
+	// complete windows that this call (plus any prior partial-window
+	// state from streaming process() calls) will close. That count is
+	// (count_ + input.size()) / R_ — must include count_, otherwise a
+	// caller mixing streaming and block usage gets an under-allocated
+	// buffer.
 	mtl::vec::dense_vector<SampleScalar>
 	process_block_min(std::span<const SampleScalar> input) {
-		const std::size_t n_out = input.size() / R_;
+		const std::size_t n_out = (count_ + input.size()) / R_;
 		mtl::vec::dense_vector<SampleScalar> out(n_out);
 		std::size_t out_idx = 0;
 		for (auto x : input) {
@@ -107,7 +112,7 @@ public:
 
 	mtl::vec::dense_vector<SampleScalar>
 	process_block_max(std::span<const SampleScalar> input) {
-		const std::size_t n_out = input.size() / R_;
+		const std::size_t n_out = (count_ + input.size()) / R_;
 		mtl::vec::dense_vector<SampleScalar> out(n_out);
 		std::size_t out_idx = 0;
 		for (auto x : input) {
@@ -121,7 +126,7 @@ public:
 	// Convenience: return both vectors in one pass.
 	PeakDetectEnvelope<SampleScalar>
 	process_block(std::span<const SampleScalar> input) {
-		const std::size_t n_out = input.size() / R_;
+		const std::size_t n_out = (count_ + input.size()) / R_;
 		PeakDetectEnvelope<SampleScalar> env{
 			mtl::vec::dense_vector<SampleScalar>(n_out),
 			mtl::vec::dense_vector<SampleScalar>(n_out)};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,3 +113,6 @@ dsp_add_test(test_instrument_ring_buffer)
 dsp_add_test(test_instrument_calibration)
 target_compile_definitions(test_instrument_calibration PRIVATE
 	TESTS_DATA_DIR="${CMAKE_SOURCE_DIR}/tests/data")
+
+# Instrument peak-detect (min/max) decimation (Issue #146)
+dsp_add_test(test_instrument_peak_detect)

--- a/tests/test_instrument_peak_detect.cpp
+++ b/tests/test_instrument_peak_detect.cpp
@@ -146,6 +146,35 @@ void test_separate_min_max_block_apis() {
 	std::cout << "  separate_min_max_block_apis: passed\n";
 }
 
+void test_block_after_partial_streaming_window() {
+	// Mix streaming and block: push 3 samples via process() (R=4 so the
+	// window is incomplete with count_=3), then call process_block on a
+	// 5-sample input. The first input sample completes the prior window
+	// (one output), then 4 more samples form a new complete window
+	// (another output). Total: 2 outputs from the 5 input samples.
+	//
+	// Earlier code computed n_out = input.size() / R_ = 5/4 = 1, which
+	// would have under-allocated the output buffer and silently dropped
+	// the second output (or written out of bounds — undefined behavior).
+	PeakDetectDecimator<int> d(4);
+	(void)d.process(10);
+	(void)d.process(20);
+	(void)d.process(30);
+	REQUIRE(d.samples_in_window() == 3);
+
+	std::vector<int> in = {40, 1, 2, 3, 4};
+	auto env = d.process_block(std::span<const int>(in.data(), in.size()));
+	REQUIRE(env.mins.size() == 2);
+	REQUIRE(env.maxs.size() == 2);
+	// First completed window: {10, 20, 30, 40} -> (10, 40)
+	REQUIRE(env.mins[0] == 10);
+	REQUIRE(env.maxs[0] == 40);
+	// Second window: {1, 2, 3, 4} -> (1, 4)
+	REQUIRE(env.mins[1] == 1);
+	REQUIRE(env.maxs[1] == 4);
+	std::cout << "  block_after_partial_streaming_window: passed\n";
+}
+
 // ============================================================================
 // reset()
 // ============================================================================
@@ -247,6 +276,7 @@ int main() {
 		test_block_drops_partial_trailing_window();
 		test_block_input_smaller_than_factor();
 		test_separate_min_max_block_apis();
+		test_block_after_partial_streaming_window();
 
 		test_reset_drops_partial_window();
 

--- a/tests/test_instrument_peak_detect.cpp
+++ b/tests/test_instrument_peak_detect.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iostream>
+#include <span>
 #include <stdexcept>
 #include <string>
 
@@ -101,7 +102,7 @@ void test_constructor_zero_throws() {
 void test_block_basic() {
 	std::array<int, 8> in = {3, 7, 1, 5, 10, 2, 9, 8};
 	PeakDetectDecimator<int> d(4);
-	auto env = d.process_block(std::span<const int>(in.data(), in.size()));
+	auto env = d.process_block(std::span<const int>{in});
 	REQUIRE(env.mins.size() == 2);
 	REQUIRE(env.maxs.size() == 2);
 	REQUIRE(env.mins[0] == 1);
@@ -117,7 +118,7 @@ void test_block_retains_partial_trailing_window_in_state() {
 	// in count_ for the next process() / process_block() call.
 	std::array<int, 7> in = {1, 2, 3, 4, 5, 6, 7};
 	PeakDetectDecimator<int> d(4);
-	auto env = d.process_block(std::span<const int>(in.data(), in.size()));
+	auto env = d.process_block(std::span<const int>{in});
 	REQUIRE(env.mins.size() == 1);
 	REQUIRE(env.mins[0] == 1);
 	REQUIRE(env.maxs[0] == 4);
@@ -136,7 +137,7 @@ void test_block_input_smaller_than_factor() {
 	// Input length 3, R=4 — no complete window, zero outputs.
 	std::array<int, 3> in = {1, 2, 3};
 	PeakDetectDecimator<int> d(4);
-	auto env = d.process_block(std::span<const int>(in.data(), in.size()));
+	auto env = d.process_block(std::span<const int>{in});
 	REQUIRE(env.mins.size() == 0);
 	REQUIRE(env.maxs.size() == 0);
 	std::cout << "  block_input_smaller_than_factor: passed\n";
@@ -147,9 +148,9 @@ void test_separate_min_max_block_apis() {
 	// the unified process_block.
 	std::array<int, 8> in = {3, 7, 1, 5, 10, 2, 9, 8};
 	PeakDetectDecimator<int> d_a(4);
-	auto mins = d_a.process_block_min(std::span<const int>(in.data(), in.size()));
+	auto mins = d_a.process_block_min(std::span<const int>{in});
 	PeakDetectDecimator<int> d_b(4);
-	auto maxs = d_b.process_block_max(std::span<const int>(in.data(), in.size()));
+	auto maxs = d_b.process_block_max(std::span<const int>{in});
 	REQUIRE(mins.size() == 2 && maxs.size() == 2);
 	REQUIRE(mins[0] == 1 && maxs[0] == 7);
 	REQUIRE(mins[1] == 2 && maxs[1] == 10);
@@ -178,7 +179,7 @@ void test_block_after_partial_streaming_window() {
 		(void)d.process(20);
 		(void)d.process(30);
 		REQUIRE(d.samples_in_window() == 3);
-		auto env = d.process_block(std::span<const int>(in.data(), in.size()));
+		auto env = d.process_block(std::span<const int>{in});
 		REQUIRE(env.mins.size() == 2);
 		REQUIRE(env.maxs.size() == 2);
 		REQUIRE(env.mins[0] == 10 && env.maxs[0] == 40);   // {10,20,30,40}
@@ -191,7 +192,7 @@ void test_block_after_partial_streaming_window() {
 		(void)d.process(20);
 		(void)d.process(30);
 		auto mins = d.process_block_min(
-			std::span<const int>(in.data(), in.size()));
+			std::span<const int>{in});
 		REQUIRE(mins.size() == 2);
 		REQUIRE(mins[0] == 10);
 		REQUIRE(mins[1] ==  1);
@@ -203,7 +204,7 @@ void test_block_after_partial_streaming_window() {
 		(void)d.process(20);
 		(void)d.process(30);
 		auto maxs = d.process_block_max(
-			std::span<const int>(in.data(), in.size()));
+			std::span<const int>{in});
 		REQUIRE(maxs.size() == 2);
 		REQUIRE(maxs[0] == 40);
 		REQUIRE(maxs[1] ==  4);
@@ -273,7 +274,7 @@ void test_glitch_survives_at_all_decimation_factors() {
 	                       std::size_t{16}, std::size_t{32}}) {
 		PeakDetectDecimator<float> d(R);
 		auto env = d.process_block(
-			std::span<const float>(stream.data(), stream.size()));
+			std::span<const float>{stream});
 
 		// Find the max-stream peak. With the glitch present, this should
 		// be exactly the glitch's amplitude (1.5), not the square wave's

--- a/tests/test_instrument_peak_detect.cpp
+++ b/tests/test_instrument_peak_detect.cpp
@@ -1,0 +1,261 @@
+// test_instrument_peak_detect.cpp: tests for the peak-detect (min/max)
+// decimator.
+//
+// Coverage:
+//   - Streaming API: emits std::nullopt while accumulating, pair on
+//     window completion
+//   - Block API: returns floor(N/R) outputs; partial trailing window
+//     correctly dropped
+//   - Edge cases: R=1 (passthrough), R > N (no outputs), reset() clears
+//     window state
+//   - **Glitch survival**: a 50 MHz square wave with a 5-sample-wide
+//     narrow positive glitch buried in it. The glitch's peak amplitude
+//     must show up in the max stream at every decimation factor we test
+//     (R = 2, 4, 8, 16, 32). This is THE acceptance criterion that
+//     distinguishes peak-detect decimation from generic averaging or
+//     polyphase decimation.
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <sw/dsp/instrument/peak_detect.hpp>
+
+using namespace sw::dsp::instrument;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+// ============================================================================
+// Streaming API
+// ============================================================================
+
+void test_streaming_basic() {
+	PeakDetectDecimator<int> d(/*R=*/4);
+	// First three samples — accumulating, no output yet.
+	REQUIRE(!d.process(3).has_value());
+	REQUIRE(!d.process(7).has_value());
+	REQUIRE(!d.process(1).has_value());
+	// Fourth sample — completes the window, returns (min, max) = (1, 7).
+	auto p = d.process(5);
+	REQUIRE(p.has_value());
+	REQUIRE(p->first  == 1);
+	REQUIRE(p->second == 7);
+	// Next window starts fresh.
+	REQUIRE(!d.process(10).has_value());
+	REQUIRE(!d.process(2).has_value());
+	REQUIRE(!d.process(9).has_value());
+	auto p2 = d.process(8);
+	REQUIRE(p2.has_value());
+	REQUIRE(p2->first  == 2);
+	REQUIRE(p2->second == 10);
+	std::cout << "  streaming_basic: passed\n";
+}
+
+void test_streaming_negative_values() {
+	// Make sure min/max work for signed values across zero.
+	PeakDetectDecimator<double> d(3);
+	REQUIRE(!d.process(-1.5).has_value());
+	REQUIRE(!d.process( 0.0).has_value());
+	auto p = d.process(2.5);
+	REQUIRE(p.has_value());
+	REQUIRE(p->first  == -1.5);
+	REQUIRE(p->second ==  2.5);
+	std::cout << "  streaming_negative_values: passed\n";
+}
+
+void test_streaming_decimation_one_passthrough() {
+	// R=1: every sample becomes (sample, sample) immediately.
+	PeakDetectDecimator<float> d(1);
+	for (float x : {1.0f, 2.0f, 3.0f, 4.0f, 5.0f}) {
+		auto p = d.process(x);
+		REQUIRE(p.has_value());
+		REQUIRE(p->first  == x);
+		REQUIRE(p->second == x);
+	}
+	std::cout << "  streaming_decimation_one_passthrough: passed\n";
+}
+
+void test_constructor_zero_throws() {
+	bool threw = false;
+	try { PeakDetectDecimator<int>(0); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  constructor_zero_throws: passed\n";
+}
+
+// ============================================================================
+// Block API
+// ============================================================================
+
+void test_block_basic() {
+	std::vector<int> in = {3, 7, 1, 5, 10, 2, 9, 8};
+	PeakDetectDecimator<int> d(4);
+	auto env = d.process_block(std::span<const int>(in.data(), in.size()));
+	REQUIRE(env.mins.size() == 2);
+	REQUIRE(env.maxs.size() == 2);
+	REQUIRE(env.mins[0] == 1);
+	REQUIRE(env.maxs[0] == 7);
+	REQUIRE(env.mins[1] == 2);
+	REQUIRE(env.maxs[1] == 10);
+	std::cout << "  block_basic: passed\n";
+}
+
+void test_block_drops_partial_trailing_window() {
+	std::vector<int> in = {1, 2, 3, 4, 5, 6, 7};   // 7 samples, R=4 → 1 output
+	PeakDetectDecimator<int> d(4);
+	auto env = d.process_block(std::span<const int>(in.data(), in.size()));
+	REQUIRE(env.mins.size() == 1);
+	REQUIRE(env.mins[0] == 1);
+	REQUIRE(env.maxs[0] == 4);
+	// The trailing 3 samples (5,6,7) are dropped — they form a partial window.
+	std::cout << "  block_drops_partial_trailing_window: passed\n";
+}
+
+void test_block_input_smaller_than_factor() {
+	// Input length 3, R=4 — no complete window, zero outputs.
+	std::vector<int> in = {1, 2, 3};
+	PeakDetectDecimator<int> d(4);
+	auto env = d.process_block(std::span<const int>(in.data(), in.size()));
+	REQUIRE(env.mins.size() == 0);
+	REQUIRE(env.maxs.size() == 0);
+	std::cout << "  block_input_smaller_than_factor: passed\n";
+}
+
+void test_separate_min_max_block_apis() {
+	// process_block_min / process_block_max should agree with
+	// the unified process_block.
+	std::vector<int> in = {3, 7, 1, 5, 10, 2, 9, 8};
+	PeakDetectDecimator<int> d_a(4);
+	auto mins = d_a.process_block_min(std::span<const int>(in.data(), in.size()));
+	PeakDetectDecimator<int> d_b(4);
+	auto maxs = d_b.process_block_max(std::span<const int>(in.data(), in.size()));
+	REQUIRE(mins.size() == 2 && maxs.size() == 2);
+	REQUIRE(mins[0] == 1 && maxs[0] == 7);
+	REQUIRE(mins[1] == 2 && maxs[1] == 10);
+	std::cout << "  separate_min_max_block_apis: passed\n";
+}
+
+// ============================================================================
+// reset()
+// ============================================================================
+
+void test_reset_drops_partial_window() {
+	PeakDetectDecimator<int> d(4);
+	d.process(100);   // partial window
+	d.process(200);
+	REQUIRE(d.samples_in_window() == 2);
+	d.reset();
+	REQUIRE(d.samples_in_window() == 0);
+	// Now run a fresh window — the previous samples should NOT be in it.
+	REQUIRE(!d.process(1).has_value());
+	REQUIRE(!d.process(2).has_value());
+	REQUIRE(!d.process(3).has_value());
+	auto p = d.process(4);
+	REQUIRE(p.has_value());
+	REQUIRE(p->first  == 1);   // not 1 vs 100 — reset cleared the window
+	REQUIRE(p->second == 4);
+	std::cout << "  reset_drops_partial_window: passed\n";
+}
+
+// ============================================================================
+// GLITCH-SURVIVAL TEST — the headline acceptance criterion
+//
+// Synthesize a 50 MHz square wave at fs=1 GSPS (so 20 samples per period,
+// 10 high + 10 low) with a 5-sample-wide narrow positive glitch buried
+// somewhere in the LOW phase. The glitch's peak amplitude is +1.5
+// (compared to the square wave's ±1.0). We then run peak-detect at
+// decimation factors 2, 4, 8, 16, 32 and verify that the glitch's
+// amplitude shows up in the max output at every factor.
+//
+// This is what distinguishes a scope's peak-detect decimator from a
+// generic averaging or polyphase decimator: those would average the
+// glitch out at sufficient decimation; peak-detect MUST preserve it.
+// ============================================================================
+
+std::vector<float> make_square_wave_with_glitch() {
+	const std::size_t N = 4096;        // total samples
+	std::vector<float> stream(N, 0.0f);
+
+	// 50 MHz square wave at fs=1 GSPS = 20 samples per period
+	for (std::size_t n = 0; n < N; ++n) {
+		stream[n] = ((n / 10) % 2 == 0) ? 1.0f : -1.0f;
+	}
+	// 5-sample-wide positive glitch buried in a LOW phase (e.g., samples
+	// 510..514 within a low region, so the surrounding values are -1.0).
+	for (std::size_t n = 510; n < 515; ++n) {
+		stream[n] = 1.5f;   // peaks above the +1.0 high level
+	}
+	return stream;
+}
+
+void test_glitch_survives_at_all_decimation_factors() {
+	const auto stream = make_square_wave_with_glitch();
+	const float glitch_peak = 1.5f;
+
+	for (std::size_t R : {std::size_t{2}, std::size_t{4}, std::size_t{8},
+	                       std::size_t{16}, std::size_t{32}}) {
+		PeakDetectDecimator<float> d(R);
+		auto env = d.process_block(
+			std::span<const float>(stream.data(), stream.size()));
+
+		// Find the max-stream peak. With the glitch present, this should
+		// be exactly the glitch's amplitude (1.5), not the square wave's
+		// (1.0).
+		float observed_peak = -1e9f;
+		for (std::size_t i = 0; i < env.maxs.size(); ++i) {
+			if (env.maxs[i] > observed_peak) observed_peak = env.maxs[i];
+		}
+
+		// The glitch's amplitude must be visible — observed_peak should
+		// be at or very close to glitch_peak. With a generic averaging
+		// decimator at R=32, observed_peak would drop toward (5 * 1.5 +
+		// 27 * -1) / 32 ≈ -0.61, but with peak-detect it stays at 1.5.
+		if (!(std::abs(observed_peak - glitch_peak) < 1e-5f))
+			throw std::runtime_error(
+				"glitch lost at R=" + std::to_string(R) + ": observed_peak=" +
+				std::to_string(observed_peak) + " want=" +
+				std::to_string(glitch_peak));
+	}
+	std::cout << "  glitch_survives_at_all_decimation_factors: passed (R=2,4,8,16,32)\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_instrument_peak_detect\n";
+
+		test_streaming_basic();
+		test_streaming_negative_values();
+		test_streaming_decimation_one_passthrough();
+		test_constructor_zero_throws();
+
+		test_block_basic();
+		test_block_drops_partial_trailing_window();
+		test_block_input_smaller_than_factor();
+		test_separate_min_max_block_apis();
+
+		test_reset_drops_partial_window();
+
+		test_glitch_survives_at_all_decimation_factors();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}

--- a/tests/test_instrument_peak_detect.cpp
+++ b/tests/test_instrument_peak_detect.cpp
@@ -4,10 +4,10 @@
 // Coverage:
 //   - Streaming API: emits std::nullopt while accumulating, pair on
 //     window completion
-//   - Block API: returns floor(N/R) outputs; partial trailing window
-//     correctly dropped
-//   - Edge cases: R=1 (passthrough), R > N (no outputs), reset() clears
-//     window state
+//   - Block API: returns floor((count_ + N) / R) outputs and retains
+//     any incomplete trailing samples in count_ for subsequent calls
+//   - Edge cases: R=1 (passthrough), R > N (no outputs, samples held
+//     in count_), reset() clears window state
 //   - **Glitch survival**: a 50 MHz square wave with a 5-sample-wide
 //     narrow positive glitch buried in it. The glitch's peak amplitude
 //     must show up in the max stream at every decimation factor we test
@@ -20,12 +20,12 @@
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <iostream>
 #include <stdexcept>
 #include <string>
-#include <vector>
 
 #include <sw/dsp/instrument/peak_detect.hpp>
 
@@ -99,7 +99,7 @@ void test_constructor_zero_throws() {
 // ============================================================================
 
 void test_block_basic() {
-	std::vector<int> in = {3, 7, 1, 5, 10, 2, 9, 8};
+	std::array<int, 8> in = {3, 7, 1, 5, 10, 2, 9, 8};
 	PeakDetectDecimator<int> d(4);
 	auto env = d.process_block(std::span<const int>(in.data(), in.size()));
 	REQUIRE(env.mins.size() == 2);
@@ -111,20 +111,30 @@ void test_block_basic() {
 	std::cout << "  block_basic: passed\n";
 }
 
-void test_block_drops_partial_trailing_window() {
-	std::vector<int> in = {1, 2, 3, 4, 5, 6, 7};   // 7 samples, R=4 → 1 output
+void test_block_retains_partial_trailing_window_in_state() {
+	// 7 samples, R=4 → only one complete window; the trailing 3 samples
+	// (5,6,7) form a partial window that is NOT dropped — they're held
+	// in count_ for the next process() / process_block() call.
+	std::array<int, 7> in = {1, 2, 3, 4, 5, 6, 7};
 	PeakDetectDecimator<int> d(4);
 	auto env = d.process_block(std::span<const int>(in.data(), in.size()));
 	REQUIRE(env.mins.size() == 1);
 	REQUIRE(env.mins[0] == 1);
 	REQUIRE(env.maxs[0] == 4);
-	// The trailing 3 samples (5,6,7) are dropped — they form a partial window.
-	std::cout << "  block_drops_partial_trailing_window: passed\n";
+	// The trailing 3 samples (5,6,7) are retained in state, NOT dropped.
+	REQUIRE(d.samples_in_window() == 3);
+	// Push one more sample; it should complete the partial window using
+	// 5,6,7 from the prior call.
+	auto p = d.process(8);
+	REQUIRE(p.has_value());
+	REQUIRE(p->first  == 5);
+	REQUIRE(p->second == 8);
+	std::cout << "  block_retains_partial_trailing_window_in_state: passed\n";
 }
 
 void test_block_input_smaller_than_factor() {
 	// Input length 3, R=4 — no complete window, zero outputs.
-	std::vector<int> in = {1, 2, 3};
+	std::array<int, 3> in = {1, 2, 3};
 	PeakDetectDecimator<int> d(4);
 	auto env = d.process_block(std::span<const int>(in.data(), in.size()));
 	REQUIRE(env.mins.size() == 0);
@@ -135,7 +145,7 @@ void test_block_input_smaller_than_factor() {
 void test_separate_min_max_block_apis() {
 	// process_block_min / process_block_max should agree with
 	// the unified process_block.
-	std::vector<int> in = {3, 7, 1, 5, 10, 2, 9, 8};
+	std::array<int, 8> in = {3, 7, 1, 5, 10, 2, 9, 8};
 	PeakDetectDecimator<int> d_a(4);
 	auto mins = d_a.process_block_min(std::span<const int>(in.data(), in.size()));
 	PeakDetectDecimator<int> d_b(4);
@@ -159,7 +169,7 @@ void test_block_after_partial_streaming_window() {
 	//
 	// Three parallel test bodies — one per block API — to lock down all
 	// three state-aware-alloc paths.
-	std::vector<int> in = {40, 1, 2, 3, 4};
+	std::array<int, 5> in = {40, 1, 2, 3, 4};
 
 	// process_block (returns both)
 	{
@@ -238,12 +248,13 @@ void test_reset_drops_partial_window() {
 // glitch out at sufficient decimation; peak-detect MUST preserve it.
 // ============================================================================
 
-std::vector<float> make_square_wave_with_glitch() {
-	const std::size_t N = 4096;        // total samples
-	std::vector<float> stream(N, 0.0f);
+constexpr std::size_t kGlitchStreamSize = 4096;
+
+std::array<float, kGlitchStreamSize> make_square_wave_with_glitch() {
+	std::array<float, kGlitchStreamSize> stream{};
 
 	// 50 MHz square wave at fs=1 GSPS = 20 samples per period
-	for (std::size_t n = 0; n < N; ++n) {
+	for (std::size_t n = 0; n < kGlitchStreamSize; ++n) {
 		stream[n] = ((n / 10) % 2 == 0) ? 1.0f : -1.0f;
 	}
 	// 5-sample-wide positive glitch buried in a LOW phase (e.g., samples
@@ -299,7 +310,7 @@ int main() {
 		test_constructor_zero_throws();
 
 		test_block_basic();
-		test_block_drops_partial_trailing_window();
+		test_block_retains_partial_trailing_window_in_state();
 		test_block_input_smaller_than_factor();
 		test_separate_min_max_block_apis();
 		test_block_after_partial_streaming_window();

--- a/tests/test_instrument_peak_detect.cpp
+++ b/tests/test_instrument_peak_detect.cpp
@@ -156,23 +156,49 @@ void test_block_after_partial_streaming_window() {
 	// Earlier code computed n_out = input.size() / R_ = 5/4 = 1, which
 	// would have under-allocated the output buffer and silently dropped
 	// the second output (or written out of bounds — undefined behavior).
-	PeakDetectDecimator<int> d(4);
-	(void)d.process(10);
-	(void)d.process(20);
-	(void)d.process(30);
-	REQUIRE(d.samples_in_window() == 3);
-
+	//
+	// Three parallel test bodies — one per block API — to lock down all
+	// three state-aware-alloc paths.
 	std::vector<int> in = {40, 1, 2, 3, 4};
-	auto env = d.process_block(std::span<const int>(in.data(), in.size()));
-	REQUIRE(env.mins.size() == 2);
-	REQUIRE(env.maxs.size() == 2);
-	// First completed window: {10, 20, 30, 40} -> (10, 40)
-	REQUIRE(env.mins[0] == 10);
-	REQUIRE(env.maxs[0] == 40);
-	// Second window: {1, 2, 3, 4} -> (1, 4)
-	REQUIRE(env.mins[1] == 1);
-	REQUIRE(env.maxs[1] == 4);
-	std::cout << "  block_after_partial_streaming_window: passed\n";
+
+	// process_block (returns both)
+	{
+		PeakDetectDecimator<int> d(4);
+		(void)d.process(10);
+		(void)d.process(20);
+		(void)d.process(30);
+		REQUIRE(d.samples_in_window() == 3);
+		auto env = d.process_block(std::span<const int>(in.data(), in.size()));
+		REQUIRE(env.mins.size() == 2);
+		REQUIRE(env.maxs.size() == 2);
+		REQUIRE(env.mins[0] == 10 && env.maxs[0] == 40);   // {10,20,30,40}
+		REQUIRE(env.mins[1] ==  1 && env.maxs[1] ==  4);   // {1,2,3,4}
+	}
+	// process_block_min
+	{
+		PeakDetectDecimator<int> d(4);
+		(void)d.process(10);
+		(void)d.process(20);
+		(void)d.process(30);
+		auto mins = d.process_block_min(
+			std::span<const int>(in.data(), in.size()));
+		REQUIRE(mins.size() == 2);
+		REQUIRE(mins[0] == 10);
+		REQUIRE(mins[1] ==  1);
+	}
+	// process_block_max
+	{
+		PeakDetectDecimator<int> d(4);
+		(void)d.process(10);
+		(void)d.process(20);
+		(void)d.process(30);
+		auto maxs = d.process_block_max(
+			std::span<const int>(in.data(), in.size()));
+		REQUIRE(maxs.size() == 2);
+		REQUIRE(maxs[0] == 40);
+		REQUIRE(maxs[1] ==  4);
+	}
+	std::cout << "  block_after_partial_streaming_window: passed (all 3 block APIs)\n";
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

First scope-specific primitive for #133 (Digital Oscilloscope Demonstrator). The foundational primitive — both the capture pipeline (post-trigger rate reduction) and the display pipeline (#149's N-pixel envelope) build on it.

## Why peak-detect specifically

A generic averaging or polyphase decimator throws away peaks shorter than the decimation interval. A scope user MUST see those peaks at every zoom level — the trace needs to show a vertical line bounding the glitch's amplitude even after surrounding samples are decimated away. Peak-detect emits one \`(min, max)\` pair per \`R\` input samples, preserving both extremes.

## What's in this PR

**New header** \`include/sw/dsp/instrument/peak_detect.hpp\`:

\`\`\`cpp
template <DspScalar SampleScalar>
class PeakDetectDecimator {
    explicit PeakDetectDecimator(std::size_t R);
    std::optional<std::pair<SampleScalar, SampleScalar>> process(SampleScalar x);
    PeakDetectEnvelope<SampleScalar> process_block(std::span<const SampleScalar>);
    mtl::vec::dense_vector<SampleScalar> process_block_min(...);
    mtl::vec::dense_vector<SampleScalar> process_block_max(...);
    void reset();
};
\`\`\`

Precision-insensitive — min/max are reductions, no arithmetic.

## Headline test: glitch survival

The acceptance criterion that defines this primitive. \`test_glitch_survives_at_all_decimation_factors\` builds a 50 MHz square wave at 1 GSPS (20 samples/period) with a 5-sample-wide narrow positive glitch (peak +1.5, square wave ±1.0) buried in a low phase. Runs peak-detect at \`R = 2, 4, 8, 16, 32\` and verifies the glitch's peak amplitude shows up in the max output at every R.

For comparison: a generic averaging decimator at R=32 would average the glitch down to ~-0.61 (5 glitch samples × 1.5 + 27 low samples × -1.0) / 32. Peak-detect keeps it at exactly 1.5. The test would fail any other decimator class.

## Files changed

| File | Change |
|---|---|
| \`include/sw/dsp/instrument/peak_detect.hpp\` | NEW — ~150 lines |
| \`tests/test_instrument_peak_detect.cpp\` | NEW — 10 tests, ~250 lines |
| \`tests/CMakeLists.txt\` | +3 lines |

## Test results

| Compiler | Build | Tests |
|---|---|---|
| gcc 13 | OK | 10/10 PASS |
| clang | OK | 10/10 PASS |

## #133 progress after this lands

| # | Title | Status |
|---|---|---|
| **#146** | **Peak-detect decimation** | **this PR** |
| #147 | Auto-trigger | open (next) |
| #148 | Cross-channel triggering | open |
| #149 | Display-rate decimation | open (depends on #146) |
| #150 | Multi-channel time alignment | open |
| #151 | Cursor / measurement primitives | open |
| #152 | scope_demo application | open |

## Test plan
- [x] Fast CI passes (gcc + clang)
- [x] CodeRabbit review
- [x] Promote to ready when satisfied

Resolves #146

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a peak-detection decimator instrument that emits per-window min/max envelopes, supports streaming and block processing, validates decimation factor, exposes current window size, reset capability, and omits incomplete trailing windows.

* **Tests**
  * Added comprehensive tests covering streaming, block APIs, partial-window state, passthrough/negative cases, constructor validation, reset, and glitch-preservation across decimation factors; test registered in the suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->