### PR TITLE
feat(scope): cursor / measurement primitives

### DIFF
--- a/include/sw/dsp/instrument/measurements.hpp
+++ b/include/sw/dsp/instrument/measurements.hpp
@@ -155,21 +155,27 @@ template <DspOrderedField T>
 	// First rising crossing of thr_lo, then first subsequent rising
 	// crossing of thr_hi. "Rising" = sample[i] < threshold,
 	// sample[i+1] >= threshold.
+	//
+	// Both checks must run in the same iteration (no `else if`): a
+	// steep edge can cross both thresholds within a single sample
+	// step (e.g., signal jumps 0.05 -> 0.95 with default 10/90
+	// thresholds). Linear interpolation gives valid sub-sample times
+	// for both, and t_hi > t_lo is guaranteed because thr_hi > thr_lo
+	// on a rising edge.
 	double t_lo = std::numeric_limits<double>::quiet_NaN();
 	double t_hi = std::numeric_limits<double>::quiet_NaN();
 	for (std::size_t i = 0; i + 1 < segment.size(); ++i) {
 		const double a = static_cast<double>(segment[i]);
 		const double b = static_cast<double>(segment[i + 1]);
-		if (std::isnan(t_lo)) {
-			if (a < thr_lo && b >= thr_lo)
-				t_lo = static_cast<double>(i)
-				     + detail::interp_crossing(a, b, thr_lo);
-		} else if (std::isnan(t_hi)) {
-			if (a < thr_hi && b >= thr_hi) {
-				t_hi = static_cast<double>(i)
-				     + detail::interp_crossing(a, b, thr_hi);
-				break;
-			}
+		if (std::isnan(t_lo) && a < thr_lo && b >= thr_lo) {
+			t_lo = static_cast<double>(i)
+			     + detail::interp_crossing(a, b, thr_lo);
+		}
+		if (!std::isnan(t_lo) && std::isnan(t_hi)
+		    && a < thr_hi && b >= thr_hi) {
+			t_hi = static_cast<double>(i)
+			     + detail::interp_crossing(a, b, thr_hi);
+			break;
 		}
 	}
 	if (std::isnan(t_lo) || std::isnan(t_hi))
@@ -200,22 +206,24 @@ template <DspOrderedField T>
 	const double thr_hi = lo + high_pct * range;
 
 	// First falling crossing of thr_hi (a >= thr_hi, b < thr_hi),
-	// then first subsequent falling crossing of thr_lo.
+	// then first subsequent falling crossing of thr_lo. Both checks
+	// run in the same iteration so a steep falling edge that crosses
+	// both thresholds within one sample step is recovered correctly
+	// (mirror of the rise-time loop above).
 	double t_hi = std::numeric_limits<double>::quiet_NaN();
 	double t_lo = std::numeric_limits<double>::quiet_NaN();
 	for (std::size_t i = 0; i + 1 < segment.size(); ++i) {
 		const double a = static_cast<double>(segment[i]);
 		const double b = static_cast<double>(segment[i + 1]);
-		if (std::isnan(t_hi)) {
-			if (a >= thr_hi && b < thr_hi)
-				t_hi = static_cast<double>(i)
-				     + detail::interp_crossing(a, b, thr_hi);
-		} else if (std::isnan(t_lo)) {
-			if (a >= thr_lo && b < thr_lo) {
-				t_lo = static_cast<double>(i)
-				     + detail::interp_crossing(a, b, thr_lo);
-				break;
-			}
+		if (std::isnan(t_hi) && a >= thr_hi && b < thr_hi) {
+			t_hi = static_cast<double>(i)
+			     + detail::interp_crossing(a, b, thr_hi);
+		}
+		if (!std::isnan(t_hi) && std::isnan(t_lo)
+		    && a >= thr_lo && b < thr_lo) {
+			t_lo = static_cast<double>(i)
+			     + detail::interp_crossing(a, b, thr_lo);
+			break;
 		}
 	}
 	if (std::isnan(t_hi) || std::isnan(t_lo))
@@ -224,16 +232,18 @@ template <DspOrderedField T>
 }
 
 // Period in samples: average distance between consecutive rising
-// threshold-crossings. Threshold defaults to T{0} (zero-crossing,
-// natural for AC-coupled signals). Returns NaN if fewer than two
-// rising crossings occur in the segment.
+// threshold-crossings. Threshold defaults to T{} (zero-crossing,
+// natural for AC-coupled signals — value-initialization yields the
+// additive identity for arithmetic types and matches the
+// default-constructibility required by DspScalar). Returns NaN if
+// fewer than two rising crossings occur in the segment.
 //
 // Sub-sample crossing times use linear interpolation, so the returned
 // period is fractional.
 template <DspOrderedField T>
 	requires ConvertibleToDouble<T>
 [[nodiscard]] double period_samples(std::span<const T> segment,
-                                    T threshold = T{0}) {
+                                    T threshold = T{}) {
 	detail::require_nonempty(segment, "period_samples");
 	if (segment.size() < 2)
 		return std::numeric_limits<double>::quiet_NaN();
@@ -267,7 +277,7 @@ template <DspOrderedField T>
 	requires ConvertibleToDouble<T>
 [[nodiscard]] double frequency_hz(std::span<const T> segment,
                                   double sample_rate,
-                                  T threshold = T{0}) {
+                                  T threshold = T{}) {
 	if (!(sample_rate > 0.0))
 		throw std::invalid_argument(
 			"frequency_hz: sample_rate must be positive");

--- a/include/sw/dsp/instrument/measurements.hpp
+++ b/include/sw/dsp/instrument/measurements.hpp
@@ -1,0 +1,278 @@
+#pragma once
+// measurements.hpp: Scope-style waveform measurements on captured segments.
+//
+// These are the numbers a digital oscilloscope displays in its bottom
+// panel: amplitude, mean, RMS, frequency, period, rise/fall time. Each
+// function takes a captured segment as a std::span<const T> and returns
+// a double scalar — same one-shot contract as a scope's measurement
+// readout.
+//
+// Mixed-precision contract: aggregations (sum, sum-of-squares, min/max,
+// threshold-crossing interpolation) run in double internally regardless
+// of SampleScalar. For narrow streaming types this preserves measurement
+// accuracy without forcing the caller to widen their sample buffer.
+// Returning double matches the precision concerns of the spectrum-
+// analyzer RMS detector (#134) and the analysis primitives in
+// sw/dsp/analysis/.
+//
+// Edge-case convention:
+//   - Empty segment       -> throw std::invalid_argument
+//   - Single sample       -> peak_to_peak=0, mean=value, rms=|value|;
+//                            rise/fall/period/frequency return NaN
+//                            (no transition to measure)
+//   - All-equal samples   -> peak_to_peak=0, mean/rms well-defined;
+//                            rise/fall/period/frequency return NaN
+//
+// NaN is preferred over throws for "no measurable transition" cases so
+// that a caller computing all seven values on one segment does not have
+// one undefined measurement abort the others.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp::instrument {
+
+namespace detail {
+
+template <typename T>
+inline void require_nonempty(std::span<const T> segment, const char* fn) {
+	if (segment.empty())
+		throw std::invalid_argument(
+			std::string(fn) + ": segment is empty");
+}
+
+// Linear interpolation: given x[i] = a, x[i+1] = b, find the fractional
+// offset within sample i where the signal crosses `threshold`. Returns
+// a value in [0, 1]. Caller adds `i` to get the absolute crossing time.
+inline double interp_crossing(double a, double b, double threshold) {
+	const double denom = b - a;
+	if (std::abs(denom) < std::numeric_limits<double>::min())
+		return 0.0;   // degenerate: a == b == threshold; pick the left edge
+	return (threshold - a) / denom;
+}
+
+} // namespace detail
+
+// Peak-to-peak amplitude: max(segment) - min(segment).
+//
+// For a unit-amplitude sine: 2.0. For a square wave of amplitude A: 2*A.
+// Single-sample / all-equal segments return 0.
+template <DspOrderedField T>
+	requires ConvertibleToDouble<T>
+[[nodiscard]] double peak_to_peak(std::span<const T> segment) {
+	detail::require_nonempty(segment, "peak_to_peak");
+	double lo = static_cast<double>(segment[0]);
+	double hi = lo;
+	for (std::size_t i = 1; i < segment.size(); ++i) {
+		const double v = static_cast<double>(segment[i]);
+		if (v < lo) lo = v;
+		if (v > hi) hi = v;
+	}
+	return hi - lo;
+}
+
+// Arithmetic mean of the segment (DC level).
+//
+// Accumulates in double regardless of SampleScalar precision so narrow
+// types do not lose accuracy on long segments.
+template <DspScalar T>
+	requires ConvertibleToDouble<T>
+[[nodiscard]] double mean(std::span<const T> segment) {
+	detail::require_nonempty(segment, "mean");
+	double sum = 0.0;
+	for (const T& s : segment) sum += static_cast<double>(s);
+	return sum / static_cast<double>(segment.size());
+}
+
+// Root-mean-square of the segment.
+//
+// For a unit-amplitude sine: 1/sqrt(2) ~= 0.7071. For a unit-amplitude
+// square wave: 1.0. Sum-of-squares is accumulated in double.
+template <DspScalar T>
+	requires ConvertibleToDouble<T>
+[[nodiscard]] double rms(std::span<const T> segment) {
+	detail::require_nonempty(segment, "rms");
+	double sumsq = 0.0;
+	for (const T& s : segment) {
+		const double v = static_cast<double>(s);
+		sumsq += v * v;
+	}
+	return std::sqrt(sumsq / static_cast<double>(segment.size()));
+}
+
+// Rise time in samples: the time for the signal to climb from
+// low_pct * peak_to_peak above the segment minimum to high_pct *
+// peak_to_peak above the minimum, measured on the first such rising
+// transition in the segment. Returns NaN if no transition spans both
+// thresholds (e.g., all-equal segment, monotonically falling, never
+// reaches high_pct).
+//
+// Sub-sample crossings are computed by linear interpolation between
+// the two samples that bracket each threshold, so the returned value
+// is fractional. Caller converts to seconds via `result / sample_rate`.
+template <DspOrderedField T>
+	requires ConvertibleToDouble<T>
+[[nodiscard]] double rise_time_samples(std::span<const T> segment,
+                                       double low_pct = 0.1,
+                                       double high_pct = 0.9) {
+	detail::require_nonempty(segment, "rise_time_samples");
+	if (!(low_pct >= 0.0 && low_pct < high_pct && high_pct <= 1.0))
+		throw std::invalid_argument(
+			"rise_time_samples: require 0 <= low_pct < high_pct <= 1");
+	if (segment.size() < 2)
+		return std::numeric_limits<double>::quiet_NaN();
+
+	double lo = static_cast<double>(segment[0]);
+	double hi = lo;
+	for (std::size_t i = 1; i < segment.size(); ++i) {
+		const double v = static_cast<double>(segment[i]);
+		if (v < lo) lo = v;
+		if (v > hi) hi = v;
+	}
+	const double range = hi - lo;
+	if (range <= 0.0)
+		return std::numeric_limits<double>::quiet_NaN();
+	const double thr_lo = lo + low_pct  * range;
+	const double thr_hi = lo + high_pct * range;
+
+	// First rising crossing of thr_lo, then first subsequent rising
+	// crossing of thr_hi. "Rising" = sample[i] < threshold,
+	// sample[i+1] >= threshold.
+	double t_lo = std::numeric_limits<double>::quiet_NaN();
+	double t_hi = std::numeric_limits<double>::quiet_NaN();
+	for (std::size_t i = 0; i + 1 < segment.size(); ++i) {
+		const double a = static_cast<double>(segment[i]);
+		const double b = static_cast<double>(segment[i + 1]);
+		if (std::isnan(t_lo)) {
+			if (a < thr_lo && b >= thr_lo)
+				t_lo = static_cast<double>(i)
+				     + detail::interp_crossing(a, b, thr_lo);
+		} else if (std::isnan(t_hi)) {
+			if (a < thr_hi && b >= thr_hi) {
+				t_hi = static_cast<double>(i)
+				     + detail::interp_crossing(a, b, thr_hi);
+				break;
+			}
+		}
+	}
+	if (std::isnan(t_lo) || std::isnan(t_hi))
+		return std::numeric_limits<double>::quiet_NaN();
+	return t_hi - t_lo;
+}
+
+// Fall time in samples: mirror of rise_time_samples for the first
+// falling transition from high_pct down to low_pct of peak-to-peak.
+// Returns NaN if no falling transition spans both thresholds.
+template <DspOrderedField T>
+	requires ConvertibleToDouble<T>
+[[nodiscard]] double fall_time_samples(std::span<const T> segment,
+                                       double low_pct = 0.1,
+                                       double high_pct = 0.9) {
+	detail::require_nonempty(segment, "fall_time_samples");
+	if (!(low_pct >= 0.0 && low_pct < high_pct && high_pct <= 1.0))
+		throw std::invalid_argument(
+			"fall_time_samples: require 0 <= low_pct < high_pct <= 1");
+	if (segment.size() < 2)
+		return std::numeric_limits<double>::quiet_NaN();
+
+	double lo = static_cast<double>(segment[0]);
+	double hi = lo;
+	for (std::size_t i = 1; i < segment.size(); ++i) {
+		const double v = static_cast<double>(segment[i]);
+		if (v < lo) lo = v;
+		if (v > hi) hi = v;
+	}
+	const double range = hi - lo;
+	if (range <= 0.0)
+		return std::numeric_limits<double>::quiet_NaN();
+	const double thr_lo = lo + low_pct  * range;
+	const double thr_hi = lo + high_pct * range;
+
+	// First falling crossing of thr_hi (a >= thr_hi, b < thr_hi),
+	// then first subsequent falling crossing of thr_lo.
+	double t_hi = std::numeric_limits<double>::quiet_NaN();
+	double t_lo = std::numeric_limits<double>::quiet_NaN();
+	for (std::size_t i = 0; i + 1 < segment.size(); ++i) {
+		const double a = static_cast<double>(segment[i]);
+		const double b = static_cast<double>(segment[i + 1]);
+		if (std::isnan(t_hi)) {
+			if (a >= thr_hi && b < thr_hi)
+				t_hi = static_cast<double>(i)
+				     + detail::interp_crossing(a, b, thr_hi);
+		} else if (std::isnan(t_lo)) {
+			if (a >= thr_lo && b < thr_lo) {
+				t_lo = static_cast<double>(i)
+				     + detail::interp_crossing(a, b, thr_lo);
+				break;
+			}
+		}
+	}
+	if (std::isnan(t_hi) || std::isnan(t_lo))
+		return std::numeric_limits<double>::quiet_NaN();
+	return t_lo - t_hi;
+}
+
+// Period in samples: average distance between consecutive rising
+// threshold-crossings. Threshold defaults to T{0} (zero-crossing,
+// natural for AC-coupled signals). Returns NaN if fewer than two
+// rising crossings occur in the segment.
+//
+// Sub-sample crossing times use linear interpolation, so the returned
+// period is fractional.
+template <DspOrderedField T>
+	requires ConvertibleToDouble<T>
+[[nodiscard]] double period_samples(std::span<const T> segment,
+                                    T threshold = T{0}) {
+	detail::require_nonempty(segment, "period_samples");
+	if (segment.size() < 2)
+		return std::numeric_limits<double>::quiet_NaN();
+	const double thr = static_cast<double>(threshold);
+
+	// Collect all rising crossing times.
+	double first_crossing = 0.0;
+	double last_crossing  = 0.0;
+	std::size_t crossings = 0;
+	for (std::size_t i = 0; i + 1 < segment.size(); ++i) {
+		const double a = static_cast<double>(segment[i]);
+		const double b = static_cast<double>(segment[i + 1]);
+		if (a < thr && b >= thr) {
+			const double t = static_cast<double>(i)
+			               + detail::interp_crossing(a, b, thr);
+			if (crossings == 0) first_crossing = t;
+			last_crossing = t;
+			++crossings;
+		}
+	}
+	if (crossings < 2)
+		return std::numeric_limits<double>::quiet_NaN();
+	// (n-1) intervals between n crossings.
+	return (last_crossing - first_crossing)
+	     / static_cast<double>(crossings - 1);
+}
+
+// Frequency in Hz: 1 / (period_samples * sample_period). Returns NaN
+// if period cannot be measured (see period_samples).
+template <DspOrderedField T>
+	requires ConvertibleToDouble<T>
+[[nodiscard]] double frequency_hz(std::span<const T> segment,
+                                  double sample_rate,
+                                  T threshold = T{0}) {
+	if (!(sample_rate > 0.0))
+		throw std::invalid_argument(
+			"frequency_hz: sample_rate must be positive");
+	const double T_samples = period_samples(segment, threshold);
+	if (std::isnan(T_samples) || T_samples <= 0.0)
+		return std::numeric_limits<double>::quiet_NaN();
+	return sample_rate / T_samples;
+}
+
+} // namespace sw::dsp::instrument

--- a/include/sw/dsp/instrument/measurements.hpp
+++ b/include/sw/dsp/instrument/measurements.hpp
@@ -37,6 +37,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <sw/dsp/concepts/scalar.hpp>
 
 namespace sw::dsp::instrument {
@@ -53,11 +54,30 @@ inline void require_nonempty(std::span<const T> segment, const char* fn) {
 // Linear interpolation: given x[i] = a, x[i+1] = b, find the fractional
 // offset within sample i where the signal crosses `threshold`. Returns
 // a value in [0, 1]. Caller adds `i` to get the absolute crossing time.
+//
+// Exact-zero guard (not <epsilon): subnormals are still legitimate
+// non-zero denominators that yield a finite, well-defined fractional
+// crossing. We only short-circuit when a == b literally — that is the
+// case where the interpolation is undefined.
 inline double interp_crossing(double a, double b, double threshold) {
 	const double denom = b - a;
-	if (std::abs(denom) < std::numeric_limits<double>::min())
+	if (denom == 0.0)
 		return 0.0;   // degenerate: a == b == threshold; pick the left edge
 	return (threshold - a) / denom;
+}
+
+// Single-pass min/max over a span, accumulating in double regardless of
+// SampleScalar precision. Caller must ensure the segment is non-empty.
+template <typename T>
+inline std::pair<double, double> min_max_double(std::span<const T> segment) {
+	double lo = static_cast<double>(segment[0]);
+	double hi = lo;
+	for (std::size_t i = 1; i < segment.size(); ++i) {
+		const double v = static_cast<double>(segment[i]);
+		if (v < lo) lo = v;
+		if (v > hi) hi = v;
+	}
+	return {lo, hi};
 }
 
 } // namespace detail
@@ -70,13 +90,7 @@ template <DspOrderedField T>
 	requires ConvertibleToDouble<T>
 [[nodiscard]] double peak_to_peak(std::span<const T> segment) {
 	detail::require_nonempty(segment, "peak_to_peak");
-	double lo = static_cast<double>(segment[0]);
-	double hi = lo;
-	for (std::size_t i = 1; i < segment.size(); ++i) {
-		const double v = static_cast<double>(segment[i]);
-		if (v < lo) lo = v;
-		if (v > hi) hi = v;
-	}
+	const auto [lo, hi] = detail::min_max_double(segment);
 	return hi - lo;
 }
 
@@ -131,13 +145,7 @@ template <DspOrderedField T>
 	if (segment.size() < 2)
 		return std::numeric_limits<double>::quiet_NaN();
 
-	double lo = static_cast<double>(segment[0]);
-	double hi = lo;
-	for (std::size_t i = 1; i < segment.size(); ++i) {
-		const double v = static_cast<double>(segment[i]);
-		if (v < lo) lo = v;
-		if (v > hi) hi = v;
-	}
+	const auto [lo, hi] = detail::min_max_double(segment);
 	const double range = hi - lo;
 	if (range <= 0.0)
 		return std::numeric_limits<double>::quiet_NaN();
@@ -184,13 +192,7 @@ template <DspOrderedField T>
 	if (segment.size() < 2)
 		return std::numeric_limits<double>::quiet_NaN();
 
-	double lo = static_cast<double>(segment[0]);
-	double hi = lo;
-	for (std::size_t i = 1; i < segment.size(); ++i) {
-		const double v = static_cast<double>(segment[i]);
-		if (v < lo) lo = v;
-		if (v > hi) hi = v;
-	}
+	const auto [lo, hi] = detail::min_max_double(segment);
 	const double range = hi - lo;
 	if (range <= 0.0)
 		return std::numeric_limits<double>::quiet_NaN();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,7 @@ dsp_add_test(test_instrument_peak_detect       "Tests/Instrument")
 dsp_add_test(test_instrument_display_envelope  "Tests/Instrument")
 dsp_add_test(test_instrument_fractional_delay  "Tests/Instrument")
 dsp_add_test(test_instrument_channel_aligner   "Tests/Instrument")
+dsp_add_test(test_instrument_measurements      "Tests/Instrument")
 
 # =============================================================================
 # Analysis — stability, sensitivity, condition number, and per-pipeline

--- a/tests/README.md
+++ b/tests/README.md
@@ -58,7 +58,8 @@ Tests/
 │   ├── test_instrument_peak_detect       Min/max decimation
 │   ├── test_instrument_display_envelope  Pixel-rate envelope
 │   ├── test_instrument_fractional_delay  Sub-sample windowed-sinc FIR delay
-│   └── test_instrument_channel_aligner   Multi-channel time alignment
+│   ├── test_instrument_channel_aligner   Multi-channel time alignment
+│   └── test_instrument_measurements      Cursor / scope-style measurements
 ├── Analysis/                    Stability, sensitivity, precision analysis
 │   ├── test_analysis            Pole-zero / sensitivity / condition number
 │   └── test_acquisition_precision  SNR/ENOB/SFDR/CIC bit-growth (acq-pipeline-specific)

--- a/tests/test_instrument_measurements.cpp
+++ b/tests/test_instrument_measurements.cpp
@@ -1,0 +1,270 @@
+// test_instrument_measurements.cpp: tests for scope-style waveform
+// measurements (peak-to-peak, mean, RMS, rise/fall time, period,
+// frequency).
+//
+// Coverage:
+//   - Aggregations: square wave, sine wave (known analytical answers)
+//   - Linear ramp: rise_time matches the analytical answer
+//   - Period/frequency: noise-free sine, with linear interpolation
+//     making the result accurate well below 1 sample
+//   - Edge cases: empty (throws), single sample, all-equal samples,
+//     monotonic (no transition for rise/fall)
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <numbers>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <sw/dsp/instrument/measurements.hpp>
+
+using namespace sw::dsp::instrument;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+static bool approx(double a, double b, double tol) {
+	return std::abs(a - b) <= tol;
+}
+
+// ============================================================================
+// Aggregations on a known square wave
+// ============================================================================
+
+void test_square_wave_aggregations() {
+	// 100-sample square wave: 50 samples at +2.0, then 50 at -1.0.
+	// DC offset = +0.5, peak-to-peak = 3.0, RMS = sqrt((50*4 + 50*1)/100)
+	//                                            = sqrt(2.5) ~= 1.5811.
+	std::vector<double> sq(100);
+	for (std::size_t n = 0; n < 50; ++n) sq[n] = 2.0;
+	for (std::size_t n = 50; n < 100; ++n) sq[n] = -1.0;
+	std::span<const double> seg{sq};
+
+	REQUIRE(approx(peak_to_peak(seg), 3.0, 1e-12));
+	REQUIRE(approx(mean(seg), 0.5, 1e-12));
+	REQUIRE(approx(rms(seg), std::sqrt(2.5), 1e-12));
+	std::cout << "  square_wave_aggregations: passed (p2p=3, mean=0.5, rms="
+	          << rms(seg) << ")\n";
+}
+
+// ============================================================================
+// Aggregations on a unit-amplitude sine
+// ============================================================================
+
+void test_sine_aggregations() {
+	// 1024 samples of one full cycle of unit-amplitude sine, no DC.
+	const std::size_t N = 1024;
+	const double pi = std::numbers::pi_v<double>;
+	std::vector<double> s(N);
+	for (std::size_t n = 0; n < N; ++n)
+		s[n] = std::sin(2.0 * pi * static_cast<double>(n) / static_cast<double>(N));
+	std::span<const double> seg{s};
+
+	REQUIRE(approx(peak_to_peak(seg), 2.0, 1e-3));     // exact 2 - tiny grid err
+	REQUIRE(approx(mean(seg), 0.0, 1e-12));            // one full cycle
+	REQUIRE(approx(rms(seg), 1.0 / std::sqrt(2.0), 1e-3));
+	std::cout << "  sine_aggregations: passed (p2p=" << peak_to_peak(seg)
+	          << ", mean=" << mean(seg) << ", rms=" << rms(seg) << ")\n";
+}
+
+// ============================================================================
+// Linear ramp: rise time has a closed-form answer
+// ============================================================================
+
+void test_linear_ramp_rise_time() {
+	// Ramp from 0 to 1 over 100 samples (samples 0..100).
+	// Peak-to-peak = 1.0. Default thresholds: low=0.1, high=0.9.
+	// 10% threshold crossed at sample 10, 90% threshold at sample 90.
+	// Expected rise time = 80 samples.
+	std::vector<double> ramp(101);
+	for (std::size_t n = 0; n <= 100; ++n)
+		ramp[n] = static_cast<double>(n) / 100.0;
+
+	const double rt = rise_time_samples(std::span<const double>{ramp});
+	REQUIRE(approx(rt, 80.0, 1e-9));
+	std::cout << "  linear_ramp_rise_time: passed (rise_time=" << rt
+	          << " samples, expected 80)\n";
+}
+
+void test_linear_ramp_fall_time() {
+	// Ramp from 1 down to 0 over 100 samples.
+	// 90% threshold crossed at sample 10, 10% threshold at sample 90.
+	// Expected fall time = 80 samples.
+	std::vector<double> ramp(101);
+	for (std::size_t n = 0; n <= 100; ++n)
+		ramp[n] = 1.0 - static_cast<double>(n) / 100.0;
+
+	const double ft = fall_time_samples(std::span<const double>{ramp});
+	REQUIRE(approx(ft, 80.0, 1e-9));
+	std::cout << "  linear_ramp_fall_time: passed (fall_time=" << ft
+	          << " samples, expected 80)\n";
+}
+
+// ============================================================================
+// Period & frequency: noise-free sine
+// ============================================================================
+
+void test_period_and_frequency_sine() {
+	// Sample rate 1 MHz, signal 50 kHz. Period = 20 samples.
+	const double pi = std::numbers::pi_v<double>;
+	const double sample_rate = 1.0e6;
+	const double f           = 50.0e3;
+	const std::size_t N      = 4000;   // 200 cycles
+	std::vector<double> s(N);
+	for (std::size_t n = 0; n < N; ++n)
+		s[n] = std::sin(2.0 * pi * f * static_cast<double>(n) / sample_rate);
+	std::span<const double> seg{s};
+
+	const double T_samp = period_samples(seg);
+	const double freq   = frequency_hz(seg, sample_rate);
+	REQUIRE(approx(T_samp, 20.0, 1e-6));
+	REQUIRE(approx(freq, f, 1.0));   // within 1 Hz of 50 kHz
+	std::cout << "  period_and_frequency_sine: passed (T=" << T_samp
+	          << " samples, f=" << freq << " Hz)\n";
+}
+
+// ============================================================================
+// Edge cases
+// ============================================================================
+
+void test_empty_segment_throws() {
+	std::span<const double> empty{};
+	bool threw_p2p = false, threw_mean = false, threw_rms = false;
+	try { (void)peak_to_peak(empty); }
+	catch (const std::invalid_argument&) { threw_p2p = true; }
+	try { (void)mean(empty); }
+	catch (const std::invalid_argument&) { threw_mean = true; }
+	try { (void)rms(empty); }
+	catch (const std::invalid_argument&) { threw_rms = true; }
+	REQUIRE(threw_p2p);
+	REQUIRE(threw_mean);
+	REQUIRE(threw_rms);
+	std::cout << "  empty_segment_throws: passed\n";
+}
+
+void test_single_sample() {
+	std::vector<double> one = {3.5};
+	std::span<const double> seg{one};
+	REQUIRE(approx(peak_to_peak(seg), 0.0, 1e-12));
+	REQUIRE(approx(mean(seg), 3.5, 1e-12));
+	REQUIRE(approx(rms(seg), 3.5, 1e-12));   // sqrt(3.5^2) = 3.5
+	REQUIRE(std::isnan(rise_time_samples(seg)));
+	REQUIRE(std::isnan(fall_time_samples(seg)));
+	REQUIRE(std::isnan(period_samples(seg)));
+	REQUIRE(std::isnan(frequency_hz(seg, 1.0e6)));
+	std::cout << "  single_sample: passed\n";
+}
+
+void test_all_equal_samples() {
+	std::vector<double> flat(64, 1.5);
+	std::span<const double> seg{flat};
+	REQUIRE(approx(peak_to_peak(seg), 0.0, 1e-12));
+	REQUIRE(approx(mean(seg), 1.5, 1e-12));
+	REQUIRE(approx(rms(seg), 1.5, 1e-12));
+	// No range -> rise/fall return NaN; no rising crossings -> period NaN.
+	REQUIRE(std::isnan(rise_time_samples(seg)));
+	REQUIRE(std::isnan(fall_time_samples(seg)));
+	REQUIRE(std::isnan(period_samples(seg)));
+	std::cout << "  all_equal_samples: passed\n";
+}
+
+void test_monotonic_no_falling_edge() {
+	// Pure rising ramp: rise_time well-defined, fall_time should be NaN.
+	std::vector<double> ramp(101);
+	for (std::size_t n = 0; n <= 100; ++n)
+		ramp[n] = static_cast<double>(n) / 100.0;
+	std::span<const double> seg{ramp};
+	REQUIRE(!std::isnan(rise_time_samples(seg)));
+	REQUIRE(std::isnan(fall_time_samples(seg)));
+	std::cout << "  monotonic_no_falling_edge: passed\n";
+}
+
+void test_invalid_thresholds_throw() {
+	std::vector<double> dummy(10, 0.0);
+	std::span<const double> seg{dummy};
+	bool threw_lo = false, threw_hi = false, threw_eq = false;
+	try { (void)rise_time_samples(seg, -0.1, 0.9); }
+	catch (const std::invalid_argument&) { threw_lo = true; }
+	try { (void)rise_time_samples(seg, 0.1, 1.1); }
+	catch (const std::invalid_argument&) { threw_hi = true; }
+	try { (void)rise_time_samples(seg, 0.5, 0.5); }
+	catch (const std::invalid_argument&) { threw_eq = true; }
+	REQUIRE(threw_lo);
+	REQUIRE(threw_hi);
+	REQUIRE(threw_eq);
+	std::cout << "  invalid_thresholds_throw: passed\n";
+}
+
+void test_invalid_sample_rate_throws() {
+	std::vector<double> dummy(10, 0.0);
+	std::span<const double> seg{dummy};
+	bool threw = false;
+	try { (void)frequency_hz(seg, 0.0); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	threw = false;
+	try { (void)frequency_hz(seg, -1.0e6); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  invalid_sample_rate_throws: passed\n";
+}
+
+// ============================================================================
+// Mixed-precision sanity: float input still gives a reasonable measurement
+// ============================================================================
+
+void test_float_input_aggregations() {
+	// Same square wave as the double test but with float samples.
+	// Aggregations run in double internally, so the result should match
+	// the double answer to within float epsilon scaled by N.
+	std::vector<float> sq(100);
+	for (std::size_t n = 0; n < 50; ++n) sq[n] = 2.0f;
+	for (std::size_t n = 50; n < 100; ++n) sq[n] = -1.0f;
+	std::span<const float> seg{sq};
+
+	REQUIRE(approx(peak_to_peak(seg), 3.0, 1e-6));
+	REQUIRE(approx(mean(seg), 0.5, 1e-6));
+	REQUIRE(approx(rms(seg), std::sqrt(2.5), 1e-6));
+	std::cout << "  float_input_aggregations: passed\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_instrument_measurements\n";
+
+		test_square_wave_aggregations();
+		test_sine_aggregations();
+		test_linear_ramp_rise_time();
+		test_linear_ramp_fall_time();
+		test_period_and_frequency_sine();
+
+		test_empty_segment_throws();
+		test_single_sample();
+		test_all_equal_samples();
+		test_monotonic_no_falling_edge();
+		test_invalid_thresholds_throw();
+		test_invalid_sample_rate_throws();
+
+		test_float_input_aggregations();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}

--- a/tests/test_instrument_measurements.cpp
+++ b/tests/test_instrument_measurements.cpp
@@ -96,6 +96,40 @@ void test_linear_ramp_rise_time() {
 	          << " samples, expected 80)\n";
 }
 
+void test_steep_step_rise_time() {
+	// Regression test for a one-sample step that crosses BOTH the 10%
+	// and 90% thresholds within a single sample interval. Previous
+	// `else if` logic skipped the t_hi check on the iteration that set
+	// t_lo, returning NaN. After the fix both crossings are recovered
+	// in the same iteration via linear interpolation.
+	std::vector<double> step = {0.0, 0.0, 1.0, 1.0, 1.0};
+	const double rt = rise_time_samples(std::span<const double>{step});
+	// p2p = 1.0; thr_lo = 0.1, thr_hi = 0.9.
+	// Crossing inside sample [1, 2] (a=0, b=1):
+	//   t_lo at fraction 0.1 -> absolute 1.1
+	//   t_hi at fraction 0.9 -> absolute 1.9
+	// Expected rise time = 0.8 samples.
+	REQUIRE(!std::isnan(rt));
+	REQUIRE(approx(rt, 0.8, 1e-12));
+	std::cout << "  steep_step_rise_time: passed (rise_time=" << rt
+	          << " samples within one sample step, expected 0.8)\n";
+}
+
+void test_steep_step_fall_time() {
+	// Mirror of the rise-time steep-step test.
+	std::vector<double> step = {1.0, 1.0, 0.0, 0.0, 0.0};
+	const double ft = fall_time_samples(std::span<const double>{step});
+	// p2p = 1.0; thr_hi = 0.9, thr_lo = 0.1.
+	// Crossing inside sample [1, 2] (a=1, b=0):
+	//   t_hi at fraction 0.1 (signal hits 0.9 going down) -> absolute 1.1
+	//   t_lo at fraction 0.9 (signal hits 0.1 going down) -> absolute 1.9
+	// Expected fall time = 0.8 samples.
+	REQUIRE(!std::isnan(ft));
+	REQUIRE(approx(ft, 0.8, 1e-12));
+	std::cout << "  steep_step_fall_time: passed (fall_time=" << ft
+	          << " samples within one sample step, expected 0.8)\n";
+}
+
 void test_linear_ramp_fall_time() {
 	// Ramp from 1 down to 0 over 100 samples.
 	// 90% threshold crossed at sample 10, 10% threshold at sample 90.
@@ -264,6 +298,8 @@ int main() {
 		test_sine_aggregations();
 		test_linear_ramp_rise_time();
 		test_linear_ramp_fall_time();
+		test_steep_step_rise_time();
+		test_steep_step_fall_time();
 		test_period_and_frequency_sine();
 
 		test_empty_segment_throws();

--- a/tests/test_instrument_measurements.cpp
+++ b/tests/test_instrument_measurements.cpp
@@ -192,16 +192,30 @@ void test_monotonic_no_falling_edge() {
 void test_invalid_thresholds_throw() {
 	std::vector<double> dummy(10, 0.0);
 	std::span<const double> seg{dummy};
-	bool threw_lo = false, threw_hi = false, threw_eq = false;
+
+	// Rise-time validation
+	bool rise_lo = false, rise_hi = false, rise_eq = false;
 	try { (void)rise_time_samples(seg, -0.1, 0.9); }
-	catch (const std::invalid_argument&) { threw_lo = true; }
+	catch (const std::invalid_argument&) { rise_lo = true; }
 	try { (void)rise_time_samples(seg, 0.1, 1.1); }
-	catch (const std::invalid_argument&) { threw_hi = true; }
+	catch (const std::invalid_argument&) { rise_hi = true; }
 	try { (void)rise_time_samples(seg, 0.5, 0.5); }
-	catch (const std::invalid_argument&) { threw_eq = true; }
-	REQUIRE(threw_lo);
-	REQUIRE(threw_hi);
-	REQUIRE(threw_eq);
+	catch (const std::invalid_argument&) { rise_eq = true; }
+	REQUIRE(rise_lo);
+	REQUIRE(rise_hi);
+	REQUIRE(rise_eq);
+
+	// Fall-time validation: same contract, must throw on the same inputs.
+	bool fall_lo = false, fall_hi = false, fall_eq = false;
+	try { (void)fall_time_samples(seg, -0.1, 0.9); }
+	catch (const std::invalid_argument&) { fall_lo = true; }
+	try { (void)fall_time_samples(seg, 0.1, 1.1); }
+	catch (const std::invalid_argument&) { fall_hi = true; }
+	try { (void)fall_time_samples(seg, 0.5, 0.5); }
+	catch (const std::invalid_argument&) { fall_eq = true; }
+	REQUIRE(fall_lo);
+	REQUIRE(fall_hi);
+	REQUIRE(fall_eq);
 	std::cout << "  invalid_thresholds_throw: passed\n";
 }
 


### PR DESCRIPTION
## Summary
- Adds seven free functions in `sw::dsp::instrument` that compute the standard scope-style readouts on a captured `std::span`: `peak_to_peak`, `mean`, `rms`, `rise_time_samples`, `fall_time_samples`, `period_samples`, `frequency_hz`.
- All aggregations run in `double` internally regardless of `SampleScalar`, so narrow streaming types (float, posit, cfloat) don't lose accuracy on long captures. Matches the precision contract used by the analysis subsystem.
- This is the last substantive primitive blocking #152 (`scope_demo` capstone).

## Design notes
- **Concepts**: `DspScalar + ConvertibleToDouble` for `mean`/`rms`; `DspOrderedField + ConvertibleToDouble` for the rest (need ordering for thresholds + min/max).
- **Edge-case convention**: empty segment throws `std::invalid_argument` (consistent with `FractionalDelay`/`ChannelAligner`); "no measurable transition" returns NaN so a caller computing all seven on one segment doesn't have one undefined value abort the others.
- **Sub-sample precision**: rise/fall/period crossings use linear interpolation between the bracketing samples — the 50 kHz / 1 MHz Fs test recovers the period to within 1e-6 samples.

## Changes
- `include/sw/dsp/instrument/measurements.hpp` — implementation (~250 lines).
- `tests/test_instrument_measurements.cpp` — 12 sub-tests covering known-answer signals and edge cases (~250 lines).
- `tests/CMakeLists.txt` — registry entry under `Tests/Instrument`.
- `tests/README.md` — Instrument tree entry.

## Test results
| Target                         | gcc build | gcc test | clang build | clang test |
|--------------------------------|-----------|----------|-------------|------------|
| test_instrument_measurements   | OK        | PASS     | OK          | PASS       |
| Full ctest (40 tests)          | OK        | PASS     | OK          | PASS       |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #151

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added waveform measurement tools: peak-to-peak, mean, RMS, rise/fall times, period detection, and frequency calculation.

* **Behavior**
  * Aggregation functions throw on empty input; timing/period measures return NaN when transitions or periods are not measurable; threshold and sample-rate parameters are validated.

* **Tests**
  * Added comprehensive tests for accuracy, interpolation, edge cases, and error handling.

* **Documentation**
  * Updated test README to list the new measurement tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->