### PR TITLE
feat(instrument): cross-channel trigger composition (#148)

### DIFF
--- a/include/sw/dsp/instrument/trigger.hpp
+++ b/include/sw/dsp/instrument/trigger.hpp
@@ -20,6 +20,10 @@
 //                     and resets the timeout counter.
 //   QualifierAnd    — fires when two triggers both fire within a window
 //   QualifierOr     — fires when either of two triggers fires
+//   CrossChannelTrigger — multi-channel scope-style trigger composing two
+//                     channels via one of seven named modes (OnlyA / OnlyB
+//                     / AandB / AorB / AxorB / AnotB / BnotA), with a
+//                     configurable inter-channel coincidence window.
 //
 // All primitives are parameterized on a single SampleScalar type. Comparisons
 // are precision-sensitive at low signal amplitudes — narrow types may
@@ -404,6 +408,136 @@ public:
 private:
 	TrigA a_;
 	TrigB b_;
+};
+
+// =============================================================================
+// CrossChannelTrigger
+//
+// Multi-channel scope-style trigger: composes two channel triggers via one
+// of seven named modes. Each `process` call takes one synchronized sample
+// from each channel.
+//
+// Modes:
+//   OnlyA  — fire when channel A's inner trigger fires (B is ignored but
+//            still driven so its state stays current)
+//   OnlyB  — symmetric
+//   AandB  — coincidence: fire when both A and B fire within `window` samples
+//            of each other. Both `since_` counters reset to "never" on fire so
+//            the same coincidence can't fire twice.
+//   AorB   — fire when either A or B fires this sample
+//   AxorB  — fire when exactly one of A/B is active in the window: A fires
+//            with no recent B, OR B fires with no recent A. Same-sample
+//            (A and B both fire) does NOT fire (both are "active"). No
+//            counter reset — repeated solo events keep firing.
+//   AnotB  — qualified A: A fires AND B has not fired in the past `window`
+//            samples. (Useful for "trigger on data line edge but not when
+//            clock is high".)
+//   BnotA  — symmetric.
+//
+// `window_samples` is the maximum age (in samples) at which a prior fire of
+// the OTHER channel is still considered "recent". Default 1 — a same-sample
+// AandB requires window=0; the default 1 admits one-sample-apart pairs.
+//
+// Sample synchronization: this wrapper assumes channels A and B are sample-
+// aligned (same rate, same time origin). Sub-sample alignment between
+// channels is a separate concern handled by #150 (multi-channel time
+// alignment).
+//
+// The two inner triggers can have different SampleScalar types (e.g.,
+// channel A in float, channel B in fixpnt) — each side is templated
+// independently.
+// =============================================================================
+
+enum class CrossChannelMode {
+	OnlyA,
+	OnlyB,
+	AandB,
+	AorB,
+	AxorB,
+	AnotB,
+	BnotA,
+};
+
+template <class TrigA, class TrigB>
+class CrossChannelTrigger {
+public:
+	using sample_a = typename TrigA::sample_scalar;
+	using sample_b = typename TrigB::sample_scalar;
+
+	CrossChannelTrigger(TrigA a, TrigB b,
+	                    CrossChannelMode mode,
+	                    std::size_t window_samples = 1)
+		: a_(std::move(a)),
+		  b_(std::move(b)),
+		  mode_(mode),
+		  window_(window_samples),
+		  since_a_(kInf),
+		  since_b_(kInf) {}
+
+	bool process(sample_a xa, sample_b xb) {
+		// Increment age counters BEFORE running inner triggers, so a fire
+		// this sample lands at since_X = 0.
+		if (since_a_ != kInf && since_a_ < kInf - 1) ++since_a_;
+		if (since_b_ != kInf && since_b_ < kInf - 1) ++since_b_;
+
+		// Drive both inner triggers unconditionally so their state stays
+		// current regardless of which channel the wrapper "cares about".
+		const bool a_fired = a_.process(xa);
+		const bool b_fired = b_.process(xb);
+		if (a_fired) since_a_ = 0;
+		if (b_fired) since_b_ = 0;
+
+		switch (mode_) {
+			case CrossChannelMode::OnlyA: return a_fired;
+			case CrossChannelMode::OnlyB: return b_fired;
+
+			case CrossChannelMode::AandB: {
+				if (since_a_ <= window_ && since_b_ <= window_) {
+					// Coincidence consumed — clear both so the same pair
+					// can't fire repeatedly while both ages are < window.
+					since_a_ = kInf;
+					since_b_ = kInf;
+					return true;
+				}
+				return false;
+			}
+
+			case CrossChannelMode::AorB:
+				return a_fired || b_fired;
+
+			case CrossChannelMode::AxorB: {
+				// "Exactly one is active in the window" — A fires with no
+				// recent B, or B fires with no recent A. Same-sample
+				// firings of both fail both checks (since_other == 0).
+				const bool a_solo = a_fired && (since_b_ > window_);
+				const bool b_solo = b_fired && (since_a_ > window_);
+				return a_solo || b_solo;
+			}
+
+			case CrossChannelMode::AnotB:
+				return a_fired && (since_b_ > window_);
+
+			case CrossChannelMode::BnotA:
+				return b_fired && (since_a_ > window_);
+		}
+		return false;  // unreachable; quiet the compiler on enum coverage
+	}
+
+	void reset() {
+		a_.reset();
+		b_.reset();
+		since_a_ = kInf;
+		since_b_ = kInf;
+	}
+
+private:
+	static constexpr std::size_t kInf = std::numeric_limits<std::size_t>::max();
+	TrigA            a_;
+	TrigB            b_;
+	CrossChannelMode mode_;
+	std::size_t      window_;
+	std::size_t      since_a_;
+	std::size_t      since_b_;
 };
 
 } // namespace sw::dsp::instrument

--- a/include/sw/dsp/instrument/trigger.hpp
+++ b/include/sw/dsp/instrument/trigger.hpp
@@ -434,9 +434,20 @@ private:
 //            clock is high".)
 //   BnotA  — symmetric.
 //
-// `window_samples` is the maximum age (in samples) at which a prior fire of
-// the OTHER channel is still considered "recent". Default 1 — a same-sample
-// AandB requires window=0; the default 1 admits one-sample-apart pairs.
+// `window_samples` is the maximum allowed age (in samples) of a prior
+// fire on the OTHER channel for it to count as "recent". The check is
+// inclusive: `since_other <= window_samples` means "still recent."
+//
+//   window_samples = 0 → only same-sample (both fires must land on the
+//                         same `process()` call, since=0 for both)
+//   window_samples = 1 (default) → admits same-sample AND one-sample-apart
+//   window_samples = N → admits ages 0..N inclusive
+//
+// `window_samples == std::numeric_limits<std::size_t>::max()` is rejected
+// because it collides with the internal "never fired" sentinel (would
+// cause AandB/AnotB/etc. to fire spuriously before any inner trigger has
+// fired). Callers wanting an effectively-unlimited window should use
+// `max() - 1` instead.
 //
 // Sample synchronization: this wrapper assumes channels A and B are sample-
 // aligned (same rate, same time origin). Sub-sample alignment between
@@ -472,7 +483,17 @@ public:
 		  mode_(mode),
 		  window_(window_samples),
 		  since_a_(kInf),
-		  since_b_(kInf) {}
+		  since_b_(kInf) {
+		// kInf is the internal "never fired" sentinel. If a caller passes
+		// kInf as window_samples, the `since_X <= window_` checks become
+		// trivially true even for the sentinel and AandB/AnotB/etc. would
+		// fire before any inner trigger has fired. Reject explicitly.
+		if (window_samples == kInf)
+			throw std::invalid_argument(
+				"CrossChannelTrigger: window_samples must be < "
+				"std::numeric_limits<std::size_t>::max() "
+				"(use max() - 1 for an effectively-unlimited window)");
+	}
 
 	bool process(sample_a xa, sample_b xb) {
 		// Increment age counters BEFORE running inner triggers, so a fire

--- a/tests/test_instrument_trigger.cpp
+++ b/tests/test_instrument_trigger.cpp
@@ -399,6 +399,225 @@ void test_qualifier_or() {
 }
 
 // ============================================================================
+// CrossChannelTrigger
+// ============================================================================
+//
+// Test pattern for each mode: positive case (fires when expected),
+// negative case (doesn't fire when not expected), and (where applicable)
+// windowing semantics. All tests use rising-edge triggers on level=0.5
+// so the inputs are easy to read.
+
+using TA = EdgeTrigger<double>;
+using TB = EdgeTrigger<double>;
+
+template <class CCT>
+void prime_below(CCT& q) {
+	// Establish "below" state in both inner triggers so the next
+	// up-cross is a real fire (EdgeTrigger requires a prior Below state).
+	(void)q.process(0.0, 0.0);
+}
+
+void test_cct_only_a() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::OnlyA);
+	prime_below(q);
+	REQUIRE(q.process(0.7, 0.0));    // A up-cross — fires
+	REQUIRE(!q.process(0.0, 0.7));   // B up-cross alone — ignored
+	std::cout << "  cct_only_a: passed\n";
+}
+
+void test_cct_only_b() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::OnlyB);
+	prime_below(q);
+	REQUIRE(!q.process(0.7, 0.0));   // A — ignored
+	REQUIRE(q.process(0.0, 0.7));    // B — fires
+	std::cout << "  cct_only_b: passed\n";
+}
+
+void test_cct_aandb_same_sample() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AandB,
+	                               /*window=*/0);
+	prime_below(q);
+	REQUIRE(q.process(0.7, 0.7));    // both fire same sample — fires
+	std::cout << "  cct_aandb_same_sample: passed\n";
+}
+
+void test_cct_aandb_within_window() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AandB,
+	                               /*window=*/3);
+	prime_below(q);
+	REQUIRE(!q.process(0.7, 0.0));   // A fires; no B yet
+	REQUIRE(!q.process(0.8, 0.0));   // 1 sample later
+	REQUIRE(!q.process(0.9, 0.0));   // 2 samples later
+	REQUIRE(q.process(0.9, 0.7));    // 3 samples later — B fires, in window
+	std::cout << "  cct_aandb_within_window: passed\n";
+}
+
+void test_cct_aandb_outside_window() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AandB,
+	                               /*window=*/2);
+	prime_below(q);
+	REQUIRE(!q.process(0.7, 0.0));   // A fires
+	REQUIRE(!q.process(0.8, 0.0));   // 1
+	REQUIRE(!q.process(0.9, 0.0));   // 2 — still in window
+	REQUIRE(!q.process(0.9, 0.0));   // 3 — out of window
+	REQUIRE(!q.process(0.9, 0.7));   // 4 — B fires, but A is outside
+	std::cout << "  cct_aandb_outside_window: passed\n";
+}
+
+void test_cct_aandb_no_double_fire_on_same_coincidence() {
+	// After AandB fires, both `since_` counters reset to "never". So a
+	// subsequent sample where neither inner fires must NOT re-trigger
+	// AandB just because the previous fires are still mathematically
+	// "in window".
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AandB,
+	                               /*window=*/5);
+	prime_below(q);
+	REQUIRE(q.process(0.7, 0.7));    // coincidence — fires
+	REQUIRE(!q.process(0.8, 0.8));   // both still high — no inner fire,
+	                                  // no AandB re-fire either
+	REQUIRE(!q.process(0.9, 0.9));
+	std::cout << "  cct_aandb_no_double_fire_on_same_coincidence: passed\n";
+}
+
+void test_cct_aorb() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AorB);
+	prime_below(q);
+	REQUIRE(q.process(0.7, 0.0));    // A alone — fires
+	REQUIRE(q.process(0.0, 0.7));    // B alone — fires (after both fall)
+	REQUIRE(!q.process(0.0, 0.0));   // neither — no fire
+	REQUIRE(q.process(0.7, 0.7));    // both same sample — fires
+	std::cout << "  cct_aorb: passed\n";
+}
+
+void test_cct_axorb_same_sample_no_fire() {
+	// XOR: same-sample firings of both should NOT fire (both are active).
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AxorB,
+	                               /*window=*/0);
+	prime_below(q);
+	REQUIRE(!q.process(0.7, 0.7));   // both same sample — no fire
+	std::cout << "  cct_axorb_same_sample_no_fire: passed\n";
+}
+
+void test_cct_axorb_a_alone_fires() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AxorB,
+	                               /*window=*/3);
+	prime_below(q);
+	REQUIRE(q.process(0.7, 0.0));    // A alone — fires (B has never fired)
+	std::cout << "  cct_axorb_a_alone_fires: passed\n";
+}
+
+void test_cct_axorb_b_within_window_suppressed() {
+	// After A fires solo, a B fire within the window is "coincident with
+	// A" and should NOT fire as solo.
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AxorB,
+	                               /*window=*/5);
+	prime_below(q);
+	REQUIRE(q.process(0.7, 0.0));    // A solo — fires
+	REQUIRE(!q.process(0.0, 0.0));   // gap
+	REQUIRE(!q.process(0.0, 0.7));   // B — within A's 5-sample window — suppressed
+	std::cout << "  cct_axorb_b_within_window_suppressed: passed\n";
+}
+
+void test_cct_axorb_b_outside_window_fires() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AxorB,
+	                               /*window=*/2);
+	prime_below(q);
+	REQUIRE(q.process(0.7, 0.0));    // A solo — fires
+	REQUIRE(!q.process(0.0, 0.0));   // 1
+	REQUIRE(!q.process(0.0, 0.0));   // 2 — A still active
+	REQUIRE(!q.process(0.0, 0.0));   // 3 — A out of window
+	REQUIRE(q.process(0.0, 0.7));    // 4 — B solo, A is outside window
+	std::cout << "  cct_axorb_b_outside_window_fires: passed\n";
+}
+
+void test_cct_anotb_a_alone_fires() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AnotB,
+	                               /*window=*/3);
+	prime_below(q);
+	REQUIRE(q.process(0.7, 0.0));    // A fires, B has never — fires
+	std::cout << "  cct_anotb_a_alone_fires: passed\n";
+}
+
+void test_cct_anotb_a_within_window_of_b_suppressed() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AnotB,
+	                               /*window=*/5);
+	prime_below(q);
+	REQUIRE(!q.process(0.0, 0.7));   // B fires (no A) — AnotB requires A
+	REQUIRE(!q.process(0.0, 0.0));   // gap
+	REQUIRE(!q.process(0.7, 0.0));   // A fires, but B is in window — suppressed
+	std::cout << "  cct_anotb_a_within_window_of_b_suppressed: passed\n";
+}
+
+void test_cct_anotb_a_outside_window_of_b_fires() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AnotB,
+	                               /*window=*/2);
+	prime_below(q);
+	REQUIRE(!q.process(0.0, 0.7));   // B fires
+	REQUIRE(!q.process(0.0, 0.0));   // 1 (B still active)
+	REQUIRE(!q.process(0.0, 0.0));   // 2 (B at boundary, still active)
+	REQUIRE(!q.process(0.0, 0.0));   // 3 (B out of window)
+	REQUIRE(q.process(0.7, 0.0));    // A fires, B outside window — fires
+	std::cout << "  cct_anotb_a_outside_window_of_b_fires: passed\n";
+}
+
+void test_cct_bnota_mirror() {
+	// Single mirror test: B fires + A absent → fires; B fires + A recent → no.
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::BnotA,
+	                               /*window=*/3);
+	prime_below(q);
+	REQUIRE(q.process(0.0, 0.7));    // B alone — fires
+	REQUIRE(!q.process(0.7, 0.0));   // A fires; BnotA only fires on B
+	REQUIRE(!q.process(0.0, 0.0));   // 1 (A active)
+	REQUIRE(!q.process(0.0, 0.7));   // B fires but A is at age 2 ≤ 3 → no fire
+	std::cout << "  cct_bnota_mirror: passed\n";
+}
+
+void test_cct_reset() {
+	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
+	                               TB(0.5, Slope::Rising),
+	                               CrossChannelMode::AandB,
+	                               /*window=*/3);
+	prime_below(q);
+	REQUIRE(!q.process(0.7, 0.0));   // A fires
+	q.reset();
+	prime_below(q);
+	// After reset, since_a is back to "never". A subsequent B fire should
+	// NOT pair with the pre-reset A fire.
+	REQUIRE(!q.process(0.0, 0.7));   // B fires; A's prior fire forgotten
+	std::cout << "  cct_reset: passed\n";
+}
+
+// ============================================================================
 // Precision sweep — minimum-detectable-edge across types
 // ============================================================================
 
@@ -489,6 +708,22 @@ int main() {
 		test_qualifier_and_within_window();
 		test_qualifier_and_outside_window();
 		test_qualifier_or();
+		test_cct_only_a();
+		test_cct_only_b();
+		test_cct_aandb_same_sample();
+		test_cct_aandb_within_window();
+		test_cct_aandb_outside_window();
+		test_cct_aandb_no_double_fire_on_same_coincidence();
+		test_cct_aorb();
+		test_cct_axorb_same_sample_no_fire();
+		test_cct_axorb_a_alone_fires();
+		test_cct_axorb_b_within_window_suppressed();
+		test_cct_axorb_b_outside_window_fires();
+		test_cct_anotb_a_alone_fires();
+		test_cct_anotb_a_within_window_of_b_suppressed();
+		test_cct_anotb_a_outside_window_of_b_fires();
+		test_cct_bnota_mirror();
+		test_cct_reset();
 		test_precision_sweep_minimum_detectable();
 
 		std::cout << "all tests passed\n";

--- a/tests/test_instrument_trigger.cpp
+++ b/tests/test_instrument_trigger.cpp
@@ -18,6 +18,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -602,6 +603,43 @@ void test_cct_bnota_mirror() {
 	std::cout << "  cct_bnota_mirror: passed\n";
 }
 
+void test_cct_window_kinf_throws() {
+	// window_samples == kInf collides with the "never fired" sentinel; the
+	// constructor must reject it.
+	bool threw = false;
+	try {
+		CrossChannelTrigger<TA, TB> q(
+			TA(0.5, Slope::Rising), TB(0.5, Slope::Rising),
+			CrossChannelMode::AandB,
+			std::numeric_limits<std::size_t>::max());
+	} catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  cct_window_kinf_throws: passed\n";
+}
+
+void test_cct_mixed_scalar_types() {
+	// Smoke test: heterogeneous inner-trigger scalar types. The wrapper
+	// should accept TrigA::sample_scalar = float and
+	// TrigB::sample_scalar = posit<16,2> with no coupling between the
+	// two channels.
+	using TAH = EdgeTrigger<float>;
+	using TBH = EdgeTrigger<sw::universal::posit<16, 2>>;
+	using P16 = sw::universal::posit<16, 2>;
+
+	CrossChannelTrigger<TAH, TBH> q(
+		TAH(0.5f, Slope::Rising),
+		TBH(P16(0.5), Slope::Rising),
+		CrossChannelMode::AorB);
+
+	// Prime both inner triggers to "below" state via a fully-typed call.
+	(void)q.process(0.0f, P16(0.0));
+	// A up-cross via float; B stays at zero.
+	REQUIRE(q.process(0.7f, P16(0.0)));
+	// B up-cross via posit; A back to zero.
+	REQUIRE(q.process(0.0f, P16(0.7)));
+	std::cout << "  cct_mixed_scalar_types: passed\n";
+}
+
 void test_cct_reset() {
 	CrossChannelTrigger<TA, TB> q(TA(0.5, Slope::Rising),
 	                               TB(0.5, Slope::Rising),
@@ -723,6 +761,8 @@ int main() {
 		test_cct_anotb_a_within_window_of_b_suppressed();
 		test_cct_anotb_a_outside_window_of_b_fires();
 		test_cct_bnota_mirror();
+		test_cct_window_kinf_throws();
+		test_cct_mixed_scalar_types();
 		test_cct_reset();
 		test_precision_sweep_minimum_detectable();
 


### PR DESCRIPTION
## Summary

Sub-issue of #133 (Digital Oscilloscope Demonstrator). Standard multi-channel scope trigger feature: fire on inter-channel correlations like "clock rises AND data line is high" or "channel A but not channel B within the past N samples". Builds on the QualifierAnd/Or pattern from #140 with named modes and proper multi-channel framing.

## What's in this PR

**Appended to** \`include/sw/dsp/instrument/trigger.hpp\`:

\`\`\`cpp
enum class CrossChannelMode {
    OnlyA, OnlyB, AandB, AorB, AxorB, AnotB, BnotA
};

template <class TrigA, class TrigB>
class CrossChannelTrigger {
    CrossChannelTrigger(TrigA, TrigB, CrossChannelMode,
                        std::size_t window_samples = 1);
    bool process(sample_a, sample_b);  // synchronized samples
    void reset();
};
\`\`\`

## Per-mode semantics

| Mode | Fires when |
|---|---|
| \`OnlyA\` / \`OnlyB\` | one channel's inner trigger fires; the other is still driven so its state stays current |
| \`AandB\` | both fire within \`window\` samples of each other; both \`since_\` counters reset on fire so the same coincidence can't re-trigger |
| \`AorB\` | either fires this sample |
| \`AxorB\` | exactly-one-active in window: A fires with no recent B, OR B fires with no recent A. Same-sample double fires DON'T fire. |
| \`AnotB\` / \`BnotA\` | A fires AND no recent B (within \`window\`). Useful for "trigger on data edge BUT NOT when clock is high". |

Sample synchronization assumed (channels A and B sample-aligned). Sub-sample alignment between channels is a separate concern handled by #150 (multi-channel time alignment).

Inner trigger types are independent: A can be \`EdgeTrigger<float>\` and B can be \`EdgeTrigger<fixpnt32>\` in the same composition.

## Files changed

| File | Change |
|---|---|
| \`include/sw/dsp/instrument/trigger.hpp\` | +130 lines (enum + class + comment block + entry in primitive list) |
| \`tests/test_instrument_trigger.cpp\` | +240 lines (16 new test functions + main() entries) |

## Test results

| Compiler | Build | Tests |
|---|---|---|
| gcc | OK | 40/40 PASS (24 prior + 16 new) |
| clang | OK | 40/40 PASS, identical output |

Coverage:
- All 7 modes positive case
- AandB / AxorB / AnotB windowing (within-window vs outside-window)
- AandB no-double-fire on same coincidence (verifies the since_ reset)
- AxorB same-sample double-fire correctly suppressed
- BnotA mirror test (single — semantics are symmetric to AnotB)
- reset() clears since_ counters in addition to inner triggers

## #133 progress

| # | Status |
|---|---|
| #146 peak-detect | merged ✓ |
| #147 auto-trigger | merged ✓ |
| #149 display-rate envelope | merged ✓ |
| #162 (cleanup) peak_detect concept | merged ✓ |
| **#148 cross-channel triggering** | **this PR** |
| #150 multi-channel time alignment | open |
| #151 cursor / measurement primitives | open |
| #152 scope_demo application | open (depends on all above) |

After this lands, the trigger module is feature-complete for the scope demonstrator — only #150 (sub-sample interp) and #151 (measurements) remain before #152 can integrate.

## Test plan
- [x] Fast CI passes (gcc + clang)
- [x] CodeRabbit review
- [x] Promote to ready when satisfied

Resolves #148

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-channel trigger with multiple modes, a configurable coincidence window, and reliable reset/clear behavior; invalid window values are rejected.

* **Tests**
  * Added comprehensive tests covering all cross-channel modes, window/coincidence semantics, reset behavior, and invalid-configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->