### PR TITLE
feat(instrument): multi-channel time alignment (#150)

### DIFF
--- a/include/sw/dsp/filter/fir/fir_filter.hpp
+++ b/include/sw/dsp/filter/fir/fir_filter.hpp
@@ -41,6 +41,22 @@ public:
 		write_pos_ = 0;
 	}
 
+	// Update taps in place WITHOUT clearing the delay-line state. Useful
+	// for callers that need to retune coefficients mid-stream (e.g.,
+	// FractionalDelay::set_delay) and want to avoid the transient that
+	// would result from a full delay-line reset.
+	//
+	// Requires the new taps to have the same length as the current taps —
+	// changing length would invalidate the delay-line addressing. If you
+	// need a different length, use set_taps() instead.
+	void update_taps(const mtl::vec::dense_vector<CoeffScalar>& taps) {
+		if (taps.size() != taps_.size())
+			throw std::invalid_argument(
+				"FIRFilter::update_taps: new taps must have the same length "
+				"as the current taps (use set_taps() to change length)");
+		taps_ = taps;
+	}
+
 	// Process a single sample through the FIR filter
 	SampleScalar process(SampleScalar in) {
 		std::size_t N = taps_.size();

--- a/include/sw/dsp/instrument/channel_aligner.hpp
+++ b/include/sw/dsp/instrument/channel_aligner.hpp
@@ -91,15 +91,27 @@ public:
 	// std::vector — see CLAUDE.md).
 	mtl::vec::dense_vector<SampleScalar>
 	process(std::span<const SampleScalar> channel_samples) {
+		mtl::vec::dense_vector<SampleScalar> out(channel_samples.size());
+		process(channel_samples, std::span<SampleScalar>{out.data(), out.size()});
+		return out;
+	}
+
+	// Allocation-free overload: write aligned samples into a caller-
+	// provided buffer. Useful for hot-path streaming where the same
+	// output buffer is reused every call.
+	void process(std::span<const SampleScalar> channel_samples,
+	             std::span<SampleScalar>       out) {
 		if (channel_samples.size() != delays_.size())
 			throw std::invalid_argument(
 				"ChannelAligner::process: input length must equal "
 				"number of channels");
-		mtl::vec::dense_vector<SampleScalar> out(channel_samples.size());
+		if (out.size() != delays_.size())
+			throw std::invalid_argument(
+				"ChannelAligner::process: output length must equal "
+				"number of channels");
 		for (std::size_t c = 0; c < delays_.size(); ++c) {
 			out[c] = delays_[c].process(channel_samples[c]);
 		}
-		return out;
 	}
 
 	std::size_t num_channels() const { return delays_.size(); }

--- a/include/sw/dsp/instrument/channel_aligner.hpp
+++ b/include/sw/dsp/instrument/channel_aligner.hpp
@@ -4,8 +4,16 @@
 //
 // Aligns N channels that share a sample rate but have fixed inter-channel
 // time skews. Channel 0 is the reference (skew = 0); each other channel's
-// skew is the offset that would make IT line up with channel 0 — a
-// positive skew means the channel is sampled LATER than channel 0.
+// skew is the magnitude of the delay applied to that channel.
+//
+// Convention: the wrapper only does causal delays in [0, 1), so it can
+// only correct channels that are sampled LATER than the reference (delay
+// pulls their effective time BACK toward the reference). Channels sampled
+// EARLIER than the reference would need a non-causal advance, which is
+// not supported. So in practice the user must designate the EARLIEST-
+// sampling channel as the reference (channel 0); all other channels'
+// skew values are how much LATER they sample, and the wrapper delays
+// each by that amount to align them to the reference's time grid.
 //
 // Implementation: one FractionalDelay per non-reference channel, with the
 // integer part of the skew handled by the caller (via ring-buffer offset)
@@ -27,7 +35,7 @@
 #include <cstddef>
 #include <span>
 #include <stdexcept>
-#include <vector>
+#include <vector>     // std::vector for the per-channel FractionalDelay storage
 #include <mtl/vec/dense_vector.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
 #include <sw/dsp/instrument/fractional_delay.hpp>
@@ -77,13 +85,17 @@ public:
 	// (N-1)/2; other channels' group delay is (N-1)/2 + their_skew. The
 	// design ensures all channels have THE SAME group delay AT THE
 	// reference time grid — the whole point of alignment.
-	std::vector<SampleScalar>
+	//
+	// Returns mtl::vec::dense_vector<SampleScalar> per the library
+	// signal-container convention (signal data is dense_vector, not
+	// std::vector — see CLAUDE.md).
+	mtl::vec::dense_vector<SampleScalar>
 	process(std::span<const SampleScalar> channel_samples) {
 		if (channel_samples.size() != delays_.size())
 			throw std::invalid_argument(
 				"ChannelAligner::process: input length must equal "
 				"number of channels");
-		std::vector<SampleScalar> out(channel_samples.size());
+		mtl::vec::dense_vector<SampleScalar> out(channel_samples.size());
 		for (std::size_t c = 0; c < delays_.size(); ++c) {
 			out[c] = delays_[c].process(channel_samples[c]);
 		}

--- a/include/sw/dsp/instrument/channel_aligner.hpp
+++ b/include/sw/dsp/instrument/channel_aligner.hpp
@@ -1,0 +1,99 @@
+#pragma once
+// channel_aligner.hpp: Multi-channel time alignment for instrument-style
+// data acquisition.
+//
+// Aligns N channels that share a sample rate but have fixed inter-channel
+// time skews. Channel 0 is the reference (skew = 0); each other channel's
+// skew is the offset that would make IT line up with channel 0 — a
+// positive skew means the channel is sampled LATER than channel 0.
+//
+// Implementation: one FractionalDelay per non-reference channel, with the
+// integer part of the skew handled by the caller (via ring-buffer offset)
+// and the fractional part [0, 1) routed through the FractionalDelay's
+// windowed-sinc FIR.
+//
+// Real instruments need this for things like:
+//   - Multi-ADC scopes where each ADC has a slightly different clock
+//     latency (factory-calibrated skew)
+//   - Differential probe pairs with cable-length mismatches
+//   - Multiple independent capture cards on a shared trigger
+//
+// This issue handles the STATIC case (skews known at construction).
+// Dynamic skew estimation (e.g., cross-correlation-based) is a follow-up.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <vector>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/instrument/fractional_delay.hpp>
+
+namespace sw::dsp::instrument {
+
+template <DspField CoeffScalar  = double,
+          DspField StateScalar  = CoeffScalar,
+          DspScalar SampleScalar = StateScalar>
+class ChannelAligner {
+public:
+	using coeff_scalar  = CoeffScalar;
+	using state_scalar  = StateScalar;
+	using sample_scalar = SampleScalar;
+
+	// skews: per-channel fractional skew in samples, in [0, 1). Channel 0
+	//   is the reference (skews[0] should be 0; nonzero is rejected to
+	//   prevent the user accidentally double-correcting).
+	// num_taps: FIR length passed through to each FractionalDelay.
+	explicit ChannelAligner(std::span<const double> skews,
+	                        std::size_t num_taps = 31) {
+		if (skews.empty())
+			throw std::invalid_argument(
+				"ChannelAligner: at least one channel required");
+		if (skews[0] != 0.0)
+			throw std::invalid_argument(
+				"ChannelAligner: channel 0 is the reference; "
+				"skews[0] must be 0.0");
+		// Channel 0: no delay needed; we keep a no-op stand-in via a
+		// FractionalDelay(0.0, num_taps) so all channels go through the
+		// same length of pipeline (matters for group-delay matching).
+		// Each channel gets its own FractionalDelay — the per-channel
+		// skew tells the FractionalDelay what fractional offset to
+		// compensate.
+		delays_.reserve(skews.size());
+		for (double s : skews) {
+			delays_.emplace_back(s, num_taps);
+		}
+	}
+
+	// Push one sample per channel; returns the aligned samples in the
+	// same channel order. The output has the same length as the input.
+	//
+	// Note on group delay: every channel's output is delayed by the FIR's
+	// (N-1)/2 samples PLUS its individual fractional skew compensation.
+	// Channel 0's compensation is 0 so its group delay is exactly
+	// (N-1)/2; other channels' group delay is (N-1)/2 + their_skew. The
+	// design ensures all channels have THE SAME group delay AT THE
+	// reference time grid — the whole point of alignment.
+	std::vector<SampleScalar>
+	process(std::span<const SampleScalar> channel_samples) {
+		if (channel_samples.size() != delays_.size())
+			throw std::invalid_argument(
+				"ChannelAligner::process: input length must equal "
+				"number of channels");
+		std::vector<SampleScalar> out(channel_samples.size());
+		for (std::size_t c = 0; c < delays_.size(); ++c) {
+			out[c] = delays_[c].process(channel_samples[c]);
+		}
+		return out;
+	}
+
+	std::size_t num_channels() const { return delays_.size(); }
+
+private:
+	std::vector<FractionalDelay<CoeffScalar, StateScalar, SampleScalar>> delays_;
+};
+
+} // namespace sw::dsp::instrument

--- a/include/sw/dsp/instrument/fractional_delay.hpp
+++ b/include/sw/dsp/instrument/fractional_delay.hpp
@@ -61,6 +61,7 @@ public:
 	//   sample (simpler design + symmetric phase response when delay=0).
 	FractionalDelay(double delay_samples, std::size_t num_taps = 31)
 		: num_taps_(num_taps),
+		  delay_samples_(delay_samples),
 		  fir_(design_taps(delay_samples, num_taps)) {}
 
 	SampleScalar process(SampleScalar in) { return fir_.process(in); }
@@ -77,8 +78,14 @@ public:
 	// Re-tune the delay without resetting the FIR delay-line state. The
 	// new taps replace the old in place; a brief transient is expected
 	// as the delay-line samples adapt to the new impulse response.
+	//
+	// Strong exception guarantee: if design_taps throws (e.g., out-of-
+	// range delay), the existing taps and delay_samples_ are unchanged.
 	void set_delay(double delay_samples) {
-		fir_.update_taps(design_taps(delay_samples, num_taps_));
+		auto new_taps = design_taps(delay_samples, num_taps_);
+		// design_taps returned cleanly — now commit the state changes.
+		delay_samples_ = delay_samples;
+		fir_.update_taps(new_taps);
 	}
 
 	// Clear the FIR delay-line state. Useful between independent test
@@ -97,10 +104,16 @@ public:
 	double      delay()    const { return delay_samples_; }
 
 private:
-	// Design windowed-sinc taps for a fractional delay.
-	// h[n] = window[n] * sinc(n - center - delay) for n = 0..N-1
-	// Then normalize so sum(h[n]) == 1 (DC gain = 1).
-	mtl::vec::dense_vector<CoeffScalar>
+	// Design windowed-sinc taps for a fractional delay. PURE: no side
+	// effects on object state. Callers (constructor + set_delay) own
+	// the state mutations.
+	//
+	//   h[n] = window[n] * sinc(n - center - delay) for n = 0..N-1
+	//   then normalize so sum(h[n]) == 1 (DC gain = 1)
+	//
+	// Static so the constructor's initializer list can call it before
+	// the object is fully constructed.
+	static mtl::vec::dense_vector<CoeffScalar>
 	design_taps(double delay_samples, std::size_t num_taps) {
 		if (num_taps < 3 || (num_taps & 1U) == 0)
 			throw std::invalid_argument(
@@ -109,8 +122,6 @@ private:
 			throw std::invalid_argument(
 				"FractionalDelay: delay_samples must be in [0, 1) "
 				"(use a ring buffer for integer delays)");
-
-		delay_samples_ = delay_samples;
 
 		const double center = static_cast<double>(num_taps - 1) / 2.0;
 		const double pi     = std::numbers::pi_v<double>;

--- a/include/sw/dsp/instrument/fractional_delay.hpp
+++ b/include/sw/dsp/instrument/fractional_delay.hpp
@@ -75,11 +75,16 @@ public:
 	}
 
 	// Re-tune the delay without resetting the FIR delay-line state. The
-	// new taps replace the old; a brief transient is expected as the
-	// delay-line samples adapt to the new impulse response.
+	// new taps replace the old in place; a brief transient is expected
+	// as the delay-line samples adapt to the new impulse response.
 	void set_delay(double delay_samples) {
-		fir_.set_taps(design_taps(delay_samples, num_taps_));
+		fir_.update_taps(design_taps(delay_samples, num_taps_));
 	}
+
+	// Clear the FIR delay-line state. Useful between independent test
+	// runs or stream segments where prior samples should not bleed into
+	// the new measurement.
+	void reset() { fir_.reset(); }
 
 	// Group delay introduced by this filter (in samples). For a
 	// linear-phase FIR of odd length N with fractional delay d, the
@@ -110,7 +115,7 @@ private:
 		const double center = static_cast<double>(num_taps - 1) / 2.0;
 		const double pi     = std::numbers::pi_v<double>;
 
-		std::vector<double> h(num_taps);
+		mtl::vec::dense_vector<double> h(num_taps);
 		double sum = 0.0;
 		for (std::size_t n = 0; n < num_taps; ++n) {
 			// sinc((n - center) - delay), with sinc(0) = 1

--- a/include/sw/dsp/instrument/fractional_delay.hpp
+++ b/include/sw/dsp/instrument/fractional_delay.hpp
@@ -1,0 +1,150 @@
+#pragma once
+// fractional_delay.hpp: Static sub-sample fractional-delay FIR for
+// instrument-style data acquisition.
+//
+// Real instruments often need to align channels that are sampled at the same
+// rate but are offset by a fixed fractional sample period — e.g., due to ADC
+// clock skew, cable-length differences, or differential probe routing. This
+// primitive shifts a stream by a static fractional delay in [0, 1) samples.
+//
+// Implementation: a windowed-sinc FIR designed at construction time. The
+// ideal fractional delay's impulse response is a shifted sinc, h[n] =
+// sinc(n - center - delay) for n = 0..N-1 where center = (N-1)/2. We
+// truncate to N taps and apply a Hamming window to suppress sidelobes,
+// then normalize so the DC gain is exactly 1.
+//
+// The class can be re-tuned via `set_delay()` without resetting the FIR
+// state, useful for trim adjustments. Larger integer delays should be
+// handled by the caller (e.g., via a ring buffer); this primitive only
+// covers the sub-sample fractional part.
+//
+// Three-scalar precision parameterization:
+//   CoeffScalar  — sinc-windowed taps (sensitive to delay accuracy)
+//   StateScalar  — FIR delay-line accumulator
+//   SampleScalar — input/output stream
+//
+// Tap design runs in `double` and is cast to `CoeffScalar` at the end —
+// the same pattern used by EqualizerFilter (calibration.hpp). This keeps
+// cross-precision SNR comparisons meaningful by isolating streaming-
+// arithmetic precision from filter-design variance.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <numbers>
+#include <span>
+#include <stdexcept>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/filter/fir/fir_filter.hpp>
+
+namespace sw::dsp::instrument {
+
+template <DspField CoeffScalar  = double,
+          DspField StateScalar  = CoeffScalar,
+          DspScalar SampleScalar = StateScalar>
+class FractionalDelay {
+public:
+	using coeff_scalar  = CoeffScalar;
+	using state_scalar  = StateScalar;
+	using sample_scalar = SampleScalar;
+
+	// delay_samples: a real number in [0, 1) for the desired sub-sample
+	//   delay. Values outside [0, 1) are rejected — larger integer
+	//   delays should be handled by the caller via a ring buffer offset.
+	// num_taps:      FIR length. Longer = better in-band flatness and
+	//   more accurate group delay, at the cost of more arithmetic.
+	//   31 taps is typical for 0.5-sample resolution with > -60 dB
+	//   stopband. Must be odd so the integer-delay center is an integer
+	//   sample (simpler design + symmetric phase response when delay=0).
+	FractionalDelay(double delay_samples, std::size_t num_taps = 31)
+		: num_taps_(num_taps),
+		  fir_(design_taps(delay_samples, num_taps)) {}
+
+	SampleScalar process(SampleScalar in) { return fir_.process(in); }
+
+	void process_block(std::span<SampleScalar> samples) {
+		fir_.process_block(samples);
+	}
+
+	void process_block(std::span<const SampleScalar> input,
+	                   std::span<SampleScalar> output) {
+		fir_.process_block(input, output);
+	}
+
+	// Re-tune the delay without resetting the FIR delay-line state. The
+	// new taps replace the old; a brief transient is expected as the
+	// delay-line samples adapt to the new impulse response.
+	void set_delay(double delay_samples) {
+		fir_.set_taps(design_taps(delay_samples, num_taps_));
+	}
+
+	// Group delay introduced by this filter (in samples). For a
+	// linear-phase FIR of odd length N with fractional delay d, the
+	// group delay is exactly (N-1)/2 + d.
+	double group_delay_samples() const {
+		return delay_samples_ + static_cast<double>(num_taps_ - 1) / 2.0;
+	}
+
+	std::size_t num_taps() const { return num_taps_; }
+	double      delay()    const { return delay_samples_; }
+
+private:
+	// Design windowed-sinc taps for a fractional delay.
+	// h[n] = window[n] * sinc(n - center - delay) for n = 0..N-1
+	// Then normalize so sum(h[n]) == 1 (DC gain = 1).
+	mtl::vec::dense_vector<CoeffScalar>
+	design_taps(double delay_samples, std::size_t num_taps) {
+		if (num_taps < 3 || (num_taps & 1U) == 0)
+			throw std::invalid_argument(
+				"FractionalDelay: num_taps must be odd and >= 3");
+		if (!(delay_samples >= 0.0 && delay_samples < 1.0))
+			throw std::invalid_argument(
+				"FractionalDelay: delay_samples must be in [0, 1) "
+				"(use a ring buffer for integer delays)");
+
+		delay_samples_ = delay_samples;
+
+		const double center = static_cast<double>(num_taps - 1) / 2.0;
+		const double pi     = std::numbers::pi_v<double>;
+
+		std::vector<double> h(num_taps);
+		double sum = 0.0;
+		for (std::size_t n = 0; n < num_taps; ++n) {
+			// sinc((n - center) - delay), with sinc(0) = 1
+			const double x = static_cast<double>(n) - center - delay_samples;
+			double s;
+			if (std::abs(x) < 1e-12) {
+				s = 1.0;
+			} else {
+				const double pix = pi * x;
+				s = std::sin(pix) / pix;
+			}
+			// Hamming window
+			const double w = 0.54 - 0.46 * std::cos(
+				2.0 * pi * static_cast<double>(n) /
+				static_cast<double>(num_taps - 1));
+			h[n] = w * s;
+			sum += h[n];
+		}
+		// Normalize for unity DC gain. With delay=0 and a symmetric window
+		// the unnormalized taps already sum close to 1; for nonzero delay
+		// the symmetry breaks and a small renorm is needed.
+		if (std::abs(sum) < 1e-300)
+			throw std::runtime_error(
+				"FractionalDelay: window+sinc summed to zero (degenerate)");
+		mtl::vec::dense_vector<CoeffScalar> taps(num_taps);
+		for (std::size_t n = 0; n < num_taps; ++n) {
+			taps[n] = static_cast<CoeffScalar>(h[n] / sum);
+		}
+		return taps;
+	}
+
+	std::size_t                                                 num_taps_;
+	double                                                      delay_samples_ = 0.0;
+	FIRFilter<CoeffScalar, StateScalar, SampleScalar>           fir_;
+};
+
+} // namespace sw::dsp::instrument

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,3 +119,9 @@ dsp_add_test(test_instrument_peak_detect)
 
 # Instrument display-rate envelope (Issue #149)
 dsp_add_test(test_instrument_display_envelope)
+
+# Instrument fractional-delay FIR (Issue #150)
+dsp_add_test(test_instrument_fractional_delay)
+
+# Instrument channel-aligner (Issue #150)
+dsp_add_test(test_instrument_channel_aligner)

--- a/tests/test_instrument_channel_aligner.cpp
+++ b/tests/test_instrument_channel_aligner.cpp
@@ -149,24 +149,28 @@ double pearson_correlation(const std::vector<double>& a,
 }
 
 void test_skew_correction_two_channels() {
-	// Convention: skews[c] is the per-channel DELAY that the aligner
-	// applies. Since the wrapper only does causal delays in [0, 1),
-	// the reference channel (skews[0] = 0) must be the LATEST-sampling
-	// one in real-world terms; other channels are sampled EARLIER and
-	// get delayed to catch up.
+	// Convention: skews[c] is the magnitude of the per-channel delay.
+	// Since the wrapper only does causal delays in [0, 1), it can only
+	// align channels that are sampled LATER than the reference (delay
+	// pulls their effective time BACK toward the reference). The
+	// reference (skews[0]=0) must therefore be the EARLIEST-sampling
+	// channel; other channels are sampled LATER by skews[c] samples and
+	// get delayed by exactly that amount to align with the reference.
 	//
 	// Setup:
 	//   ground truth signal: s(t) = sin(2πf t/T)
 	//   channel 0 samples at t = n*T:       ch0_in[n] = sin(2πf*n)
 	//   channel 1 samples 0.3T LATER:       ch1_in[n] = sin(2πf*(n + 0.3))
 	//
-	// Channel 1's "current sample" represents the signal 0.3 sample
-	// periods AHEAD of channel 0's. To align them, delay channel 1 by
-	// 0.3 samples, bringing its effective time back in line with
-	// channel 0's. That maps to skews = {0.0, 0.3}.
+	// Channel 1's sample n already represents the signal value at time
+	// (n + 0.3)*T — 0.3 sample periods AHEAD of channel 0's grid. The
+	// FractionalDelay(0.3) on channel 1 produces an output sample that
+	// represents the input from 0.3 samples earlier, i.e., the signal
+	// at time ((n + 0.3) - 0.3)*T = n*T — back in line with channel 0.
 	//
-	// After alignment + the shared 15-sample FIR group delay, both
-	// outputs represent s((n - 15) * T). They should be highly correlated.
+	// After both channels go through the shared 15-sample FIR group
+	// delay, the two outputs both represent s((n - 15)*T) and should be
+	// highly correlated.
 
 	const double pi = std::numbers::pi_v<double>;
 	const double f  = 0.20;

--- a/tests/test_instrument_channel_aligner.cpp
+++ b/tests/test_instrument_channel_aligner.cpp
@@ -1,0 +1,250 @@
+// test_instrument_channel_aligner.cpp: tests for the multi-channel
+// time-alignment wrapper.
+//
+// Coverage:
+//   - Constructor validation: empty skews, nonzero skew[0] throw
+//   - num_channels() reports the right count
+//   - Single-channel passthrough (delays = {0.0})
+//   - Two-channel zero-skew: outputs match inputs after the FIR transient
+//   - **Skew-correction headline test**: synthesize two channels of the
+//     same tone with a known 0.3-sample skew, run through ChannelAligner,
+//     verify the output channels are correlated to within ~99%
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <numbers>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <sw/dsp/instrument/channel_aligner.hpp>
+
+using namespace sw::dsp::instrument;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+// ============================================================================
+// Constructor validation
+// ============================================================================
+
+void test_ctor_empty_skews_throws() {
+	bool threw = false;
+	try {
+		std::span<const double> empty;
+		ChannelAligner<double> ca(empty);
+	} catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  ctor_empty_skews_throws: passed\n";
+}
+
+void test_ctor_nonzero_reference_skew_throws() {
+	std::array<double, 2> skews = {0.1, 0.3};   // skew[0] != 0 — bug guard
+	bool threw = false;
+	try { ChannelAligner<double> ca(std::span<const double>{skews}); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  ctor_nonzero_reference_skew_throws: passed\n";
+}
+
+void test_num_channels() {
+	std::array<double, 4> skews = {0.0, 0.25, 0.5, 0.75};
+	ChannelAligner<double> ca(std::span<const double>{skews});
+	REQUIRE(ca.num_channels() == 4);
+	std::cout << "  num_channels: passed\n";
+}
+
+// ============================================================================
+// Single-channel + zero-skew passthrough
+// ============================================================================
+
+void test_single_channel() {
+	std::array<double, 1> skews = {0.0};
+	ChannelAligner<double> ca(std::span<const double>{skews});
+	std::array<double, 1> in_buf;
+
+	// Push a few samples and verify the channel-0 output is what came out
+	// of the underlying FractionalDelay(0, 31). With delay=0, an impulse
+	// at sample 0 reappears at sample 15 (group delay = (N-1)/2).
+	std::vector<double> out_at_15;
+	for (std::size_t n = 0; n < 32; ++n) {
+		in_buf[0] = (n == 0 ? 1.0 : 0.0);
+		auto out = ca.process(std::span<const double>{in_buf});
+		REQUIRE(out.size() == 1);
+		if (n == 15) out_at_15.push_back(out[0]);
+	}
+	REQUIRE(!out_at_15.empty());
+	REQUIRE(std::abs(out_at_15[0] - 1.0) < 0.05);   // close to unity
+	std::cout << "  single_channel: passed (impulse at sample 15 = "
+	          << out_at_15[0] << ")\n";
+}
+
+void test_two_channels_zero_skew() {
+	std::array<double, 2> skews = {0.0, 0.0};
+	ChannelAligner<double> ca(std::span<const double>{skews});
+	std::array<double, 2> in_buf;
+	// Both channels get the same impulse; outputs should match.
+	std::vector<double> ch0, ch1;
+	for (std::size_t n = 0; n < 32; ++n) {
+		in_buf[0] = (n == 0 ? 1.0 : 0.0);
+		in_buf[1] = (n == 0 ? 1.0 : 0.0);
+		auto out = ca.process(std::span<const double>{in_buf});
+		ch0.push_back(out[0]);
+		ch1.push_back(out[1]);
+	}
+	for (std::size_t n = 0; n < 32; ++n) {
+		REQUIRE(std::abs(ch0[n] - ch1[n]) < 1e-12);
+	}
+	std::cout << "  two_channels_zero_skew: passed\n";
+}
+
+void test_process_wrong_size_throws() {
+	std::array<double, 2> skews = {0.0, 0.3};
+	ChannelAligner<double> ca(std::span<const double>{skews});
+	std::array<double, 1> in_buf = {0.0};   // wrong length
+	bool threw = false;
+	try {
+		(void)ca.process(std::span<const double>{in_buf});
+	} catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  process_wrong_size_throws: passed\n";
+}
+
+// ============================================================================
+// Headline test: skew correction
+// ============================================================================
+
+// Compute Pearson correlation coefficient between two equal-length streams,
+// skipping the first `skip` samples to avoid the FIR transient.
+double pearson_correlation(const std::vector<double>& a,
+                           const std::vector<double>& b,
+                           std::size_t skip) {
+	const std::size_t N = a.size();
+	double sum_a = 0.0, sum_b = 0.0;
+	for (std::size_t i = skip; i < N; ++i) {
+		sum_a += a[i];
+		sum_b += b[i];
+	}
+	const double mean_a = sum_a / static_cast<double>(N - skip);
+	const double mean_b = sum_b / static_cast<double>(N - skip);
+	double num = 0.0, den_a = 0.0, den_b = 0.0;
+	for (std::size_t i = skip; i < N; ++i) {
+		const double da = a[i] - mean_a;
+		const double db = b[i] - mean_b;
+		num   += da * db;
+		den_a += da * da;
+		den_b += db * db;
+	}
+	return num / std::sqrt(den_a * den_b);
+}
+
+void test_skew_correction_two_channels() {
+	// Convention: skews[c] is the per-channel DELAY that the aligner
+	// applies. Since the wrapper only does causal delays in [0, 1),
+	// the reference channel (skews[0] = 0) must be the LATEST-sampling
+	// one in real-world terms; other channels are sampled EARLIER and
+	// get delayed to catch up.
+	//
+	// Setup:
+	//   ground truth signal: s(t) = sin(2πf t/T)
+	//   channel 0 samples at t = n*T:       ch0_in[n] = sin(2πf*n)
+	//   channel 1 samples 0.3T LATER:       ch1_in[n] = sin(2πf*(n + 0.3))
+	//
+	// Channel 1's "current sample" represents the signal 0.3 sample
+	// periods AHEAD of channel 0's. To align them, delay channel 1 by
+	// 0.3 samples, bringing its effective time back in line with
+	// channel 0's. That maps to skews = {0.0, 0.3}.
+	//
+	// After alignment + the shared 15-sample FIR group delay, both
+	// outputs represent s((n - 15) * T). They should be highly correlated.
+
+	const double pi = std::numbers::pi_v<double>;
+	const double f  = 0.20;
+	const std::size_t N_in = 256;
+
+	std::vector<double> ch0_in(N_in), ch1_in(N_in);
+	for (std::size_t n = 0; n < N_in; ++n) {
+		ch0_in[n] = std::sin(2.0 * pi * f * static_cast<double>(n));
+		ch1_in[n] = std::sin(2.0 * pi * f *
+		                      (static_cast<double>(n) + 0.3));   // 0.3 late
+	}
+
+	std::array<double, 2> skews = {0.0, 0.3};
+	ChannelAligner<double> ca(std::span<const double>{skews});
+
+	std::vector<double> ch0_out(N_in), ch1_out(N_in);
+	std::array<double, 2> in_buf;
+	for (std::size_t n = 0; n < N_in; ++n) {
+		in_buf[0] = ch0_in[n];
+		in_buf[1] = ch1_in[n];
+		auto out = ca.process(std::span<const double>{in_buf});
+		ch0_out[n] = out[0];
+		ch1_out[n] = out[1];
+	}
+	// Skip transient (first 31 = num_taps samples).
+	const double rho = pearson_correlation(ch0_out, ch1_out, /*skip=*/31);
+	if (!(rho > 0.99))
+		throw std::runtime_error(
+			"skew correction: correlation = " + std::to_string(rho) +
+			" (expected > 0.99)");
+	std::cout << "  skew_correction_two_channels: passed (correlation="
+	          << rho << ")\n";
+}
+
+void test_uncorrected_skew_has_lower_correlation() {
+	// Sanity check on the test setup: WITHOUT alignment, two channels
+	// with a 0.3-sample skew should be visibly less correlated. If the
+	// uncorrected correlation is already 1.0, the headline test isn't
+	// proving anything.
+	const double pi = std::numbers::pi_v<double>;
+	const double f  = 0.20;
+	const std::size_t N = 256;
+
+	std::vector<double> ch0(N), ch1(N);
+	for (std::size_t n = 0; n < N; ++n) {
+		ch0[n] = std::sin(2.0 * pi * f * static_cast<double>(n));
+		ch1[n] = std::sin(2.0 * pi * f *
+		                   (static_cast<double>(n) + 0.3));   // 0.3 late
+	}
+	const double rho_uncorrected = pearson_correlation(ch0, ch1, /*skip=*/0);
+	REQUIRE(rho_uncorrected < 0.99);   // there really is a meaningful skew
+	std::cout << "  uncorrected_skew_has_lower_correlation: passed "
+	             "(uncorrected rho=" << rho_uncorrected << ")\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_instrument_channel_aligner\n";
+
+		test_ctor_empty_skews_throws();
+		test_ctor_nonzero_reference_skew_throws();
+		test_num_channels();
+
+		test_single_channel();
+		test_two_channels_zero_skew();
+		test_process_wrong_size_throws();
+
+		test_uncorrected_skew_has_lower_correlation();
+		test_skew_correction_two_channels();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}

--- a/tests/test_instrument_channel_aligner.cpp
+++ b/tests/test_instrument_channel_aligner.cpp
@@ -126,6 +126,11 @@ void test_process_wrong_size_throws() {
 
 // Compute Pearson correlation coefficient between two equal-length streams,
 // skipping the first `skip` samples to avoid the FIR transient.
+//
+// Guards against the degenerate case where one or both streams are constant
+// across the post-skip window: den_a or den_b would be zero, producing
+// 0/0 = NaN. We return 0.0 in that case (zero correlation between a
+// constant signal and anything is the conventional definition).
 double pearson_correlation(const std::vector<double>& a,
                            const std::vector<double>& b,
                            std::size_t skip) {
@@ -145,7 +150,9 @@ double pearson_correlation(const std::vector<double>& a,
 		den_a += da * da;
 		den_b += db * db;
 	}
-	return num / std::sqrt(den_a * den_b);
+	const double den = std::sqrt(den_a * den_b);
+	if (den < 1e-300) return 0.0;   // one (or both) streams are constant
+	return num / den;
 }
 
 void test_skew_correction_two_channels() {

--- a/tests/test_instrument_fractional_delay.cpp
+++ b/tests/test_instrument_fractional_delay.cpp
@@ -192,6 +192,7 @@ void test_delay_accuracy() {
 		double exp_phase = expected_phase;
 		while (exp_phase >  pi) exp_phase -= 2.0 * pi;
 		while (exp_phase < -pi) exp_phase += 2.0 * pi;
+		d.reset();   // isolate iterations: clear any prior-tone state
 		const auto resp = measure_tone_response(d, f);
 		// Phase difference (wrapped). 0.05 rad ≈ 3 degrees tolerance.
 		double dphase = resp.phase_rad - exp_phase;
@@ -218,6 +219,7 @@ void test_in_band_flatness() {
 	// roll off).
 	const std::array<double, 5> freqs = {0.01, 0.05, 0.10, 0.15, 0.20};
 	for (double f : freqs) {
+		d.reset();   // isolate iterations: clear any prior-tone state
 		const auto resp = measure_tone_response(d, f);
 		if (std::abs(resp.magnitude_dB) > 0.5)
 			throw std::runtime_error(
@@ -243,6 +245,7 @@ void test_group_delay_flatness() {
 	const std::array<double, 4> freqs = {0.05, 0.10, 0.15, 0.20};
 	std::vector<double> phases;
 	for (double f : freqs) {
+		d.reset();   // isolate iterations
 		auto resp = measure_tone_response(d, f);
 		// Unwrap based on expected linear ramp
 		double exp_phase = -2.0 * pi * f * total_delay;

--- a/tests/test_instrument_fractional_delay.cpp
+++ b/tests/test_instrument_fractional_delay.cpp
@@ -1,0 +1,365 @@
+// test_instrument_fractional_delay.cpp: tests for the windowed-sinc
+// fractional-delay FIR primitive.
+//
+// Coverage:
+//   - Constructor validation: even num_taps, num_taps < 3, delay outside
+//     [0, 1) all throw
+//   - Zero-delay passthrough: with delay=0, the FIR's group delay is just
+//     (N-1)/2 — input is faithfully reproduced after a known integer
+//     latency
+//   - **Delay accuracy**: feed a tone, measure the actual output delay
+//     against the requested fractional delay across the band
+//   - **In-band magnitude flatness**: ±0.5 dB across the passband (DC
+//     to fs/2.5 approximately)
+//   - **Group-delay flatness**: linear-phase FIR ⇒ constant group delay
+//   - set_delay() retunes without resetting state (the FIR's internal
+//     delay-line samples are preserved)
+//   - Precision sweep: delay-accuracy degradation as types narrow
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <numbers>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <sw/dsp/instrument/fractional_delay.hpp>
+#include <sw/universal/number/posit/posit.hpp>
+
+using namespace sw::dsp::instrument;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+#define REQUIRE_NEAR(a, b, tol) \
+	do { const double aa = (a), bb = (b), tt = (tol); \
+		if (std::abs(aa - bb) > tt) \
+			throw std::runtime_error(std::string("test failed: |") + \
+				#a " - " #b "| = " + std::to_string(std::abs(aa-bb)) + \
+				" > " + std::to_string(tt) + " at " __FILE__ ":" + \
+				std::to_string(__LINE__)); } while (0)
+
+// ============================================================================
+// Constructor validation
+// ============================================================================
+
+void test_ctor_even_taps_throws() {
+	bool threw = false;
+	try { FractionalDelay<double> d(0.5, /*num_taps=*/30); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  ctor_even_taps_throws: passed\n";
+}
+
+void test_ctor_too_few_taps_throws() {
+	bool threw = false;
+	try { FractionalDelay<double> d(0.5, /*num_taps=*/1); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  ctor_too_few_taps_throws: passed\n";
+}
+
+void test_ctor_delay_negative_throws() {
+	bool threw = false;
+	try { FractionalDelay<double> d(-0.1); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  ctor_delay_negative_throws: passed\n";
+}
+
+void test_ctor_delay_one_or_more_throws() {
+	bool threw = false;
+	try { FractionalDelay<double> d(1.0); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  ctor_delay_one_or_more_throws: passed\n";
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// Run a complex tone of frequency f (cycles/sample) through the filter,
+// returning the steady-state magnitude and phase response. Skips the
+// transient (first num_taps samples) before measuring.
+template <class FD>
+struct ToneResponse {
+	double magnitude_dB;
+	double phase_rad;
+};
+
+template <class FD>
+ToneResponse<FD> measure_tone_response(FD& fd, double f_norm,
+                                        std::size_t num_samples = 1024) {
+	using T = typename FD::sample_scalar;
+	const double pi = std::numbers::pi_v<double>;
+	// Drive cosine, observe both real and imaginary correlations to
+	// recover magnitude + phase.
+	double sum_in_re = 0.0, sum_in_im = 0.0;
+	double sum_out_re = 0.0, sum_out_im = 0.0;
+	const std::size_t skip = fd.num_taps();
+	for (std::size_t n = 0; n < num_samples; ++n) {
+		const double phase = 2.0 * pi * f_norm * static_cast<double>(n);
+		const T x = static_cast<T>(std::cos(phase));
+		const T y = fd.process(x);
+		if (n >= skip) {
+			const double yd = static_cast<double>(y);
+			const double xd = std::cos(phase);
+			sum_in_re  += xd * std::cos(phase);
+			sum_in_im  += xd * std::sin(phase);
+			sum_out_re += yd * std::cos(phase);
+			sum_out_im += yd * std::sin(phase);
+		}
+	}
+	// |H(f)| ≈ 2 * sqrt((sum_out_re)^2 + (sum_out_im)^2) /
+	//          2 * sqrt((sum_in_re)^2 + (sum_in_im)^2)
+	const double mag_in  = std::hypot(sum_in_re,  sum_in_im);
+	const double mag_out = std::hypot(sum_out_re, sum_out_im);
+	const double mag_dB  = 20.0 * std::log10(mag_out / mag_in);
+	// Standard filter phase response convention: H(f) = sum y[n] e^{-j2πfn}
+	// means phase = atan2(-sum_out_im, sum_out_re). Equivalently, the
+	// cross-correlation phase (atan2(sum_out_im, sum_out_re)) is the
+	// NEGATIVE of the filter phase response. Negate to match Bode/DTFT
+	// convention: a delay of τ samples gives phase = -2π f τ (negative).
+	const double phase_in  = std::atan2(sum_in_im,  sum_in_re);
+	const double phase_out = std::atan2(sum_out_im, sum_out_re);
+	double phase_rad = phase_in - phase_out;
+	// Wrap to [-π, π]
+	while (phase_rad >  pi) phase_rad -= 2.0 * pi;
+	while (phase_rad < -pi) phase_rad += 2.0 * pi;
+	return ToneResponse<FD>{mag_dB, phase_rad};
+}
+
+// ============================================================================
+// Zero-delay passthrough
+// ============================================================================
+
+void test_zero_delay_passthrough() {
+	// delay=0 should give a near-perfect linear-phase FIR with peak at the
+	// center tap. Group delay = (N-1)/2 = 15 for N=31. A unit impulse in
+	// at sample 0 should appear (approximately) at output sample 15.
+	FractionalDelay<double> d(0.0, /*num_taps=*/31);
+	std::vector<double> input(64, 0.0);
+	input[0] = 1.0;
+	std::vector<double> output(input.size());
+	for (std::size_t n = 0; n < input.size(); ++n) {
+		output[n] = d.process(input[n]);
+	}
+	// Find the peak index
+	double peak = 0.0;
+	std::size_t peak_idx = 0;
+	for (std::size_t n = 0; n < output.size(); ++n) {
+		if (std::abs(output[n]) > peak) {
+			peak     = std::abs(output[n]);
+			peak_idx = n;
+		}
+	}
+	REQUIRE(peak_idx == 15);                    // (N-1)/2 = 15
+	REQUIRE_NEAR(output[15], 1.0, 0.05);         // close to unity (Hamming attenuates a bit)
+	std::cout << "  zero_delay_passthrough: passed (peak at sample "
+	          << peak_idx << ", value=" << output[15] << ")\n";
+}
+
+// ============================================================================
+// Delay accuracy across the band
+// ============================================================================
+
+void test_delay_accuracy() {
+	// A linear-phase FIR with group delay (N-1)/2 + d_frac means a tone at
+	// frequency f_norm gets a phase shift of:
+	//   phase = -2π * f_norm * total_delay
+	// Pick a delay (e.g., 0.3) and verify that the measured phase at
+	// several test frequencies matches the predicted one within tolerance.
+	const double delay_frac = 0.3;
+	FractionalDelay<double> d(delay_frac, /*num_taps=*/31);
+	const double total_delay = 15.0 + delay_frac;
+	const double pi = std::numbers::pi_v<double>;
+
+	// Test frequencies inside the passband (well below Nyquist).
+	const std::array<double, 4> freqs = {0.05, 0.10, 0.15, 0.20};
+	for (double f : freqs) {
+		const double expected_phase = -2.0 * pi * f * total_delay;
+		// Wrap expected phase to [-π, π] for comparison
+		double exp_phase = expected_phase;
+		while (exp_phase >  pi) exp_phase -= 2.0 * pi;
+		while (exp_phase < -pi) exp_phase += 2.0 * pi;
+		const auto resp = measure_tone_response(d, f);
+		// Phase difference (wrapped). 0.05 rad ≈ 3 degrees tolerance.
+		double dphase = resp.phase_rad - exp_phase;
+		while (dphase >  pi) dphase -= 2.0 * pi;
+		while (dphase < -pi) dphase += 2.0 * pi;
+		if (std::abs(dphase) > 0.05)
+			throw std::runtime_error(
+				"delay accuracy: at f_norm=" + std::to_string(f) +
+				" measured phase=" + std::to_string(resp.phase_rad) +
+				" expected=" + std::to_string(exp_phase) +
+				" diff=" + std::to_string(dphase));
+	}
+	std::cout << "  delay_accuracy: passed (4 frequencies, ±3° phase)\n";
+}
+
+// ============================================================================
+// In-band magnitude flatness
+// ============================================================================
+
+void test_in_band_flatness() {
+	FractionalDelay<double> d(0.3, /*num_taps=*/31);
+	// Test in-band magnitude — should be ~0 dB (well within ±0.5 dB)
+	// from DC up to roughly fs/2.5 (where the windowed-sinc starts to
+	// roll off).
+	const std::array<double, 5> freqs = {0.01, 0.05, 0.10, 0.15, 0.20};
+	for (double f : freqs) {
+		const auto resp = measure_tone_response(d, f);
+		if (std::abs(resp.magnitude_dB) > 0.5)
+			throw std::runtime_error(
+				"in-band flatness: at f_norm=" + std::to_string(f) +
+				" mag_dB=" + std::to_string(resp.magnitude_dB) +
+				" (want |dB| < 0.5)");
+	}
+	std::cout << "  in_band_flatness: passed (5 frequencies, ±0.5 dB)\n";
+}
+
+// ============================================================================
+// Group-delay flatness — linear-phase FIR property
+// ============================================================================
+
+void test_group_delay_flatness() {
+	const double delay_frac = 0.3;
+	FractionalDelay<double> d(delay_frac, /*num_taps=*/31);
+	const double total_delay = 15.0 + delay_frac;
+	const double pi = std::numbers::pi_v<double>;
+	// Group delay = -d(phase)/d(omega). For a linear-phase FIR, this is
+	// exactly the constant total_delay. Compute by finite differences
+	// across the passband.
+	const std::array<double, 4> freqs = {0.05, 0.10, 0.15, 0.20};
+	std::vector<double> phases;
+	for (double f : freqs) {
+		auto resp = measure_tone_response(d, f);
+		// Unwrap based on expected linear ramp
+		double exp_phase = -2.0 * pi * f * total_delay;
+		while (resp.phase_rad - exp_phase >  pi) resp.phase_rad -= 2.0 * pi;
+		while (resp.phase_rad - exp_phase < -pi) resp.phase_rad += 2.0 * pi;
+		phases.push_back(resp.phase_rad);
+	}
+	// Compute group delay from consecutive (f_k, phase_k) pairs:
+	//   gd = -(phase[k+1] - phase[k]) / (2π * (f[k+1] - f[k]))
+	for (std::size_t k = 0; k + 1 < freqs.size(); ++k) {
+		const double gd = -(phases[k+1] - phases[k]) /
+		                   (2.0 * pi * (freqs[k+1] - freqs[k]));
+		if (std::abs(gd - total_delay) > 0.05)
+			throw std::runtime_error(
+				"group_delay: between f=" + std::to_string(freqs[k]) +
+				" and f=" + std::to_string(freqs[k+1]) +
+				" gd=" + std::to_string(gd) +
+				" want " + std::to_string(total_delay));
+	}
+	std::cout << "  group_delay_flatness: passed (gd ≈ "
+	          << total_delay << " across passband)\n";
+}
+
+// ============================================================================
+// set_delay() retunes
+// ============================================================================
+
+void test_set_delay_retunes() {
+	FractionalDelay<double> d(0.0, /*num_taps=*/31);
+	// Verify at delay=0 the response is consistent
+	auto r0 = measure_tone_response(d, 0.10);
+	REQUIRE_NEAR(r0.magnitude_dB, 0.0, 0.5);
+
+	// Retune to delay=0.5; the response should still be in-band-flat but
+	// the phase changes.
+	d.set_delay(0.5);
+	auto r1 = measure_tone_response(d, 0.10);
+	REQUIRE_NEAR(r1.magnitude_dB, 0.0, 0.5);
+	// Phase difference between r0 and r1 corresponds to 0.5 sample of
+	// extra delay at f_norm=0.1 → -2π * 0.1 * 0.5 ≈ -0.314 rad
+	const double pi = std::numbers::pi_v<double>;
+	const double expected_dphase = -2.0 * pi * 0.10 * 0.5;
+	const double measured_dphase = r1.phase_rad - r0.phase_rad;
+	double dphase = measured_dphase - expected_dphase;
+	while (dphase >  pi) dphase -= 2.0 * pi;
+	while (dphase < -pi) dphase += 2.0 * pi;
+	REQUIRE(std::abs(dphase) < 0.1);
+	std::cout << "  set_delay_retunes: passed\n";
+}
+
+// ============================================================================
+// Precision sweep
+// ============================================================================
+
+template <class T>
+double measure_delay_error_at_f(double delay_frac, double f_norm) {
+	FractionalDelay<T, T, T> d(delay_frac, /*num_taps=*/31);
+	const auto resp = measure_tone_response(d, f_norm);
+	const double pi = std::numbers::pi_v<double>;
+	const double total_delay = 15.0 + delay_frac;
+	double exp_phase = -2.0 * pi * f_norm * total_delay;
+	while (exp_phase >  pi) exp_phase -= 2.0 * pi;
+	while (exp_phase < -pi) exp_phase += 2.0 * pi;
+	double dphase = resp.phase_rad - exp_phase;
+	while (dphase >  pi) dphase -= 2.0 * pi;
+	while (dphase < -pi) dphase += 2.0 * pi;
+	// Convert phase error to fractional-sample error
+	return std::abs(dphase) / (2.0 * pi * f_norm);
+}
+
+void test_precision_sweep() {
+	const double delay = 0.3;
+	const double f     = 0.10;
+
+	const double err_double = measure_delay_error_at_f<double>(delay, f);
+	const double err_float  = measure_delay_error_at_f<float>(delay, f);
+	const double err_p32    = measure_delay_error_at_f<sw::universal::posit<32, 2>>(delay, f);
+
+	std::cout << "  precision sweep: delay accuracy at delay=0.3, f_norm=0.10\n";
+	std::cout << "    double:        " << err_double << " samples\n";
+	std::cout << "    float:         " << err_float  << " samples\n";
+	std::cout << "    posit<32,2>:   " << err_p32    << " samples\n";
+
+	// All should be small (sub-sample). The comparison is what matters:
+	// double should be the most accurate, float and posit32 close behind.
+	REQUIRE(err_double < 0.01);
+	REQUIRE(err_float  < 0.01);
+	REQUIRE(err_p32    < 0.01);
+	std::cout << "  precision_sweep: passed\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_instrument_fractional_delay\n";
+
+		test_ctor_even_taps_throws();
+		test_ctor_too_few_taps_throws();
+		test_ctor_delay_negative_throws();
+		test_ctor_delay_one_or_more_throws();
+
+		test_zero_delay_passthrough();
+		test_delay_accuracy();
+		test_in_band_flatness();
+		test_group_delay_flatness();
+
+		test_set_delay_retunes();
+
+		test_precision_sweep();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary

Sub-issue of #133 (Digital Oscilloscope Demonstrator). Two new classes for static sub-sample skew correction across channels — the most complex remaining piece for the scope demonstrator.

## What's in this PR

**\`include/sw/dsp/instrument/fractional_delay.hpp\`** — \`FractionalDelay<CoeffScalar, StateScalar, SampleScalar>\`:

\`\`\`cpp
FractionalDelay(double delay_samples, std::size_t num_taps = 31);
SampleScalar process(SampleScalar in);
void process_block(...);
void set_delay(double delay_samples);   // retune without resetting state
\`\`\`

Windowed-sinc FIR designed at construction: \`h[n] = w[n] * sinc((n - center) - delay)\` with Hamming window, normalized for unity DC gain. Delegates streaming to the existing \`FIRFilter\` primitive.

**\`include/sw/dsp/instrument/channel_aligner.hpp\`** — \`ChannelAligner<CoeffScalar, StateScalar, SampleScalar>\`:

\`\`\`cpp
ChannelAligner(std::span<const double> skews, std::size_t num_taps = 31);
std::vector<SampleScalar> process(std::span<const SampleScalar> channel_samples);
\`\`\`

One \`FractionalDelay\` per channel. Channel 0 is the reference (\`skews[0]\` must be 0); the wrapper only does causal delays, so by convention the reference is the LATEST-sampling channel and others get delayed to catch up.

## Headline test: skew correction

\`test_skew_correction_two_channels\` synthesizes two channels of the same 0.20-cycles/sample tone with a known 0.3-sample skew. Pearson correlation:

| | Correlation |
|---|---|
| Uncorrected (raw signals) | 0.93 |
| After ChannelAligner | **1.00** |

## Files changed

| File | Change |
|---|---|
| \`include/sw/dsp/instrument/fractional_delay.hpp\` | NEW — ~150 lines |
| \`include/sw/dsp/instrument/channel_aligner.hpp\` | NEW — ~95 lines |
| \`tests/test_instrument_fractional_delay.cpp\` | NEW — 10 tests, ~270 lines |
| \`tests/test_instrument_channel_aligner.cpp\` | NEW — 8 tests, ~270 lines |
| \`tests/CMakeLists.txt\` | +6 lines |

## Test results

| Compiler | Build | Tests |
|---|---|---|
| gcc | OK | 18/18 PASS (10 + 8) |
| clang | OK | 18/18 PASS, identical output |

## Two design issues caught during testing

1. **Phase sign convention bug in test helper**: my initial \`measure_tone_response\` returned the cross-correlation phase, which has the OPPOSITE sign of the standard DTFT-based filter phase response. Fixed by negating to match the convention where a delay of τ samples gives phase = -2π f τ.

2. **Channel-aligner convention ambiguity**: my first test setup had channel 1 sampled EARLIER than the reference, which would require a non-causal advance to align. The wrapper only does causal delays, so the reference must be the LATEST-sampling channel. Documented this convention in the test's setup comment and in the channel_aligner.hpp header.

## Precision sweep result

Delay accuracy at f=0.10, requested delay=0.3:

| Type | Error |
|---|---|
| double | 2.34e-5 samples |
| float | 2.35e-5 samples |
| posit<32,2> | 2.34e-5 samples |

All sub-sample-precision; no meaningful degradation across types because the tap design runs in \`double\` regardless of \`CoeffScalar\` (matching the EqualizerFilter / SDR-demo pattern).

## #133 progress

| # | Title | Status |
|---|---|---|
| #146 peak-detect | merged ✓ |
| #147 auto-trigger | merged ✓ |
| #148 cross-channel triggering | merged ✓ |
| #149 display-rate envelope | merged ✓ |
| #162 (cleanup) peak_detect concept | merged ✓ |
| #165 (cleanup) QualifierAnd kInf guard + rename | merged ✓ |
| **#150 multi-channel time alignment** | **this PR** |
| #151 cursor / measurement primitives | open |
| #152 scope_demo application | open (depends on #151 + this PR) |

After this lands, **only #151 (measurements) remains** before #152 (scope_demo) can integrate everything.

## Test plan
- [x] Fast CI passes (gcc + clang)
- [x] CodeRabbit review
- [x] Promote to ready when satisfied

Resolves #150

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-channel time alignment with per-channel fractional skews to produce aligned streams in original channel order.
  * Fractional-sample delay filter with adjustable delay and predictable group delay.
  * In-place retuning of FIR coefficients without resetting filter state.

* **Tests**
  * New tests validating alignment accuracy, fractional-delay phase/group-delay behavior, signal fidelity, and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->