### PR TITLE
feat(instrument): display-rate min/max envelope (#149)

### DIFF
--- a/include/sw/dsp/instrument/display_envelope.hpp
+++ b/include/sw/dsp/instrument/display_envelope.hpp
@@ -1,0 +1,128 @@
+#pragma once
+// display_envelope.hpp: Reduce a captured signal segment to a fixed-pixel
+// min/max envelope for display-rate rendering.
+//
+// Real scopes do this constantly: a 10-million-sample capture must fit on a
+// 1024-pixel-wide screen. Each pixel column displays the (min, max) of the
+// samples that fell in its time bin. The user's eye sees a vertical line
+// bounding the signal's amplitude in each column — narrow glitches still
+// show up as long as they appeared somewhere in the column's span.
+//
+// Distinct from PeakDetectDecimator (peak_detect.hpp) in two ways:
+//
+//   1. Variable decimation factor: input length is arbitrary, output length
+//      is fixed (pixel_width). The decimation factor falls out of
+//      (input.size() / pixel_width) and is in general not constant —
+//      remainder samples are distributed across leading pixels.
+//
+//   2. One-shot reduction over a complete captured segment, not a streaming
+//      decimator. Free function rather than a stateful class.
+//
+// Both primitives use the same min/max logic; this one just picks the
+// per-bin span dynamically.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp::instrument {
+
+template <DspScalar SampleScalar>
+struct DisplayEnvelope {
+	mtl::vec::dense_vector<SampleScalar> mins;  // length == pixel_width
+	mtl::vec::dense_vector<SampleScalar> maxs;  // length == pixel_width
+};
+
+// =============================================================================
+// render_envelope
+//
+// Reduce `samples` to exactly `pixel_width` (min, max) pairs.
+//
+// Cases:
+//   - samples.size() == 0:
+//       returns an empty envelope (mins.size() == maxs.size() == 0).
+//       pixel_width must still be > 0; an empty envelope is the right
+//       answer because there's nothing to render.
+//   - samples.size() <= pixel_width:
+//       each input sample becomes one pixel column with min == max == that
+//       sample. Trailing pixels (if pixel_width > samples.size()) are
+//       padded with the LAST sample's value, so the trace flat-lines
+//       at the right edge rather than dropping to zero. (This is the
+//       conventional choice; alternatives are NaN or 0, neither of which
+//       renders sensibly.)
+//   - samples.size() > pixel_width:
+//       distribute samples across pixels. Floor-distribution leaves a
+//       remainder of (samples.size() % pixel_width); spread it one extra
+//       sample per leading pixel until exhausted. So the leading
+//       (remainder) pixels each cover ⌈N/W⌉ samples and the trailing
+//       (pixel_width - remainder) pixels each cover ⌊N/W⌋ samples.
+// =============================================================================
+template <DspScalar SampleScalar>
+DisplayEnvelope<SampleScalar> render_envelope(
+		std::span<const SampleScalar> samples,
+		std::size_t                   pixel_width) {
+	if (pixel_width == 0)
+		throw std::invalid_argument(
+			"render_envelope: pixel_width must be > 0");
+
+	DisplayEnvelope<SampleScalar> env{
+		mtl::vec::dense_vector<SampleScalar>(pixel_width),
+		mtl::vec::dense_vector<SampleScalar>(pixel_width)};
+
+	const std::size_t N = samples.size();
+
+	// Empty input — return empty envelope (we still report pixel_width
+	// in the allocated vectors, but they have no meaningful content).
+	// Prefer to surface this by returning an envelope with size 0 so
+	// callers can detect "nothing to render."
+	if (N == 0) {
+		env.mins = mtl::vec::dense_vector<SampleScalar>(0);
+		env.maxs = mtl::vec::dense_vector<SampleScalar>(0);
+		return env;
+	}
+
+	// Sparse case: one input sample per pixel (or fewer). Pad trailing
+	// pixels with the last sample's value so the trace flat-lines at the
+	// edge.
+	if (N <= pixel_width) {
+		for (std::size_t i = 0; i < N; ++i) {
+			env.mins[i] = samples[i];
+			env.maxs[i] = samples[i];
+		}
+		const SampleScalar last = samples[N - 1];
+		for (std::size_t i = N; i < pixel_width; ++i) {
+			env.mins[i] = last;
+			env.maxs[i] = last;
+		}
+		return env;
+	}
+
+	// Dense case: each pixel covers ≥ 1 sample. Distribute the remainder
+	// (N % pixel_width) across the leading pixels.
+	const std::size_t base_span = N / pixel_width;
+	const std::size_t remainder = N % pixel_width;
+
+	std::size_t in_pos = 0;
+	for (std::size_t p = 0; p < pixel_width; ++p) {
+		const std::size_t span = base_span + (p < remainder ? 1 : 0);
+		// At least one sample per pixel since N > pixel_width.
+		SampleScalar mn = samples[in_pos];
+		SampleScalar mx = samples[in_pos];
+		for (std::size_t k = 1; k < span; ++k) {
+			const SampleScalar x = samples[in_pos + k];
+			if (x < mn) mn = x;
+			if (x > mx) mx = x;
+		}
+		env.mins[p] = mn;
+		env.maxs[p] = mx;
+		in_pos += span;
+	}
+	return env;
+}
+
+} // namespace sw::dsp::instrument

--- a/include/sw/dsp/instrument/display_envelope.hpp
+++ b/include/sw/dsp/instrument/display_envelope.hpp
@@ -32,7 +32,7 @@
 
 namespace sw::dsp::instrument {
 
-template <DspScalar SampleScalar>
+template <DspOrderedField SampleScalar>
 struct DisplayEnvelope {
 	mtl::vec::dense_vector<SampleScalar> mins;  // length == pixel_width
 	mtl::vec::dense_vector<SampleScalar> maxs;  // length == pixel_width
@@ -62,7 +62,7 @@ struct DisplayEnvelope {
 //       (remainder) pixels each cover ⌈N/W⌉ samples and the trailing
 //       (pixel_width - remainder) pixels each cover ⌊N/W⌋ samples.
 // =============================================================================
-template <DspScalar SampleScalar>
+template <DspOrderedField SampleScalar>
 DisplayEnvelope<SampleScalar> render_envelope(
 		std::span<const SampleScalar> samples,
 		std::size_t                   pixel_width) {
@@ -70,21 +70,22 @@ DisplayEnvelope<SampleScalar> render_envelope(
 		throw std::invalid_argument(
 			"render_envelope: pixel_width must be > 0");
 
+	const std::size_t N = samples.size();
+
+	// Empty input — return an envelope with zero-length vectors so callers
+	// can detect "nothing to render" via env.mins.size() == 0. Avoid
+	// allocating pixel_width up front in this path; the allocation could
+	// be large (e.g., 10K pixels for a wide display) and there's nothing
+	// to put into it.
+	if (N == 0) {
+		return DisplayEnvelope<SampleScalar>{
+			mtl::vec::dense_vector<SampleScalar>(0),
+			mtl::vec::dense_vector<SampleScalar>(0)};
+	}
+
 	DisplayEnvelope<SampleScalar> env{
 		mtl::vec::dense_vector<SampleScalar>(pixel_width),
 		mtl::vec::dense_vector<SampleScalar>(pixel_width)};
-
-	const std::size_t N = samples.size();
-
-	// Empty input — return empty envelope (we still report pixel_width
-	// in the allocated vectors, but they have no meaningful content).
-	// Prefer to surface this by returning an envelope with size 0 so
-	// callers can detect "nothing to render."
-	if (N == 0) {
-		env.mins = mtl::vec::dense_vector<SampleScalar>(0);
-		env.maxs = mtl::vec::dense_vector<SampleScalar>(0);
-		return env;
-	}
 
 	// Sparse case: one input sample per pixel (or fewer). Pad trailing
 	// pixels with the last sample's value so the trace flat-lines at the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,3 +116,6 @@ target_compile_definitions(test_instrument_calibration PRIVATE
 
 # Instrument peak-detect (min/max) decimation (Issue #146)
 dsp_add_test(test_instrument_peak_detect)
+
+# Instrument display-rate envelope (Issue #149)
+dsp_add_test(test_instrument_display_envelope)

--- a/tests/test_instrument_display_envelope.cpp
+++ b/tests/test_instrument_display_envelope.cpp
@@ -1,0 +1,245 @@
+// test_instrument_display_envelope.cpp: tests for the display-rate min/max
+// envelope reducer.
+//
+// Coverage:
+//   - Exact division: input length is a clean multiple of pixel_width
+//   - Inexact division: remainder distributed across leading pixels
+//   - Sparse: input shorter than pixel_width (passthrough + tail padding)
+//   - Single-pixel output: one (min, max) covering the whole input
+//   - Empty input: returns empty envelope; pixel_width=0 throws
+//   - **Glitch survival**: 5-sample-wide narrow glitch in a 10000-sample
+//     square wave reduced to 100 pixels — the glitch's peak amplitude
+//     must show up in its corresponding pixel's max.
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <span>
+#include <stdexcept>
+#include <string>
+
+#include <sw/dsp/instrument/display_envelope.hpp>
+
+using namespace sw::dsp::instrument;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+// ============================================================================
+// Exact division
+// ============================================================================
+
+void test_exact_division() {
+	// 8 samples, 4 pixels — each pixel covers 2 samples.
+	std::array<int, 8> in = {1, 5, 2, 6, 7, 3, 8, 4};
+	auto env = render_envelope<int>(std::span<const int>{in}, 4);
+	REQUIRE(env.mins.size() == 4);
+	REQUIRE(env.maxs.size() == 4);
+	// pixel 0: {1, 5} → (1, 5)
+	// pixel 1: {2, 6} → (2, 6)
+	// pixel 2: {7, 3} → (3, 7)
+	// pixel 3: {8, 4} → (4, 8)
+	REQUIRE(env.mins[0] == 1 && env.maxs[0] == 5);
+	REQUIRE(env.mins[1] == 2 && env.maxs[1] == 6);
+	REQUIRE(env.mins[2] == 3 && env.maxs[2] == 7);
+	REQUIRE(env.mins[3] == 4 && env.maxs[3] == 8);
+	std::cout << "  exact_division: passed\n";
+}
+
+// ============================================================================
+// Inexact division — remainder distributed across leading pixels
+// ============================================================================
+
+void test_inexact_division() {
+	// 7 samples, 3 pixels — base_span=2, remainder=1
+	// Leading 1 pixel gets span=3, trailing 2 pixels get span=2.
+	// Pixel 0: samples[0..2]   = {1,2,3} → (1, 3)
+	// Pixel 1: samples[3..4]   = {4, 5}  → (4, 5)
+	// Pixel 2: samples[5..6]   = {6, 7}  → (6, 7)
+	std::array<int, 7> in = {1, 2, 3, 4, 5, 6, 7};
+	auto env = render_envelope<int>(std::span<const int>{in}, 3);
+	REQUIRE(env.mins.size() == 3 && env.maxs.size() == 3);
+	REQUIRE(env.mins[0] == 1 && env.maxs[0] == 3);
+	REQUIRE(env.mins[1] == 4 && env.maxs[1] == 5);
+	REQUIRE(env.mins[2] == 6 && env.maxs[2] == 7);
+	std::cout << "  inexact_division: passed\n";
+}
+
+void test_inexact_division_large_remainder() {
+	// 10 samples, 3 pixels — base_span=3, remainder=1
+	// Leading 1 pixel gets span=4, trailing 2 pixels get span=3.
+	// Pixel 0: samples[0..3]   = {0,1,2,3} → (0, 3)
+	// Pixel 1: samples[4..6]   = {4,5,6}   → (4, 6)
+	// Pixel 2: samples[7..9]   = {7,8,9}   → (7, 9)
+	std::array<int, 10> in = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+	auto env = render_envelope<int>(std::span<const int>{in}, 3);
+	REQUIRE(env.mins[0] == 0 && env.maxs[0] == 3);
+	REQUIRE(env.mins[1] == 4 && env.maxs[1] == 6);
+	REQUIRE(env.mins[2] == 7 && env.maxs[2] == 9);
+	std::cout << "  inexact_division_large_remainder: passed\n";
+}
+
+// ============================================================================
+// Sparse: input shorter than pixel_width
+// ============================================================================
+
+void test_sparse_input_shorter() {
+	// 3 samples → 8 pixels. First 3 pixels each get one sample (min == max);
+	// trailing 5 pixels are padded with the last sample's value.
+	std::array<int, 3> in = {10, 20, 30};
+	auto env = render_envelope<int>(std::span<const int>{in}, 8);
+	REQUIRE(env.mins.size() == 8 && env.maxs.size() == 8);
+	REQUIRE(env.mins[0] == 10 && env.maxs[0] == 10);
+	REQUIRE(env.mins[1] == 20 && env.maxs[1] == 20);
+	REQUIRE(env.mins[2] == 30 && env.maxs[2] == 30);
+	for (std::size_t p = 3; p < 8; ++p) {
+		REQUIRE(env.mins[p] == 30 && env.maxs[p] == 30);
+	}
+	std::cout << "  sparse_input_shorter: passed\n";
+}
+
+void test_sparse_equal_width() {
+	// N == pixel_width — each sample becomes one pixel; no padding.
+	std::array<int, 4> in = {7, 8, 9, 10};
+	auto env = render_envelope<int>(std::span<const int>{in}, 4);
+	REQUIRE(env.mins.size() == 4);
+	for (std::size_t i = 0; i < 4; ++i) {
+		REQUIRE(env.mins[i] == in[i]);
+		REQUIRE(env.maxs[i] == in[i]);
+	}
+	std::cout << "  sparse_equal_width: passed\n";
+}
+
+// ============================================================================
+// Single-pixel output
+// ============================================================================
+
+void test_single_pixel() {
+	// pixel_width=1: one (min, max) covering everything.
+	std::array<int, 5> in = {3, 7, 1, 9, 5};
+	auto env = render_envelope<int>(std::span<const int>{in}, 1);
+	REQUIRE(env.mins.size() == 1 && env.maxs.size() == 1);
+	REQUIRE(env.mins[0] == 1);
+	REQUIRE(env.maxs[0] == 9);
+	std::cout << "  single_pixel: passed\n";
+}
+
+// ============================================================================
+// Edge cases: empty input, zero pixel width
+// ============================================================================
+
+void test_empty_input() {
+	std::span<const int> empty;
+	auto env = render_envelope<int>(empty, 100);
+	// Empty envelope — explicit signal that there's nothing to render.
+	REQUIRE(env.mins.size() == 0);
+	REQUIRE(env.maxs.size() == 0);
+	std::cout << "  empty_input: passed\n";
+}
+
+void test_zero_pixel_width_throws() {
+	std::array<int, 4> in = {1, 2, 3, 4};
+	bool threw = false;
+	try {
+		(void)render_envelope<int>(std::span<const int>{in}, 0);
+	} catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  zero_pixel_width_throws: passed\n";
+}
+
+// ============================================================================
+// GLITCH-SURVIVAL TEST — the headline acceptance criterion
+//
+// 50 MHz square wave at fs=1 GSPS = 20 samples/period, 10000 samples
+// total. Buried in a low phase: a 5-sample-wide narrow positive glitch
+// (peak +1.5, square wave ±1.0). Render to 100 pixels — input/output
+// ratio is 100:1 and the glitch is only 5 samples wide, so a generic
+// averaging or polyphase decimator would average it out below the
+// noise floor. Min/max envelope keeps the peak at 1.5 in whichever
+// pixel the glitch happened to fall in.
+// ============================================================================
+
+constexpr std::size_t kStreamSize = 10000;
+
+std::array<float, kStreamSize> make_square_wave_with_glitch() {
+	std::array<float, kStreamSize> stream{};
+	for (std::size_t n = 0; n < kStreamSize; ++n) {
+		stream[n] = ((n / 10) % 2 == 0) ? 1.0f : -1.0f;
+	}
+	// Glitch in samples [5010..5014] — within a low-phase region.
+	for (std::size_t n = 5010; n < 5015; ++n) {
+		stream[n] = 1.5f;
+	}
+	return stream;
+}
+
+void test_glitch_survives_at_100_pixels() {
+	const auto stream = make_square_wave_with_glitch();
+	const float glitch_peak = 1.5f;
+
+	auto env = render_envelope<float>(
+		std::span<const float>{stream}, /*pixel_width=*/100);
+	REQUIRE(env.mins.size() == 100);
+	REQUIRE(env.maxs.size() == 100);
+
+	// Find the peak of the max stream — should be exactly the glitch
+	// amplitude. With averaging/polyphase, this would have averaged
+	// down toward (5*1.5 + 95*-1)/100 ≈ -0.875 — far below 1.0,
+	// invisible against the square wave's ±1.0.
+	float observed_peak = -1e9f;
+	std::size_t glitch_pixel = 0;
+	for (std::size_t i = 0; i < env.maxs.size(); ++i) {
+		if (env.maxs[i] > observed_peak) {
+			observed_peak = env.maxs[i];
+			glitch_pixel = i;
+		}
+	}
+	if (!(std::abs(observed_peak - glitch_peak) < 1e-5f))
+		throw std::runtime_error(
+			"glitch lost: observed_peak=" + std::to_string(observed_peak) +
+			" want=" + std::to_string(glitch_peak));
+
+	// Sanity: glitch was at samples ~5010-5014 in a 10000-sample stream
+	// reduced to 100 pixels (each pixel covers 100 samples). So the
+	// glitch should land in pixel 50 (samples 5000..5099).
+	if (!(glitch_pixel == 50))
+		throw std::runtime_error(
+			"glitch in pixel " + std::to_string(glitch_pixel) +
+			", expected pixel 50");
+	std::cout << "  glitch_survives_at_100_pixels: passed (pixel "
+	          << glitch_pixel << ", peak=" << observed_peak << ")\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_instrument_display_envelope\n";
+
+		test_exact_division();
+		test_inexact_division();
+		test_inexact_division_large_remainder();
+		test_sparse_input_shorter();
+		test_sparse_equal_width();
+		test_single_pixel();
+		test_empty_input();
+		test_zero_pixel_width_throws();
+		test_glitch_survives_at_100_pixels();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}

--- a/tests/test_instrument_display_envelope.cpp
+++ b/tests/test_instrument_display_envelope.cpp
@@ -74,16 +74,21 @@ void test_inexact_division() {
 }
 
 void test_inexact_division_large_remainder() {
-	// 10 samples, 3 pixels — base_span=3, remainder=1
-	// Leading 1 pixel gets span=4, trailing 2 pixels get span=3.
-	// Pixel 0: samples[0..3]   = {0,1,2,3} → (0, 3)
-	// Pixel 1: samples[4..6]   = {4,5,6}   → (4, 6)
-	// Pixel 2: samples[7..9]   = {7,8,9}   → (7, 9)
-	std::array<int, 10> in = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-	auto env = render_envelope<int>(std::span<const int>{in}, 3);
-	REQUIRE(env.mins[0] == 0 && env.maxs[0] == 3);
-	REQUIRE(env.mins[1] == 4 && env.maxs[1] == 6);
-	REQUIRE(env.mins[2] == 7 && env.maxs[2] == 9);
+	// 11 samples, 4 pixels — base_span=2, remainder=3
+	// Leading 3 pixels get span=3 (cover 3 samples each), trailing 1
+	// pixel gets span=2. Verifies the extra-sample distribution is
+	// correctly applied to ALL `remainder` leading pixels, not just one.
+	// Pixel 0: samples[0..2]   = {0,1,2}   → (0, 2)
+	// Pixel 1: samples[3..5]   = {3,4,5}   → (3, 5)
+	// Pixel 2: samples[6..8]   = {6,7,8}   → (6, 8)
+	// Pixel 3: samples[9..10]  = {9,10}    → (9, 10)
+	std::array<int, 11> in = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+	auto env = render_envelope<int>(std::span<const int>{in}, 4);
+	REQUIRE(env.mins.size() == 4 && env.maxs.size() == 4);
+	REQUIRE(env.mins[0] == 0 && env.maxs[0] == 2);
+	REQUIRE(env.mins[1] == 3 && env.maxs[1] == 5);
+	REQUIRE(env.mins[2] == 6 && env.maxs[2] == 8);
+	REQUIRE(env.mins[3] == 9 && env.maxs[3] == 10);
 	std::cout << "  inexact_division_large_remainder: passed\n";
 }
 


### PR DESCRIPTION
## Summary

Sub-issue of #133 (Digital Oscilloscope Demonstrator). Builds on #146 (peak-detect, just merged). The display-pipeline counterpart: takes a captured segment of arbitrary length and reduces it to exactly N (min, max) pairs — one per pixel column — for direct screen rendering.

## What's in this PR

**New header** \`include/sw/dsp/instrument/display_envelope.hpp\`:

\`\`\`cpp
template <DspScalar T>
struct DisplayEnvelope { dense_vector<T> mins, maxs; };

template <DspScalar T>
DisplayEnvelope<T> render_envelope(
    std::span<const T> samples, std::size_t pixel_width);
\`\`\`

## Distinct from #146 in two ways

1. **Variable per-pixel decimation factor.** Falls out of \`samples.size() / pixel_width\` and isn't constant. The remainder \`samples.size() % pixel_width\` is distributed across leading pixels — leading R pixels each cover ⌈N/W⌉ samples, trailing (W-R) pixels each cover ⌊N/W⌋.
2. **One-shot reduction**, not streaming. Free function rather than a stateful class.

## Edge cases handled

| Case | Behavior |
|---|---|
| \`samples.size() < pixel_width\` | Each input → one pixel; trailing pixels pad with last value (flat-line right edge) |
| \`samples.size() == 0\` | Returns empty envelope (callers can detect "nothing to render") |
| \`pixel_width == 0\` | Throws \`std::invalid_argument\` |

## Headline test: glitch survival

\`test_glitch_survives_at_100_pixels\` reduces a 10000-sample square wave (50 MHz at 1 GSPS) with a 5-sample-wide narrow positive glitch to 100 pixels (100:1 ratio). The glitch's peak amplitude survives in pixel 50's max. A generic averaging decimator at the same ratio would smear the glitch to ~-0.875 — invisible against the ±1.0 square-wave background.

## Files changed

| File | Change |
|---|---|
| \`include/sw/dsp/instrument/display_envelope.hpp\` | NEW — ~110 lines |
| \`tests/test_instrument_display_envelope.cpp\` | NEW — 9 tests, ~230 lines |
| \`tests/CMakeLists.txt\` | +3 lines |

## Test results

| Compiler | Build | Tests |
|---|---|---|
| gcc | OK | 9/9 PASS |
| clang | OK | 9/9 PASS |

## #133 progress after this lands

| # | Status |
|---|---|
| #146 peak-detect | merged ✓ |
| #147 auto-trigger | merged ✓ |
| **#149 display-rate envelope** | **this PR** |
| #148 cross-channel triggering | open |
| #150 multi-channel time alignment | open |
| #151 cursor / measurement primitives | open |
| #152 scope_demo application | open (depends on all above) |

## Test plan
- [x] Fast CI passes (gcc + clang)
- [x] CodeRabbit review
- [x] Promote to ready when satisfied

Resolves #149

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added envelope rendering to convert arbitrary-length audio into fixed-width waveform displays, producing per-pixel minimum and maximum sample values; handles empty inputs and pads short signals to fill pixels.

* **Tests**
  * Added comprehensive tests covering exact/inexact partitioning, padding behavior, single-pixel and empty cases, error on zero pixel width, and a glitch-preservation check to ensure narrow spikes survive rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->