### PR TITLE
fix(instrument): tighten peak_detect concept to DspOrderedField (#162)

### DIFF
--- a/include/sw/dsp/instrument/peak_detect.hpp
+++ b/include/sw/dsp/instrument/peak_detect.hpp
@@ -16,8 +16,10 @@
 // display_envelope.hpp / issue #149).
 //
 // Precision-insensitive: min/max are reductions, not arithmetic. The
-// SampleScalar parameter only controls the type of the values being
-// compared and emitted.
+// SampleScalar type only controls the values being compared and emitted.
+// Constrained on DspOrderedField (the < / > comparisons require ordering),
+// matching the convention used elsewhere in the library for min/max-using
+// primitives — see morphology.hpp, agc.hpp, generators.hpp.
 //
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -55,13 +57,13 @@ namespace sw::dsp::instrument {
 // returns both vectors as a PeakDetectEnvelope struct in a single call.
 // =============================================================================
 
-template <DspScalar SampleScalar>
+template <DspOrderedField SampleScalar>
 struct PeakDetectEnvelope {
 	mtl::vec::dense_vector<SampleScalar> mins;
 	mtl::vec::dense_vector<SampleScalar> maxs;
 };
 
-template <DspScalar SampleScalar>
+template <DspOrderedField SampleScalar>
 class PeakDetectDecimator {
 public:
 	using sample_scalar = SampleScalar;


### PR DESCRIPTION
## Summary

Trivial concept-tightening follow-up from PR #161's review. The \`PeakDetectDecimator\` class and \`PeakDetectEnvelope\` struct in \`include/sw/dsp/instrument/peak_detect.hpp\` (from the merged #146) were templated on \`DspScalar\`, but the implementation uses \`<\` and \`>\` for min/max comparisons — which require ordering, not just arithmetic.

\`DspOrderedField\` is the established library convention for min/max-using primitives (used by \`morphology.hpp\`, \`agc.hpp\`, \`generators.hpp\`). PR #161 tightened \`display_envelope.hpp\` for the same reason; this PR brings \`peak_detect.hpp\` into line.

## Files changed

| File | Change |
|---|---|
| \`include/sw/dsp/instrument/peak_detect.hpp\` | 2 template parameters \`DspScalar\` → \`DspOrderedField\` + 3-line header-comment expansion explaining the convention |

No test changes needed: \`int\`, \`float\`, \`double\` all satisfy \`DspOrderedField\`.

## Test results

| Compiler | Build | Tests |
|---|---|---|
| gcc | OK | 11/11 PASS |
| clang | OK | 11/11 PASS |

## Test plan
- [x] Fast CI passes (gcc + clang)
- [x] Promote to ready when satisfied

Resolves #162

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened type constraints for peak detection components to enforce ordered field types, ensuring proper comparison operations and improving type safety.

* **Documentation**
  * Updated inline documentation to clarify ordering requirements for sample scalar types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->