### PR TITLE
fix(instrument): reject window_samples == kInf in QualifierAnd (#165)

### DIFF
--- a/include/sw/dsp/instrument/trigger.hpp
+++ b/include/sw/dsp/instrument/trigger.hpp
@@ -349,7 +349,17 @@ public:
 		  b_(std::move(b)),
 		  window_(window_samples),
 		  since_a_(kInf),
-		  since_b_(kInf) {}
+		  since_b_(kInf) {
+		// kInf is the internal "never fired" sentinel. window_samples ==
+		// kInf would make `since_X <= window_` trivially true for the
+		// sentinel, firing AandB before either inner trigger has fired.
+		// Reject explicitly. Same guard pattern as CrossChannelTrigger.
+		if (window_samples == kInf)
+			throw std::invalid_argument(
+				"QualifierAnd: window_samples must be < "
+				"std::numeric_limits<std::size_t>::max() "
+				"(use max() - 1 for an effectively-unlimited window)");
+	}
 
 	bool process(sample_a xa, sample_b xb) {
 		if (since_a_ != kInf && since_a_ < kInf - 1) ++since_a_;

--- a/include/sw/dsp/instrument/trigger.hpp
+++ b/include/sw/dsp/instrument/trigger.hpp
@@ -348,13 +348,13 @@ public:
 		: a_(std::move(a)),
 		  b_(std::move(b)),
 		  window_(window_samples),
-		  since_a_(kInf),
-		  since_b_(kInf) {
-		// kInf is the internal "never fired" sentinel. window_samples ==
-		// kInf would make `since_X <= window_` trivially true for the
+		  since_a_(kNeverFired),
+		  since_b_(kNeverFired) {
+		// kNeverFired is the internal "never fired" sentinel. window_samples ==
+		// kNeverFired would make `since_X <= window_` trivially true for the
 		// sentinel, firing AandB before either inner trigger has fired.
 		// Reject explicitly. Same guard pattern as CrossChannelTrigger.
-		if (window_samples == kInf)
+		if (window_samples == kNeverFired)
 			throw std::invalid_argument(
 				"QualifierAnd: window_samples must be < "
 				"std::numeric_limits<std::size_t>::max() "
@@ -362,15 +362,15 @@ public:
 	}
 
 	bool process(sample_a xa, sample_b xb) {
-		if (since_a_ != kInf && since_a_ < kInf - 1) ++since_a_;
-		if (since_b_ != kInf && since_b_ < kInf - 1) ++since_b_;
+		if (since_a_ != kNeverFired && since_a_ < kNeverFired - 1) ++since_a_;
+		if (since_b_ != kNeverFired && since_b_ < kNeverFired - 1) ++since_b_;
 
 		if (a_.process(xa)) since_a_ = 0;
 		if (b_.process(xb)) since_b_ = 0;
 
 		if (since_a_ <= window_ && since_b_ <= window_) {
-			since_a_ = kInf;
-			since_b_ = kInf;
+			since_a_ = kNeverFired;
+			since_b_ = kNeverFired;
 			return true;
 		}
 		return false;
@@ -379,12 +379,12 @@ public:
 	void reset() {
 		a_.reset();
 		b_.reset();
-		since_a_ = kInf;
-		since_b_ = kInf;
+		since_a_ = kNeverFired;
+		since_b_ = kNeverFired;
 	}
 
 private:
-	static constexpr std::size_t kInf = std::numeric_limits<std::size_t>::max();
+	static constexpr std::size_t kNeverFired = std::numeric_limits<std::size_t>::max();
 	TrigA       a_;
 	TrigB       b_;
 	std::size_t window_;
@@ -492,13 +492,13 @@ public:
 		  b_(std::move(b)),
 		  mode_(mode),
 		  window_(window_samples),
-		  since_a_(kInf),
-		  since_b_(kInf) {
-		// kInf is the internal "never fired" sentinel. If a caller passes
-		// kInf as window_samples, the `since_X <= window_` checks become
+		  since_a_(kNeverFired),
+		  since_b_(kNeverFired) {
+		// kNeverFired is the internal "never fired" sentinel. If a caller passes
+		// kNeverFired as window_samples, the `since_X <= window_` checks become
 		// trivially true even for the sentinel and AandB/AnotB/etc. would
 		// fire before any inner trigger has fired. Reject explicitly.
-		if (window_samples == kInf)
+		if (window_samples == kNeverFired)
 			throw std::invalid_argument(
 				"CrossChannelTrigger: window_samples must be < "
 				"std::numeric_limits<std::size_t>::max() "
@@ -508,8 +508,8 @@ public:
 	bool process(sample_a xa, sample_b xb) {
 		// Increment age counters BEFORE running inner triggers, so a fire
 		// this sample lands at since_X = 0.
-		if (since_a_ != kInf && since_a_ < kInf - 1) ++since_a_;
-		if (since_b_ != kInf && since_b_ < kInf - 1) ++since_b_;
+		if (since_a_ != kNeverFired && since_a_ < kNeverFired - 1) ++since_a_;
+		if (since_b_ != kNeverFired && since_b_ < kNeverFired - 1) ++since_b_;
 
 		// Drive both inner triggers unconditionally so their state stays
 		// current regardless of which channel the wrapper "cares about".
@@ -526,8 +526,8 @@ public:
 				if (since_a_ <= window_ && since_b_ <= window_) {
 					// Coincidence consumed — clear both so the same pair
 					// can't fire repeatedly while both ages are < window.
-					since_a_ = kInf;
-					since_b_ = kInf;
+					since_a_ = kNeverFired;
+					since_b_ = kNeverFired;
 					return true;
 				}
 				return false;
@@ -557,12 +557,12 @@ public:
 	void reset() {
 		a_.reset();
 		b_.reset();
-		since_a_ = kInf;
-		since_b_ = kInf;
+		since_a_ = kNeverFired;
+		since_b_ = kNeverFired;
 	}
 
 private:
-	static constexpr std::size_t kInf = std::numeric_limits<std::size_t>::max();
+	static constexpr std::size_t kNeverFired = std::numeric_limits<std::size_t>::max();
 	TrigA            a_;
 	TrigB            b_;
 	CrossChannelMode mode_;

--- a/tests/test_instrument_trigger.cpp
+++ b/tests/test_instrument_trigger.cpp
@@ -380,6 +380,22 @@ void test_qualifier_and_outside_window() {
 	std::cout << "  qualifier_and_outside_window: passed\n";
 }
 
+void test_qualifier_and_window_kinf_throws() {
+	// window_samples == kInf collides with the "never fired" sentinel —
+	// would fire AandB before either inner trigger fires. Same guard
+	// pattern as CrossChannelTrigger; same regression test.
+	using TA = EdgeTrigger<double>;
+	using TB = EdgeTrigger<double>;
+	bool threw = false;
+	try {
+		QualifierAnd<TA, TB> q(TA(0.5, Slope::Rising),
+		                       TB(0.5, Slope::Rising),
+		                       std::numeric_limits<std::size_t>::max());
+	} catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  qualifier_and_window_kinf_throws: passed\n";
+}
+
 // ============================================================================
 // QualifierOr
 // ============================================================================
@@ -745,6 +761,7 @@ int main() {
 		test_qualifier_and_coincidence();
 		test_qualifier_and_within_window();
 		test_qualifier_and_outside_window();
+		test_qualifier_and_window_kinf_throws();
 		test_qualifier_or();
 		test_cct_only_a();
 		test_cct_only_b();


### PR DESCRIPTION
## Summary

Trivial follow-up from #148 (PR #164). \`CrossChannelTrigger\` gained a constructor guard rejecting \`window_samples == kInf\` because it collides with the internal "never fired" sentinel. \`QualifierAnd\` from #140 has the exact same bug pattern — same kInf, same unguarded \`since_X <= window_\` check. This PR adds the same guard.

## What's in this PR

\`\`\`cpp
QualifierAnd(TrigA a, TrigB b, std::size_t window_samples = 1)
    : a_(...), b_(...), window_(window_samples), since_a_(kInf), since_b_(kInf) {
    if (window_samples == kInf)
        throw std::invalid_argument(
            "QualifierAnd: window_samples must be < "
            "std::numeric_limits<std::size_t>::max() ...");
}
\`\`\`

Plus a regression test \`test_qualifier_and_window_kinf_throws\` mirroring the one added in PR #164.

## Files changed

| File | Change |
|---|---|
| \`include/sw/dsp/instrument/trigger.hpp\` | +9 lines (constructor guard + comment) |
| \`tests/test_instrument_trigger.cpp\` | +16 lines (test + main() entry) |

## Test results

| Compiler | Build | Tests |
|---|---|---|
| gcc | OK | 43/43 PASS (42 prior + 1 new) |
| clang | OK | 43/43 PASS |

## Test plan
- [x] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied

Resolves #165

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where AND-style triggers could fire prematurely when configured with extreme window values by adding constructor validation and improved internal handling.

* **Tests**
  * Added a regression test that verifies invalid window configurations are rejected and that the fix prevents premature triggering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->