### PR TITLE
feat(instrument): auto-trigger wrapper (#147)

### DIFF
--- a/include/sw/dsp/instrument/trigger.hpp
+++ b/include/sw/dsp/instrument/trigger.hpp
@@ -15,6 +15,9 @@
 //   HoldoffWrapper  — wraps any trigger and suppresses re-triggering for
 //                     N samples after a fire (the inner trigger is still
 //                     driven during the holdoff so its state stays sane)
+//   AutoTriggerWrapper — wraps any trigger and force-fires after N samples
+//                     of inactivity. A real inner fire preempts the auto-fire
+//                     and resets the timeout counter.
 //   QualifierAnd    — fires when two triggers both fire within a window
 //   QualifierOr     — fires when either of two triggers fires
 //
@@ -255,6 +258,61 @@ private:
 	std::size_t holdoff_;
 	std::size_t remaining_;
 	std::size_t samples_since_;
+};
+
+// =============================================================================
+// AutoTriggerWrapper
+//
+// Wraps any trigger primitive and force-fires after `timeout_samples` of
+// inactivity if no real fire has occurred. Without this, a scope viewing
+// a slow or absent signal would sit blank forever waiting for the trigger
+// condition; with it, the user always sees something — a recent capture,
+// even if no edge crossed the threshold.
+//
+// The inner trigger is always driven so its internal state stays sane.
+// A real fire from the inner trigger preempts any pending auto-fire and
+// resets the timeout counter; an auto-fire on timeout also resets the
+// counter, so on a flat signal auto-fires happen at regular intervals
+// (one every `timeout_samples` samples after the first one).
+// =============================================================================
+template <class Inner>
+class AutoTriggerWrapper {
+public:
+	using sample_scalar = typename Inner::sample_scalar;
+
+	AutoTriggerWrapper(Inner inner, std::size_t timeout_samples)
+		: inner_(std::move(inner)),
+		  timeout_(timeout_samples),
+		  since_fire_(0) {}
+
+	bool process(sample_scalar x) {
+		// Always drive inner so its state is current.
+		const bool real_fire = inner_.process(x);
+		++since_fire_;
+
+		if (real_fire) {
+			since_fire_ = 0;
+			return true;
+		}
+		// No real fire — has the timeout elapsed?
+		if (since_fire_ >= timeout_) {
+			since_fire_ = 0;
+			return true;   // forced auto-fire
+		}
+		return false;
+	}
+
+	std::size_t samples_since_trigger() const { return since_fire_; }
+
+	void reset() {
+		inner_.reset();
+		since_fire_ = 0;
+	}
+
+private:
+	Inner       inner_;
+	std::size_t timeout_;
+	std::size_t since_fire_;
 };
 
 // =============================================================================

--- a/include/sw/dsp/instrument/trigger.hpp
+++ b/include/sw/dsp/instrument/trigger.hpp
@@ -283,7 +283,16 @@ public:
 	AutoTriggerWrapper(Inner inner, std::size_t timeout_samples)
 		: inner_(std::move(inner)),
 		  timeout_(timeout_samples),
-		  since_fire_(0) {}
+		  since_fire_(0) {
+		// timeout=0 would force-fire on every sample (since_fire_ becomes
+		// 1 after the first increment, which is >= 0). That's degenerate
+		// and almost certainly a user error; reject it. Use a sufficiently
+		// large value (e.g., std::numeric_limits<std::size_t>::max()) if
+		// effectively-no-timeout behavior is wanted.
+		if (timeout_samples == 0)
+			throw std::invalid_argument(
+				"AutoTriggerWrapper: timeout_samples must be > 0");
+	}
 
 	bool process(sample_scalar x) {
 		// Always drive inner so its state is current.

--- a/tests/test_instrument_trigger.cpp
+++ b/tests/test_instrument_trigger.cpp
@@ -241,6 +241,85 @@ void test_holdoff_drives_inner() {
 }
 
 // ============================================================================
+// AutoTriggerWrapper
+// ============================================================================
+
+void test_auto_trigger_real_preempts_auto() {
+	// A real inner-trigger fire BEFORE the timeout expires should fire
+	// the wrapper and reset the timer. After the real fire, the timeout
+	// counter starts from zero.
+	using Inner = EdgeTrigger<double>;
+	AutoTriggerWrapper<Inner> t(Inner(/*level=*/0.5, Slope::Rising),
+	                             /*timeout=*/100);
+
+	REQUIRE(!t.process(0.0));   // below — counter=1
+	REQUIRE(t.process(0.7));    // up-cross — real fire, counter resets to 0
+	REQUIRE(!t.process(0.0));   // counter=1
+	REQUIRE(!t.process(0.0));   // counter=2
+	REQUIRE(t.samples_since_trigger() == 2);
+	std::cout << "  auto_trigger_real_preempts_auto: passed\n";
+}
+
+void test_auto_trigger_force_fires_after_timeout() {
+	// On a flat signal that never crosses the threshold, the wrapper
+	// should force-fire exactly at the configured timeout.
+	using Inner = EdgeTrigger<double>;
+	AutoTriggerWrapper<Inner> t(Inner(/*level=*/0.5, Slope::Rising),
+	                             /*timeout=*/5);
+
+	// First 4 samples: no real fire, no auto-fire yet (since_fire_ < timeout)
+	REQUIRE(!t.process(0.0));   // 1
+	REQUIRE(!t.process(0.0));   // 2
+	REQUIRE(!t.process(0.0));   // 3
+	REQUIRE(!t.process(0.0));   // 4
+	// 5th sample: timeout reached, force auto-fire
+	REQUIRE(t.process(0.0));
+	// Counter resets after auto-fire — next 4 samples no fire
+	REQUIRE(!t.process(0.0));
+	REQUIRE(!t.process(0.0));
+	REQUIRE(!t.process(0.0));
+	REQUIRE(!t.process(0.0));
+	// 5th sample after the previous auto-fire: another auto-fire
+	REQUIRE(t.process(0.0));
+	std::cout << "  auto_trigger_force_fires_after_timeout: passed\n";
+}
+
+void test_auto_trigger_real_fire_resets_timer() {
+	// After a real fire, the timer restarts — auto-fire shouldn't trip
+	// just because we're past the original "would-have-auto-fired" mark.
+	using Inner = EdgeTrigger<double>;
+	AutoTriggerWrapper<Inner> t(Inner(0.5, Slope::Rising), /*timeout=*/4);
+
+	// 3 below samples — counter=3
+	REQUIRE(!t.process(0.0));
+	REQUIRE(!t.process(0.0));
+	REQUIRE(!t.process(0.0));
+	// real fire on sample 4 — counter resets
+	REQUIRE(t.process(0.7));
+	// Now another 3 below samples; with timer reset, no auto-fire yet
+	REQUIRE(!t.process(0.0));
+	REQUIRE(!t.process(0.0));
+	REQUIRE(!t.process(0.0));
+	// 4th post-fire sample: auto-fire (counter hits timeout=4)
+	REQUIRE(t.process(0.0));
+	std::cout << "  auto_trigger_real_fire_resets_timer: passed\n";
+}
+
+void test_auto_trigger_reset() {
+	// reset() must clear the timer and reset the inner trigger.
+	using Inner = EdgeTrigger<double>;
+	AutoTriggerWrapper<Inner> t(Inner(0.5, Slope::Rising), /*timeout=*/3);
+	REQUIRE(!t.process(0.0));
+	REQUIRE(!t.process(0.0));
+	t.reset();
+	// After reset, timer is 0 — should take another full timeout to auto-fire
+	REQUIRE(!t.process(0.0));   // 1
+	REQUIRE(!t.process(0.0));   // 2
+	REQUIRE(t.process(0.0));    // 3 — first auto-fire post-reset
+	std::cout << "  auto_trigger_reset: passed\n";
+}
+
+// ============================================================================
 // QualifierAnd
 // ============================================================================
 
@@ -388,6 +467,10 @@ int main() {
 		test_slope_negative_threshold_throws();
 		test_holdoff_basic();
 		test_holdoff_drives_inner();
+		test_auto_trigger_real_preempts_auto();
+		test_auto_trigger_force_fires_after_timeout();
+		test_auto_trigger_real_fire_resets_timer();
+		test_auto_trigger_reset();
 		test_qualifier_and_coincidence();
 		test_qualifier_and_within_window();
 		test_qualifier_and_outside_window();

--- a/tests/test_instrument_trigger.cpp
+++ b/tests/test_instrument_trigger.cpp
@@ -305,6 +305,19 @@ void test_auto_trigger_real_fire_resets_timer() {
 	std::cout << "  auto_trigger_real_fire_resets_timer: passed\n";
 }
 
+void test_auto_trigger_zero_timeout_throws() {
+	// timeout=0 would force-fire on every sample (since_fire_ becomes 1
+	// after the first increment, which is >= 0). The constructor must
+	// reject it.
+	using Inner = EdgeTrigger<double>;
+	bool threw = false;
+	try {
+		AutoTriggerWrapper<Inner> t(Inner(0.5, Slope::Rising), /*timeout=*/0);
+	} catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  auto_trigger_zero_timeout_throws: passed\n";
+}
+
 void test_auto_trigger_reset() {
 	// reset() must clear the timer and reset the inner trigger.
 	using Inner = EdgeTrigger<double>;
@@ -470,6 +483,7 @@ int main() {
 		test_auto_trigger_real_preempts_auto();
 		test_auto_trigger_force_fires_after_timeout();
 		test_auto_trigger_real_fire_resets_timer();
+		test_auto_trigger_zero_timeout_throws();
 		test_auto_trigger_reset();
 		test_qualifier_and_coincidence();
 		test_qualifier_and_within_window();


### PR DESCRIPTION
## Summary

Sub-issue of #133 (Digital Oscilloscope Demonstrator). Small extension to the existing trigger primitive module. Without auto-trigger, a scope viewing a slow or absent signal sits blank waiting for the trigger condition; with it, the user always sees something — a recent capture, even if no edge crossed the threshold.

## What's in this PR

**Appended to** \`include/sw/dsp/instrument/trigger.hpp\`:

\`\`\`cpp
template <class Inner>
class AutoTriggerWrapper {
public:
    AutoTriggerWrapper(Inner inner, std::size_t timeout_samples);
    bool process(sample_scalar x);
    std::size_t samples_since_trigger() const;
    void reset();
};
\`\`\`

Behavior:
- The inner trigger is always driven so its state stays current.
- A real fire from the inner trigger preempts any pending auto-fire and resets the timeout counter.
- An auto-fire on timeout also resets the counter, so on a flat signal auto-fires happen at regular intervals (one every \`timeout_samples\` after the first one).

Layering follows the same pattern as \`HoldoffWrapper\`: one inner trigger, single counter, drives inner unconditionally.

## Files changed

| File | Change |
|---|---|
| \`include/sw/dsp/instrument/trigger.hpp\` | +56 lines (new class + comment block + entry in primitive list) |
| \`tests/test_instrument_trigger.cpp\` | +85 lines (4 new test functions + main() entries) |

## Test results

| Compiler | Build | Tests |
|---|---|---|
| gcc | OK | 23/23 PASS (19 prior + 4 new) |
| clang | OK | 23/23 PASS, identical output |

New tests:
- \`test_auto_trigger_real_preempts_auto\` — real fire before timeout preempts auto-fire and resets timer
- \`test_auto_trigger_force_fires_after_timeout\` — force-fires exactly at the timeout boundary, then again every timeout interval on a flat signal
- \`test_auto_trigger_real_fire_resets_timer\` — after a real fire, the timer restarts (post-fire samples don't carry over)
- \`test_auto_trigger_reset\` — reset() clears the timer

## #133 progress

| # | Status |
|---|---|
| #146 peak-detect decimation | merged ✓ |
| **#147 auto-trigger** | **this PR** |
| #148 cross-channel triggering | open |
| #149 display-rate decimation | open (#146 done; unblocked) |
| #150 multi-channel time alignment | open |
| #151 cursor / measurement primitives | open |
| #152 scope_demo application | open |

## Test plan
- [x] Fast CI passes (gcc + clang)
- [x] CodeRabbit review
- [x] Promote to ready when satisfied

Resolves #147

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an automatic trigger wrapper that emits a periodic trigger when input remains idle, with a configurable timeout, an inactivity counter, and a reset capability.
* **Tests**
  * Adds unit tests validating timed auto-fires on flat input, proper reset behavior, interaction with underlying triggers, and constructor validation for invalid timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->