### PR TITLE
fix(build): replace deprecated FetchContent_Populate with MakeAvailable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,16 +42,23 @@ if(universal_FOUND)
 	message(STATUS "Found Universal via find_package")
 else()
 	message(STATUS "Universal not found via find_package, fetching headers from GitHub")
+	# Header-only consumption: we want to fetch the source tree but NOT
+	# call add_subdirectory on Universal's CMakeLists.txt (which would
+	# build its tests, examples, and other targets we don't need).
+	#
+	# The classic idiom for this — FetchContent_GetProperties + manual
+	# FetchContent_Populate — is deprecated as of CMake 3.30 (CMP0169).
+	# The forward-compatible pattern is FetchContent_MakeAvailable with
+	# SOURCE_SUBDIR pointing at a non-existent subdirectory: MakeAvailable
+	# only calls add_subdirectory when the subdir contains a CMakeLists.txt,
+	# so a path that doesn't exist gives us populate-without-build.
 	FetchContent_Declare(universal
 		GIT_REPOSITORY https://github.com/stillwater-sc/universal.git
 		GIT_TAG        v4.6.10
 		GIT_SHALLOW    TRUE
+		SOURCE_SUBDIR  _do_not_build_
 	)
-	# Header-only: fetch source but do NOT add_subdirectory (avoids building Universal's targets)
-	FetchContent_GetProperties(universal)
-	if(NOT universal_POPULATED)
-		FetchContent_Populate(universal)
-	endif()
+	FetchContent_MakeAvailable(universal)
 	# Universal headers use two include conventions:
 	#   - External: #include <sw/universal/...>  (needs include/)
 	#   - Internal: #include <universal/...>     (needs include/sw/)
@@ -67,16 +74,14 @@ if(MTL5_FOUND)
 	message(STATUS "Found MTL5 via find_package")
 else()
 	message(STATUS "MTL5 not found via find_package, fetching headers from GitHub")
+	# Same SOURCE_SUBDIR-doesn't-exist pattern as Universal above.
 	FetchContent_Declare(mtl5
 		GIT_REPOSITORY https://github.com/stillwater-sc/mtl5.git
 		GIT_TAG        main
 		GIT_SHALLOW    TRUE
+		SOURCE_SUBDIR  _do_not_build_
 	)
-	# Header-only: fetch source but do NOT add_subdirectory (avoids building MTL5's targets)
-	FetchContent_GetProperties(mtl5)
-	if(NOT mtl5_POPULATED)
-		FetchContent_Populate(mtl5)
-	endif()
+	FetchContent_MakeAvailable(mtl5)
 	target_include_directories(${PROJECT_NAME} INTERFACE
 		$<BUILD_INTERFACE:${mtl5_SOURCE_DIR}/include>)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,37 @@ target_include_directories(${PROJECT_NAME} INTERFACE
 # then fall back to FetchContent from GitHub (headers only).
 include(FetchContent)
 
+# Helper: fetch a header-only dependency from GitHub WITHOUT calling
+# add_subdirectory on its CMakeLists.txt (which would build its tests,
+# examples, and other targets we don't need).
+#
+# The classic idiom — FetchContent_GetProperties + manual
+# FetchContent_Populate — is deprecated as of CMake 3.30 (CMP0169).
+# The forward-compatible replacement is FetchContent_MakeAvailable with
+# SOURCE_SUBDIR pointing at a non-existent subdirectory: MakeAvailable
+# only calls add_subdirectory when the subdir contains a CMakeLists.txt,
+# so a path that doesn't exist gives us populate-without-build.
+#
+# Implemented as a macro (not function) so the `<name>_SOURCE_DIR`
+# variable that FetchContent_MakeAvailable sets ends up in the caller's
+# scope where the subsequent target_include_directories() can read it.
+# CMake functions introduce their own scope, which would swallow the
+# variable assignment. Universal's compile_all() macro uses the same
+# trick (and same rationale).
+#
+# Caller is responsible for setting up include directories from the
+# resulting <name>_SOURCE_DIR, since each dep has its own include-path
+# layout.
+macro(dsp_fetch_headers_only dep_name dep_repo dep_tag)
+	FetchContent_Declare(${dep_name}
+		GIT_REPOSITORY ${dep_repo}
+		GIT_TAG        ${dep_tag}
+		GIT_SHALLOW    TRUE
+		SOURCE_SUBDIR  _do_not_build_
+	)
+	FetchContent_MakeAvailable(${dep_name})
+endmacro()
+
 # Universal number arithmetic library (header-only)
 find_package(universal CONFIG QUIET)
 if(universal_FOUND)
@@ -42,23 +73,9 @@ if(universal_FOUND)
 	message(STATUS "Found Universal via find_package")
 else()
 	message(STATUS "Universal not found via find_package, fetching headers from GitHub")
-	# Header-only consumption: we want to fetch the source tree but NOT
-	# call add_subdirectory on Universal's CMakeLists.txt (which would
-	# build its tests, examples, and other targets we don't need).
-	#
-	# The classic idiom for this — FetchContent_GetProperties + manual
-	# FetchContent_Populate — is deprecated as of CMake 3.30 (CMP0169).
-	# The forward-compatible pattern is FetchContent_MakeAvailable with
-	# SOURCE_SUBDIR pointing at a non-existent subdirectory: MakeAvailable
-	# only calls add_subdirectory when the subdir contains a CMakeLists.txt,
-	# so a path that doesn't exist gives us populate-without-build.
-	FetchContent_Declare(universal
-		GIT_REPOSITORY https://github.com/stillwater-sc/universal.git
-		GIT_TAG        v4.6.10
-		GIT_SHALLOW    TRUE
-		SOURCE_SUBDIR  _do_not_build_
-	)
-	FetchContent_MakeAvailable(universal)
+	dsp_fetch_headers_only(universal
+		https://github.com/stillwater-sc/universal.git
+		v4.6.10)
 	# Universal headers use two include conventions:
 	#   - External: #include <sw/universal/...>  (needs include/)
 	#   - Internal: #include <universal/...>     (needs include/sw/)
@@ -74,14 +91,9 @@ if(MTL5_FOUND)
 	message(STATUS "Found MTL5 via find_package")
 else()
 	message(STATUS "MTL5 not found via find_package, fetching headers from GitHub")
-	# Same SOURCE_SUBDIR-doesn't-exist pattern as Universal above.
-	FetchContent_Declare(mtl5
-		GIT_REPOSITORY https://github.com/stillwater-sc/mtl5.git
-		GIT_TAG        main
-		GIT_SHALLOW    TRUE
-		SOURCE_SUBDIR  _do_not_build_
-	)
-	FetchContent_MakeAvailable(mtl5)
+	dsp_fetch_headers_only(mtl5
+		https://github.com/stillwater-sc/mtl5.git
+		main)
 	target_include_directories(${PROJECT_NAME} INTERFACE
 		$<BUILD_INTERFACE:${mtl5_SOURCE_DIR}/include>)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,11 @@ if(MTL5_FOUND)
 	message(STATUS "Found MTL5 via find_package")
 else()
 	message(STATUS "MTL5 not found via find_package, fetching headers from GitHub")
+	# Pinning note: MTL5 floats on `main` because we depend on
+	# `mtl/operation/ldlt.hpp` (used by `include/sw/dsp/estimation/ukf.hpp`),
+	# which landed post-v5.2.0 and is not yet in a tagged release.
+	# Switch this to a tag (e.g., v5.3.0) the moment one cuts that
+	# includes ldlt.
 	dsp_fetch_headers_only(mtl5
 		https://github.com/stillwater-sc/mtl5.git
 		main)


### PR DESCRIPTION
## Summary

CMake 3.30+ deprecates \`FetchContent_GetProperties + FetchContent_Populate\` (CMP0169). Configuring on recent CMake versions (e.g., MSVC's CMake 4.2 from VS 2026 Preview, plus current Linux distros) prints a warning per fetched dep:

\`\`\`
CMake Warning (dev) at .../FetchContent.cmake:1963 (message):
  Calling FetchContent_Populate(universal) is deprecated, call
  FetchContent_MakeAvailable(universal) instead.
\`\`\`

## What changed

\`CMakeLists.txt\` — both Universal and MTL5 fetch blocks switch from the deprecated explicit-Populate idiom to \`FetchContent_MakeAvailable\` with \`SOURCE_SUBDIR\` pointing at a non-existent path.

## Why \`SOURCE_SUBDIR\` to a non-existent path

We deliberately fetch the source tree but DO NOT want \`add_subdirectory\` to run on Universal's or MTL5's \`CMakeLists.txt\` — both define their own tests, examples, and other targets we don't need for header-only consumption. The original code achieved this by manually calling \`Populate\` and skipping \`add_subdirectory\`.

\`FetchContent_MakeAvailable\` runs \`add_subdirectory\` automatically — UNLESS the configured \`SOURCE_SUBDIR\` doesn't contain a \`CMakeLists.txt\`. So pointing \`SOURCE_SUBDIR\` at a path like \`_do_not_build_\` (which doesn't exist in either repo) gives us populate-without-build via the supported MakeAvailable API.

This idiom has been the recommended replacement since CMake 3.18; an inline comment in the new code documents it so future readers don't have to hunt for the pattern.

## Verification

\`\`\`
$ cmake -B build 2>&1 | grep -i "Populate\|deprecated\|Warning"
\` \` \`(no output)\` \` \`
$ cmake --build build --target test_instrument_fractional_delay
[100%] Built target test_instrument_fractional_delay
$ ./build/tests/test_instrument_fractional_delay | tail -3
    posit<32,2>:   2.34182e-05 samples
  precision_sweep: passed
all tests passed
\`\`\`

The deprecation warning is gone and the existing tests (which exercise Universal's posit headers, proving the fetch works) still pass.

## Test plan
- [x] Fast CI passes on all platforms (the change is CMake-side, but every build configures CMake)
- [x] No deprecation warnings in CI output
- [x] Promote to ready when satisfied

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Modernized build setup to fetch upstream headers without building their examples/tests, yielding smaller, faster local builds and cleaner packaging.
  * Replaced older fallback logic with a consolidated header-only fetch approach and added clarifying inline comments for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->