### PR TITLE
feat(scope): scope_demo capstone application

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -47,5 +47,8 @@ add_subdirectory(fft_tradeoff)
 # Acquisition pipeline demo (Issue #93)
 add_subdirectory(acquisition_demo)
 
+# Scope demonstrator (Issue #152) — capstone for #133
+add_subdirectory(scope_demo)
+
 # Phase 8: Signal conditioning (placeholder, not yet implemented)
 # add_subdirectory(conditioning_demo)

--- a/applications/README.md
+++ b/applications/README.md
@@ -23,6 +23,8 @@ Applications/
 │   └── fft_tradeoff            FFT precision/length trade-off analysis
 ├── SDR/                        Software-defined radio receiver demos
 │   └── acquisition_demo        End-to-end SDR pipeline (capstone for #84)
+├── Instrument/                 Digital-oscilloscope / spectrum-analyzer demos
+│   └── scope_demo              End-to-end scope pipeline (capstone for #133)
 ├── Estimation/
 │   ├── ekf_bearing_range       Extended Kalman filter
 │   └── ukf_tracking            Unscented Kalman filter

--- a/applications/scope_demo/CMakeLists.txt
+++ b/applications/scope_demo/CMakeLists.txt
@@ -1,0 +1,1 @@
+dsp_add_application(scope_demo "Applications/Instrument")

--- a/applications/scope_demo/scope_demo.cpp
+++ b/applications/scope_demo/scope_demo.cpp
@@ -2,45 +2,65 @@
 //
 // Synthesizes a realistic test waveform — 50 MHz square wave with a 5 ns
 // narrow positive glitch buried in it plus low-level AWGN — and runs it
-// through the full scope DSP pipeline at multiple precisions:
+// through the full scope DSP pipeline:
 //
 //   simulate_adc(N_bits, sample_rate)
 //        |
 //        v
-//   EdgeTrigger + AutoTriggerWrapper       (instrument/trigger.hpp)
+//   EqualizerFilter<EqCoeff,EqState,EqSample>   (instrument/calibration.hpp)
+//        |   <-- the precision-sensitive stage
+//        v
+//   EdgeTrigger + AutoTriggerWrapper            (instrument/trigger.hpp)
 //        |
 //        v
-//   TriggerRingBuffer (pre/post capture)   (instrument/ring_buffer.hpp)
+//   TriggerRingBuffer (pre/post capture)        (instrument/ring_buffer.hpp)
 //        |
 //        v
-//   PeakDetectDecimator                    (instrument/peak_detect.hpp)
+//   PeakDetectDecimator                         (instrument/peak_detect.hpp)
 //        |
 //        v
-//   render_envelope (-> N pixels)          (instrument/display_envelope.hpp)
+//   render_envelope (-> N pixels)               (instrument/display_envelope.hpp)
 //        |
 //        v
-//   measurements (rise time, RMS, ...)     (instrument/measurements.hpp)
+//   measurements (rise time, RMS, ...)          (instrument/measurements.hpp)
 //        |
 //        v
 //   scope_demo.csv + console summary
 //
-// Capstone for the Digital Oscilloscope Demonstrator epic (#133). The
-// six-config sweep (uniform_double, uniform_float, uniform_posit32,
-// uniform_posit16, uniform_cfloat32, uniform_fixpnt) lets the user see
-// how each pipeline stage's quality varies with the streaming arithmetic.
+// Mixed-precision design (the WHOLE point of this demo):
 //
-// The headline acceptance is glitch survival: does the 5 ns positive
-// glitch's peak amplitude appear in the display-rate output trace at the
-// expected location? Numbers narrow enough to quantize the glitch below
-// the surrounding noise floor will fail this — that's the lesson.
+//   The trigger -> ring -> peak-detect -> envelope chain is comparison-
+//   only and copy-only — every operation preserves bit-exact ordering
+//   regardless of the storage type. Storage precision is therefore a
+//   memory-bandwidth knob: pick the narrowest type that doesn't lose
+//   information from the ADC.
+//
+//   The EqualizerFilter is the one place where the streaming path does
+//   actual arithmetic (FIR multiply-accumulate). That's where precision
+//   matters: narrowing the equalizer's coefficient/state/sample types
+//   trades streaming-arithmetic accuracy for energy and bits.
+//
+//   Measurements always run in double internally regardless of input
+//   type — they're the analytical reporting layer, not part of the
+//   streaming arithmetic.
+//
+// A "precision plan" is the per-stage tuple of types — NOT a single
+// "uniform_T" choice. Each row of the sweep table picks each stage's
+// precision independently. SNR is measured against the all-double
+// reference plan, so a row with a narrow equalizer shows real SNR
+// degradation while one with a narrow storage type but a high-precision
+// equalizer shows none.
 //
 // Per-stage timing instrumentation produces a 10 GSPS comparison
 // (informational): real 10 GSPS scopes use ASIC pipelines, not general-
 // purpose CPUs. The number reported here is for understanding the gap.
 //
+// Capstone for the Digital Oscilloscope Demonstrator epic (#133).
+//
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <sw/dsp/instrument/calibration.hpp>
 #include <sw/dsp/instrument/trigger.hpp>
 #include <sw/dsp/instrument/ring_buffer.hpp>
 #include <sw/dsp/instrument/peak_detect.hpp>
@@ -70,16 +90,16 @@ using namespace sw::dsp::instrument;
 namespace chrono = std::chrono;
 
 // ============================================================================
-// Type aliases for the sweep
+// Type aliases used in the precision plans
 // ============================================================================
 
 using p32  = sw::universal::posit<32, 2>;
 using p16  = sw::universal::posit<16, 2>;
-using cf32 = sw::universal::cfloat<32, 8, std::uint32_t, true, false, false>;
-// Q2.30: 2 integer bits (signal amplitude is +-0.5, leaves 4x headroom)
-// and 30 fractional bits (~30 ENOB ceiling). fixpnt<32,28> would be Q4.28
-// — more integer headroom than this signal needs, fewer fractional bits.
-using fx32 = sw::universal::fixpnt<32, 30>;
+// Q4.12 (16 bits): 4 integer bits give the equalizer some headroom for
+// transient overshoots, 12 fractional bits match the ADC's 12-bit output.
+// "ADC-native" storage — narrowing storage to this size cuts ring-buffer
+// memory bandwidth 4x vs double without dropping any ADC information.
+using fx16_storage = sw::universal::fixpnt<16, 12>;
 
 // ============================================================================
 // Pipeline parameters
@@ -127,6 +147,9 @@ struct PipelineParams {
 
 	// Stream length
 	std::size_t num_samples      = 1024 * 8;
+
+	// Equalizer (calibration / front-end correction).
+	std::size_t eq_taps          = 31;      // FIR length
 };
 inline PipelineParams params;
 
@@ -178,10 +201,39 @@ std::vector<double> simulate_adc(unsigned seed = 0xACDC) {
 }
 
 // ============================================================================
+// Synthetic analog-front-end calibration profile.
+//
+// Models a mild scope front-end with shallow rolloff: -0.5 dB at 50 MHz,
+// -2 dB at 100 MHz, leveling off into the upper band. The equalizer
+// inverts this profile to flatten the band of interest.
+//
+// We deliberately keep the corrections small (max ~+2 dB) because in
+// this demo the input is the *clean* signal (not a pre-distorted one),
+// so the equalizer's job is to apply a small, mostly-flat correction.
+// A more aggressive profile (e.g., -10 dB at Nyquist) would make the
+// equalizer try to boost +10 dB at Nyquist, ringing on sharp edges
+// and reshaping the square wave beyond what the analytical
+// measurements can handle. That's a real tradeoff scope designers
+// face — but in this demo we want measurement quality preserved so
+// the precision-impact comparison is the headline, not the
+// equalizer's design tradeoffs.
+// ============================================================================
+
+CalibrationProfile make_test_profile() {
+	std::vector<double> freqs    = {0.0,   50e6, 100e6, 250e6, 500e6};
+	std::vector<double> gains_dB = {0.0,  -0.5,  -2.0,  -3.0,  -3.0};
+	std::vector<double> phases   = {0.0,  -0.10, -0.20, -0.30, -0.30};
+	return CalibrationProfile(std::move(freqs),
+	                           std::move(gains_dB),
+	                           std::move(phases));
+}
+
+// ============================================================================
 // Stage timings for a single pipeline run
 // ============================================================================
 
 struct StageTimingsNs {
+	double equalizer      = 0.0;
 	double trigger_ring   = 0.0;
 	double peak_detect    = 0.0;
 	double envelope       = 0.0;
@@ -194,10 +246,12 @@ struct StageTimingsNs {
 // ============================================================================
 
 struct ConfigResult {
-	std::string config_name;
-	std::string coeff_type;
-	std::string state_type;
-	std::string sample_type;
+	std::string plan_name;          // e.g. "eq_posit16_storage_double"
+	std::string eq_coeff_type;      // calibration FIR coefficient type
+	std::string eq_state_type;      // calibration FIR state type
+	std::string eq_sample_type;     // calibration FIR sample type
+	std::string storage_type;       // trigger/ring/peak-detect/envelope type
+	std::size_t storage_bytes_per_sample = 0;
 
 	// Headline metrics. Numeric fields default to NaN so a config that
 	// fails to capture (no trigger fired in the input window) prints as
@@ -231,43 +285,69 @@ struct ConfigResult {
 };
 
 // ============================================================================
-// run_pipeline<SampleScalar>
+// run_pipeline<EqCoeff, EqState, EqSample, StorageScalar>
 //
-// One scope pipeline run at a single precision config. Returns a
-// ConfigResult with both the headline measurements and the rendered
-// envelope. The trigger/ring/peak-detect/envelope chain is parameterized
-// solely on SampleScalar — these primitives don't take CoeffScalar /
-// StateScalar separately because they don't have filter coefficients.
-// (The spec lists three scalars to keep the type signature uniform with
-// the rest of the library; for scope_demo only Sample matters.)
+// One scope pipeline run with a per-stage precision plan:
+//   - EqualizerFilter<EqCoeff, EqState, EqSample> applies the calibration
+//     correction. EqSample is the input/output type of the equalizer's
+//     streaming arithmetic (FIR multiply-accumulate), so this is the
+//     stage where streaming-arithmetic precision actually shows up.
+//   - Trigger / ring buffer / peak-detect / envelope all run in
+//     StorageScalar — the precision used for memory storage and all the
+//     downstream comparison-only stages.
+//
+// The equalizer's output is cast to StorageScalar at the equalizer ->
+// trigger boundary, modelling a pipeline that re-quantizes after the
+// arithmetic stage to limit downstream storage bandwidth.
 // ============================================================================
 
-template <class SampleScalar>
+template <class EqCoeff, class EqState, class EqSample, class StorageScalar>
 ConfigResult run_pipeline(const std::vector<double>& adc_in_double,
-                          const std::string& config_name) {
+                          const std::string& plan_name,
+                          const std::string& eq_coeff_tag,
+                          const std::string& eq_state_tag,
+                          const std::string& eq_sample_tag,
+                          const std::string& storage_tag,
+                          std::size_t storage_bytes_per_sample,
+                          const CalibrationProfile& profile) {
 	ConfigResult result;
-	result.config_name = config_name;
-	result.coeff_type  = config_name;   // uniform — keep the column for schema
-	result.state_type  = config_name;
-	result.sample_type = config_name;
+	result.plan_name                 = plan_name;
+	result.eq_coeff_type             = eq_coeff_tag;
+	result.eq_state_type             = eq_state_tag;
+	result.eq_sample_type            = eq_sample_tag;
+	result.storage_type              = storage_tag;
+	result.storage_bytes_per_sample  = storage_bytes_per_sample;
 
-	// Project ADC samples into SampleScalar.
-	std::vector<SampleScalar> adc_in(adc_in_double.size());
-	for (std::size_t n = 0; n < adc_in_double.size(); ++n)
-		adc_in[n] = static_cast<SampleScalar>(adc_in_double[n]);
-
-	// Stage 1: trigger + ring buffer in lockstep.
+	// --- Stage 1: equalizer ---
+	// Project ADC samples into EqSample, equalize sample-by-sample, then
+	// cast to StorageScalar at the equalizer -> trigger boundary.
 	auto t0 = chrono::high_resolution_clock::now();
-	EdgeTrigger<SampleScalar> trig(static_cast<SampleScalar>(params.trigger_level),
-	                                Slope::Rising,
-	                                static_cast<SampleScalar>(params.trigger_hyst));
-	AutoTriggerWrapper<EdgeTrigger<SampleScalar>>
+	EqualizerFilter<EqCoeff, EqState, EqSample>
+		eq(profile, params.eq_taps, params.sample_rate_hz);
+
+	std::vector<StorageScalar> adc_in(adc_in_double.size());
+	for (std::size_t n = 0; n < adc_in_double.size(); ++n) {
+		const EqSample in_eq  = static_cast<EqSample>(adc_in_double[n]);
+		const EqSample out_eq = eq.process(in_eq);
+		adc_in[n] = static_cast<StorageScalar>(out_eq);
+	}
+	auto t1 = chrono::high_resolution_clock::now();
+	result.timings.equalizer =
+		chrono::duration<double, std::nano>(t1 - t0).count();
+
+	// --- Stage 2: trigger + ring buffer in lockstep ---
+	t0 = chrono::high_resolution_clock::now();
+	EdgeTrigger<StorageScalar> trig(
+		static_cast<StorageScalar>(params.trigger_level),
+		Slope::Rising,
+		static_cast<StorageScalar>(params.trigger_hyst));
+	AutoTriggerWrapper<EdgeTrigger<StorageScalar>>
 		auto_trig(trig, params.auto_trigger_to);
-	TriggerRingBuffer<SampleScalar> ring(params.pre_trigger, params.post_trigger);
+	TriggerRingBuffer<StorageScalar> ring(params.pre_trigger, params.post_trigger);
 
 	bool triggered = false;
 	for (std::size_t n = 0; n < adc_in.size(); ++n) {
-		const SampleScalar x = adc_in[n];
+		const StorageScalar x = adc_in[n];
 		// Only the FIRST fire goes to push_trigger. Subsequent edges of
 		// the inner trigger are ignored — push_trigger() is a no-op in
 		// Capturing state, and routing the sample there instead of via
@@ -282,70 +362,64 @@ ConfigResult run_pipeline(const std::vector<double>& adc_in_double,
 		}
 		if (ring.capture_complete()) break;
 	}
-	auto t1 = chrono::high_resolution_clock::now();
+	t1 = chrono::high_resolution_clock::now();
 	result.timings.trigger_ring =
 		chrono::duration<double, std::nano>(t1 - t0).count();
 
 	if (!ring.capture_complete()) {
-		// No trigger fired — leave envelope empty and bail. The console
-		// summary will show this as zero glitch survival, NaN rise time.
+		// No trigger fired — leave envelope empty and bail.
 		return result;
 	}
 	auto segment = ring.captured_segment();
 	result.captured_length = segment.size();
 
-	// Stage 2: peak-detect decimation. R=peak_detect_R; R=1 is passthrough.
+	// --- Stage 3: peak-detect decimation ---
 	t0 = chrono::high_resolution_clock::now();
-	PeakDetectDecimator<SampleScalar> pd(params.peak_detect_R);
+	PeakDetectDecimator<StorageScalar> pd(params.peak_detect_R);
 	auto pd_env = pd.process_block(segment);
 	t1 = chrono::high_resolution_clock::now();
 	result.timings.peak_detect =
 		chrono::duration<double, std::nano>(t1 - t0).count();
 
-	// Stage 3: render envelope to pixel_width columns. We render the MAX
-	// stream from peak_detect (the stream that preserves positive glitches).
-	// For a true scope display you'd render both mins and maxs as a vertical
-	// line per pixel; for this demo we focus on the max stream because
-	// that's where the positive glitch shows up.
+	// --- Stage 4: render envelope to pixel_width columns ---
 	t0 = chrono::high_resolution_clock::now();
-	std::span<const SampleScalar> max_span(pd_env.maxs.data(), pd_env.maxs.size());
-	std::span<const SampleScalar> min_span(pd_env.mins.data(), pd_env.mins.size());
-	auto disp_max = render_envelope<SampleScalar>(max_span, params.pixel_width);
-	auto disp_min = render_envelope<SampleScalar>(min_span, params.pixel_width);
+	std::span<const StorageScalar> max_span(pd_env.maxs.data(), pd_env.maxs.size());
+	std::span<const StorageScalar> min_span(pd_env.mins.data(), pd_env.mins.size());
+	auto disp_max = render_envelope<StorageScalar>(max_span, params.pixel_width);
+	auto disp_min = render_envelope<StorageScalar>(min_span, params.pixel_width);
 	t1 = chrono::high_resolution_clock::now();
 	result.timings.envelope =
 		chrono::duration<double, std::nano>(t1 - t0).count();
 
-	// Stage 4: measurements.
+	// --- Stage 5: measurements (always accumulate in double) ---
 	//
-	// rms / mean / glitch-peak read the full segment — the glitch is part
-	// of what the user wants to see in those numbers (RMS is elevated
-	// slightly, glitch peak is the headline).
+	// rms / mean read the full segment — the glitch is part of what the
+	// user wants to see in those numbers.
 	//
-	// rise_time / period / frequency read a glitch-free pre-window. The
-	// glitch's leading edge would otherwise create an extra zero-crossing
-	// (period bias) and push the 90% threshold above the carrier
-	// amplitude (rise time measures from carrier to glitch). The
-	// pre-glitch window contains several clean carrier cycles.
+	// rise_time / period / frequency read a glitch-free pre-window so
+	// the glitch's leading edge doesn't create an extra zero-crossing
+	// (period bias) or push the 90% threshold above the carrier
+	// amplitude (rise time would measure carrier->glitch instead).
 	t0 = chrono::high_resolution_clock::now();
-	result.rms = rms<SampleScalar>(segment);
-	result.mean = mean<SampleScalar>(segment);
+	result.rms = rms<StorageScalar>(segment);
+	result.mean = mean<StorageScalar>(segment);
 	const std::size_t mw_len =
 		std::min(segment.size(), params.pre_glitch_window);
 	auto measurement_window = segment.subspan(0, mw_len);
 	result.rise_time_samples =
-		rise_time_samples<SampleScalar>(measurement_window, 0.1, 0.9);
+		rise_time_samples<StorageScalar>(measurement_window, 0.1, 0.9);
 	result.period_samples =
-		period_samples<SampleScalar>(measurement_window,
-		                              static_cast<SampleScalar>(0));
+		period_samples<StorageScalar>(measurement_window,
+		                               static_cast<StorageScalar>(0));
 	result.frequency_hz =
-		frequency_hz<SampleScalar>(measurement_window, params.sample_rate_hz,
-		                            static_cast<SampleScalar>(0));
+		frequency_hz<StorageScalar>(measurement_window, params.sample_rate_hz,
+		                             static_cast<StorageScalar>(0));
 	t1 = chrono::high_resolution_clock::now();
 	result.timings.measurements =
 		chrono::duration<double, std::nano>(t1 - t0).count();
 
-	result.timings.total = result.timings.trigger_ring
+	result.timings.total = result.timings.equalizer
+	                     + result.timings.trigger_ring
 	                     + result.timings.peak_detect
 	                     + result.timings.envelope
 	                     + result.timings.measurements;
@@ -408,19 +482,23 @@ void write_csv(const std::string& path,
 		std::cerr << "warn: could not open '" << path << "' for write\n";
 		return;
 	}
-	// Schema: pipeline,config_name,coeff_type,state_type,sample_type,
+	// Schema: pipeline,plan_name,eq_coeff,eq_state,eq_sample,storage,
+	//         storage_bytes_per_sample,
 	//         pixel_index,envelope_min,envelope_max,
 	//         glitch_survived,glitch_peak,rise_time,rms,mean,output_snr_db
-	out << "pipeline,config_name,coeff_type,state_type,sample_type,"
+	out << "pipeline,plan_name,eq_coeff,eq_state,eq_sample,storage,"
+	       "storage_bytes_per_sample,"
 	       "pixel_index,envelope_min,envelope_max,"
 	       "glitch_survived,glitch_peak,rise_time_samples,rms,mean,output_snr_db\n";
 	for (const auto& r : results) {
 		for (std::size_t i = 0; i < r.envelope_max.size(); ++i) {
 			out << "scope_demo,"
-			    << r.config_name << ','
-			    << r.coeff_type  << ','
-			    << r.state_type  << ','
-			    << r.sample_type << ','
+			    << r.plan_name        << ','
+			    << r.eq_coeff_type    << ','
+			    << r.eq_state_type    << ','
+			    << r.eq_sample_type   << ','
+			    << r.storage_type     << ','
+			    << r.storage_bytes_per_sample << ','
 			    << i << ','
 			    << r.envelope_min[i] << ','
 			    << r.envelope_max[i] << ','
@@ -441,33 +519,37 @@ void write_csv(const std::string& path,
 
 void print_summary_header() {
 	std::cout << "\n=== Mixed-precision scope sweep ===\n";
-	std::cout << std::left  << std::setw(18) << "config"
-	          << std::right << std::setw(10) << "glitch?"
-	          << std::right << std::setw(12) << "peak"
-	          << std::right << std::setw(12) << "rise(samp)"
-	          << std::right << std::setw(10) << "rms"
-	          << std::right << std::setw(12) << "freq(MHz)"
-	          << std::right << std::setw(12) << "SNR(dB)"
+	std::cout << std::left  << std::setw(34) << "plan (EQ x storage)"
+	          << std::right << std::setw(8)  << "B/samp"
+	          << std::right << std::setw(8)  << "glitch?"
+	          << std::right << std::setw(10) << "peak"
+	          << std::right << std::setw(10) << "rise"
+	          << std::right << std::setw(11) << "freq(MHz)"
+	          << std::right << std::setw(10) << "SNR(dB)"
 	          << "\n";
-	std::cout << std::string(18 + 10 + 12 + 12 + 10 + 12 + 12, '-') << "\n";
+	std::cout << std::string(34 + 8 + 8 + 10 + 10 + 11 + 10, '-') << "\n";
 }
 
 void print_summary_row(const ConfigResult& r) {
-	std::cout << std::left  << std::setw(18) << r.config_name
-	          << std::right << std::setw(10) << (r.glitch_survived ? "PASS" : "fail")
-	          << std::right << std::setw(12) << std::fixed;
+	// Compose a "plan_name (eq_sample x storage)" label so the row
+	// shows what was narrowed and what wasn't, not just an opaque tag.
+	std::string label = r.plan_name + " ("
+	                  + r.eq_sample_type + " x " + r.storage_type + ")";
+	if (label.size() > 33) label = label.substr(0, 33);
+	std::cout << std::left  << std::setw(34) << label
+	          << std::right << std::setw(8)  << r.storage_bytes_per_sample
+	          << std::right << std::setw(8)  << (r.glitch_survived ? "PASS" : "fail")
+	          << std::right << std::setw(10) << std::fixed;
 	auto print_or_nan = [](double v, int prec, double scale = 1.0) {
 		if (std::isnan(v)) std::cout << "NaN";
 		else std::cout << std::setprecision(prec) << (v * scale);
 	};
 	print_or_nan(r.glitch_peak_observed, 3);
-	std::cout << std::right << std::setw(12);
-	print_or_nan(r.rise_time_samples, 2);
 	std::cout << std::right << std::setw(10);
-	print_or_nan(r.rms, 3);
-	std::cout << std::right << std::setw(12);
+	print_or_nan(r.rise_time_samples, 2);
+	std::cout << std::right << std::setw(11);
 	print_or_nan(r.frequency_hz, 3, 1.0 / 1e6);
-	std::cout << std::right << std::setw(12);
+	std::cout << std::right << std::setw(10);
 	print_or_nan(r.output_snr_db, 2);
 	std::cout << "\n";
 }
@@ -492,6 +574,7 @@ void print_timing_report(const ConfigResult& reference) {
 		          << ns_per_sample << " ns/sample"
 		          << "\n";
 	};
+	print("equalizer",      reference.timings.equalizer);
 	print("trigger+ring",   reference.timings.trigger_ring);
 	print("peak_detect",    reference.timings.peak_detect);
 	print("render_envelope",reference.timings.envelope);
@@ -533,37 +616,80 @@ int main(int argc, char** argv) try {
 	}
 
 	std::cout << "scope_demo: digital-oscilloscope mixed-precision sweep\n"
-	          << "  signal:  50 MHz square wave +- " << params.signal_amp
+	          << "  signal:    50 MHz square wave +- " << params.signal_amp
 	          << " (5 ns +" << params.glitch_peak << " glitch at "
 	          << params.glitch_offset_s * 1e9 << " ns)\n"
-	          << "  ADC:     " << params.adc_bits << "-bit, "
+	          << "  ADC:       " << params.adc_bits << "-bit, "
 	          << params.sample_rate_hz / 1e9 << " GSPS, "
 	          << params.num_samples << " samples\n"
-	          << "  capture: " << params.pre_trigger << " pre + 1 trigger + "
+	          << "  capture:   " << params.pre_trigger << " pre + 1 trigger + "
 	          << params.post_trigger << " post\n"
-	          << "  display: peak-detect R=" << params.peak_detect_R
-	          << ", " << params.pixel_width << " pixels\n";
+	          << "  display:   peak-detect R=" << params.peak_detect_R
+	          << ", " << params.pixel_width << " pixels\n"
+	          << "  equalizer: " << params.eq_taps
+	          << "-tap FIR, calibration profile -3 dB at 100 MHz\n";
 
-	// Compute analytical rise time for the carrier transition: a square
-	// wave's rising edge is one sample wide at 1 GSPS / 50 MHz (it goes
-	// from -amp to +amp in one sample), so the 10/90 rise time is 0.8
-	// samples (80% of one sample step). The pipeline's rise time should
-	// recover this within roughly half a sample.
 	const double expected_rise_samples = 0.8;
+	const auto profile = make_test_profile();
+	const auto adc     = simulate_adc();
 
-	const auto adc = simulate_adc();
+	// =========================================================================
+	// Precision plans
+	//
+	// Each plan picks types per stage:
+	//   - (EqCoeff, EqState, EqSample): the calibration FIR's three scalars.
+	//     This stage does the only streaming arithmetic in the pipeline, so
+	//     its precision dominates the SNR measurement.
+	//   - StorageScalar: trigger / ring buffer / peak-detect / envelope.
+	//     These are comparison-only and copy-only stages — narrowing this
+	//     trades memory bandwidth for nothing in measurement quality.
+	//
+	// Plan 0 is the all-double reference. Subsequent plans tighten one
+	// dimension or the other to expose the per-stage precision trade.
+	// =========================================================================
+	std::array<ConfigResult, 5> results{{
+		// reference: all double everywhere — the SNR baseline.
+		run_pipeline<double, double, double, double>(
+			adc, "reference",
+			"double", "double", "double", "double",
+			sizeof(double), profile),
 
-	// Run the six configurations.
-	std::array<ConfigResult, 6> results{{
-		run_pipeline<double>(adc, "uniform_double"),
-		run_pipeline<float>(adc,  "uniform_float"),
-		run_pipeline<p32>(adc,    "uniform_posit32"),
-		run_pipeline<p16>(adc,    "uniform_posit16"),
-		run_pipeline<cf32>(adc,   "uniform_cfloat32"),
-		run_pipeline<fx32>(adc,   "uniform_fixpnt"),
+		// High-precision EQ + ADC-native fixpnt storage. The equalizer
+		// runs in double so its arithmetic doesn't add error; the
+		// downstream comparison-only chain runs in 16-bit fixpnt to
+		// quantify the memory savings (4x reduction vs double).
+		// Expected: SNR ~ reference, storage cost halved-or-better.
+		run_pipeline<double, double, double, fx16_storage>(
+			adc, "eq_double_storage_fx16",
+			"double", "double", "double", "fixpnt<16,12>",
+			sizeof(fx16_storage), profile),
+
+		// Narrow EQ in posit32 + double storage. Isolates the cost of
+		// narrowing only the streaming arithmetic — should show a small
+		// SNR drop relative to reference.
+		run_pipeline<p32, p32, p32, double>(
+			adc, "eq_posit32_storage_double",
+			"posit<32,2>", "posit<32,2>", "posit<32,2>", "double",
+			sizeof(double), profile),
+
+		// Narrow EQ in posit16 + double storage. The headline mixed-
+		// precision case: 16-bit streaming arithmetic should produce
+		// visible SNR degradation (~30-40 dB lower than reference).
+		run_pipeline<p16, p16, p16, double>(
+			adc, "eq_posit16_storage_double",
+			"posit<16,2>", "posit<16,2>", "posit<16,2>", "double",
+			sizeof(double), profile),
+
+		// FPGA-pragmatic mix: float EQ (fast on most hardware, smaller
+		// than double) + ADC-native fixpnt storage (memory-optimal).
+		// Expected: small SNR loss + 4x storage saving.
+		run_pipeline<float, float, float, fx16_storage>(
+			adc, "eq_float_storage_fx16",
+			"float", "float", "float", "fixpnt<16,12>",
+			sizeof(fx16_storage), profile),
 	}};
 
-	// SNR vs uniform_double reference (results[0]).
+	// SNR vs the reference plan (results[0]).
 	for (auto& r : results) {
 		r.rise_time_expected = expected_rise_samples;
 		r.output_snr_db = snr_db_against_reference(r, results[0]);

--- a/applications/scope_demo/scope_demo.cpp
+++ b/applications/scope_demo/scope_demo.cpp
@@ -60,6 +60,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <random>
 #include <span>
 #include <string>
@@ -198,16 +199,27 @@ struct ConfigResult {
 	std::string state_type;
 	std::string sample_type;
 
-	// Headline metrics
-	bool        glitch_survived = false;
-	double      glitch_peak_observed = 0.0;
-	double      rise_time_samples    = 0.0;
-	double      rise_time_expected   = 0.0;
-	double      rms                  = 0.0;
-	double      mean                 = 0.0;
-	double      period_samples       = 0.0;
-	double      frequency_hz         = 0.0;
-	double      output_snr_db        = 0.0;   // vs uniform_double reference
+	// Headline metrics. Numeric fields default to NaN so a config that
+	// fails to capture (no trigger fired in the input window) prints as
+	// "not available" rather than as a column of zeros that look like
+	// legitimate measurements.
+	bool        glitch_survived      = false;
+	double      glitch_peak_observed =
+		std::numeric_limits<double>::quiet_NaN();
+	double      rise_time_samples    =
+		std::numeric_limits<double>::quiet_NaN();
+	double      rise_time_expected   =
+		std::numeric_limits<double>::quiet_NaN();
+	double      rms                  =
+		std::numeric_limits<double>::quiet_NaN();
+	double      mean                 =
+		std::numeric_limits<double>::quiet_NaN();
+	double      period_samples       =
+		std::numeric_limits<double>::quiet_NaN();
+	double      frequency_hz         =
+		std::numeric_limits<double>::quiet_NaN();
+	double      output_snr_db        =
+		std::numeric_limits<double>::quiet_NaN();
 	std::size_t captured_length      = 0;
 
 	StageTimingsNs timings;
@@ -390,7 +402,7 @@ double snr_db_against_reference(const ConfigResult& test,
 // ============================================================================
 
 void write_csv(const std::string& path,
-               const std::vector<ConfigResult>& results) {
+               std::span<const ConfigResult> results) {
 	std::ofstream out(path);
 	if (!out) {
 		std::cerr << "warn: could not open '" << path << "' for write\n";
@@ -443,17 +455,21 @@ void print_summary_header() {
 void print_summary_row(const ConfigResult& r) {
 	std::cout << std::left  << std::setw(18) << r.config_name
 	          << std::right << std::setw(10) << (r.glitch_survived ? "PASS" : "fail")
-	          << std::right << std::setw(12) << std::fixed
-	          << std::setprecision(3) << r.glitch_peak_observed
-	          << std::right << std::setw(12);
-	if (std::isnan(r.rise_time_samples)) std::cout << "NaN";
-	else std::cout << std::setprecision(2) << r.rise_time_samples;
-	std::cout << std::right << std::setw(10) << std::setprecision(3) << r.rms
-	          << std::right << std::setw(12);
-	if (std::isnan(r.frequency_hz)) std::cout << "NaN";
-	else std::cout << std::setprecision(3) << r.frequency_hz / 1e6;
-	std::cout << std::right << std::setw(12) << std::setprecision(2) << r.output_snr_db
-	          << "\n";
+	          << std::right << std::setw(12) << std::fixed;
+	auto print_or_nan = [](double v, int prec, double scale = 1.0) {
+		if (std::isnan(v)) std::cout << "NaN";
+		else std::cout << std::setprecision(prec) << (v * scale);
+	};
+	print_or_nan(r.glitch_peak_observed, 3);
+	std::cout << std::right << std::setw(12);
+	print_or_nan(r.rise_time_samples, 2);
+	std::cout << std::right << std::setw(10);
+	print_or_nan(r.rms, 3);
+	std::cout << std::right << std::setw(12);
+	print_or_nan(r.frequency_hz, 3, 1.0 / 1e6);
+	std::cout << std::right << std::setw(12);
+	print_or_nan(r.output_snr_db, 2);
+	std::cout << "\n";
 }
 
 // ============================================================================
@@ -538,13 +554,14 @@ int main(int argc, char** argv) try {
 	const auto adc = simulate_adc();
 
 	// Run the six configurations.
-	std::vector<ConfigResult> results;
-	results.push_back(run_pipeline<double>(adc, "uniform_double"));
-	results.push_back(run_pipeline<float>(adc,  "uniform_float"));
-	results.push_back(run_pipeline<p32>(adc,    "uniform_posit32"));
-	results.push_back(run_pipeline<p16>(adc,    "uniform_posit16"));
-	results.push_back(run_pipeline<cf32>(adc,   "uniform_cfloat32"));
-	results.push_back(run_pipeline<fx32>(adc,   "uniform_fixpnt"));
+	std::array<ConfigResult, 6> results{{
+		run_pipeline<double>(adc, "uniform_double"),
+		run_pipeline<float>(adc,  "uniform_float"),
+		run_pipeline<p32>(adc,    "uniform_posit32"),
+		run_pipeline<p16>(adc,    "uniform_posit16"),
+		run_pipeline<cf32>(adc,   "uniform_cfloat32"),
+		run_pipeline<fx32>(adc,   "uniform_fixpnt"),
+	}};
 
 	// SNR vs uniform_double reference (results[0]).
 	for (auto& r : results) {

--- a/applications/scope_demo/scope_demo.cpp
+++ b/applications/scope_demo/scope_demo.cpp
@@ -1,0 +1,567 @@
+// scope_demo.cpp: end-to-end digital-oscilloscope mixed-precision sweep.
+//
+// Synthesizes a realistic test waveform — 50 MHz square wave with a 5 ns
+// narrow positive glitch buried in it plus low-level AWGN — and runs it
+// through the full scope DSP pipeline at multiple precisions:
+//
+//   simulate_adc(N_bits, sample_rate)
+//        |
+//        v
+//   EdgeTrigger + AutoTriggerWrapper       (instrument/trigger.hpp)
+//        |
+//        v
+//   TriggerRingBuffer (pre/post capture)   (instrument/ring_buffer.hpp)
+//        |
+//        v
+//   PeakDetectDecimator                    (instrument/peak_detect.hpp)
+//        |
+//        v
+//   render_envelope (-> N pixels)          (instrument/display_envelope.hpp)
+//        |
+//        v
+//   measurements (rise time, RMS, ...)     (instrument/measurements.hpp)
+//        |
+//        v
+//   scope_demo.csv + console summary
+//
+// Capstone for the Digital Oscilloscope Demonstrator epic (#133). The
+// six-config sweep (uniform_double, uniform_float, uniform_posit32,
+// uniform_posit16, uniform_cfloat32, uniform_fixpnt) lets the user see
+// how each pipeline stage's quality varies with the streaming arithmetic.
+//
+// The headline acceptance is glitch survival: does the 5 ns positive
+// glitch's peak amplitude appear in the display-rate output trace at the
+// expected location? Numbers narrow enough to quantize the glitch below
+// the surrounding noise floor will fail this — that's the lesson.
+//
+// Per-stage timing instrumentation produces a 10 GSPS comparison
+// (informational): real 10 GSPS scopes use ASIC pipelines, not general-
+// purpose CPUs. The number reported here is for understanding the gap.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/instrument/trigger.hpp>
+#include <sw/dsp/instrument/ring_buffer.hpp>
+#include <sw/dsp/instrument/peak_detect.hpp>
+#include <sw/dsp/instrument/display_envelope.hpp>
+#include <sw/dsp/instrument/measurements.hpp>
+
+#include <sw/universal/number/posit/posit.hpp>
+#include <sw/universal/number/cfloat/cfloat.hpp>
+#include <sw/universal/number/fixpnt/fixpnt.hpp>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <span>
+#include <string>
+#include <vector>
+
+using namespace sw::dsp::instrument;
+namespace chrono = std::chrono;
+
+// ============================================================================
+// Type aliases for the sweep
+// ============================================================================
+
+using p32  = sw::universal::posit<32, 2>;
+using p16  = sw::universal::posit<16, 2>;
+using cf32 = sw::universal::cfloat<32, 8, std::uint32_t, true, false, false>;
+// Q2.30: 2 integer bits (signal amplitude is +-0.5, leaves 4x headroom)
+// and 30 fractional bits (~30 ENOB ceiling). fixpnt<32,28> would be Q4.28
+// — more integer headroom than this signal needs, fewer fractional bits.
+using fx32 = sw::universal::fixpnt<32, 30>;
+
+// ============================================================================
+// Pipeline parameters
+// ============================================================================
+
+struct PipelineParams {
+	// Signal: 50 MHz square wave, +-0.5 amplitude (well inside posit16 sweet
+	// spot). Low-level AWGN keeps the trigger reliable but doesn't dominate.
+	double      sample_rate_hz = 1e9;       // 1 GSPS sim (10 GSPS is the perf
+	                                        // target, not the actual rate)
+	double      signal_freq_hz = 50e6;      // 50 MHz square wave
+	double      signal_amp     = 0.5;
+	double      noise_rms      = 0.005;
+	int         adc_bits       = 12;        // 12-bit ADC
+
+	// Glitch: a 5 ns positive overshoot that overrides the carrier (a
+	// scope probe getting hit by an EMI pulse). The amplitude is the
+	// absolute glitch peak, not an addition — so the glitch is well-
+	// defined regardless of what the carrier was doing underneath.
+	//
+	// Placed at 500 ns into the stream so it lands AFTER the analytical
+	// measurement window (rise_time / frequency are computed on the
+	// pre-glitch region; the full segment is used for envelope and
+	// peak_to_peak).
+	double      glitch_peak       = 0.95;   // absolute glitch peak amplitude
+	                                        // (must be < 1.0 so the 12-bit
+	                                        // ADC's [-1, +1) range doesn't
+	                                        // clamp it)
+	double      glitch_width_s    = 5e-9;   // 5 ns wide
+	double      glitch_offset_s   = 5e-7;   // 500 ns into the stream
+	std::size_t pre_glitch_window = 400;    // samples used for rise_time /
+	                                        // period / frequency. Must end
+	                                        // before glitch_offset_s.
+
+	// Capture
+	std::size_t pre_trigger      = 256;
+	std::size_t post_trigger     = 768;
+	double      trigger_level    = 0.0;
+	double      trigger_hyst     = 0.05;    // suppress noise re-triggers
+	std::size_t auto_trigger_to  = 4000;    // force-fire if no edge
+
+	// Display reduction
+	std::size_t peak_detect_R    = 2;       // first decimation
+	std::size_t pixel_width      = 200;     // final display columns
+
+	// Stream length
+	std::size_t num_samples      = 1024 * 8;
+};
+inline PipelineParams params;
+
+// ============================================================================
+// ADC simulation: 50 MHz square wave + narrow positive glitch + AWGN, then
+// quantized to N bits.
+// ============================================================================
+
+std::vector<double> simulate_adc(unsigned seed = 0xACDC) {
+	std::vector<double> samples(params.num_samples);
+	std::mt19937 rng(seed);
+	std::normal_distribution<double> noise(0.0, params.noise_rms);
+
+	const double half_levels = std::ldexp(1.0, params.adc_bits - 1);
+	const double q_step      = 1.0 / half_levels;
+	const double code_max    = half_levels - 1.0;
+	const double code_min    = -half_levels;
+
+	const double dt          = 1.0 / params.sample_rate_hz;
+	const double glitch_t0   = params.glitch_offset_s;
+	const double glitch_t1   = glitch_t0 + params.glitch_width_s;
+
+	// Integer-phase square wave: avoid `sin(2*pi*f*t) >= 0`, which is
+	// numerically unstable at sample boundaries where sin(k*pi) returns
+	// tiny FP-noise values that flip sign unpredictably (e.g., sin(6*pi)
+	// on x86 came out positive on this build, shortening one low half-
+	// cycle by a sample and biasing period measurements).
+	const std::size_t half_period_samples =
+		static_cast<std::size_t>(std::round(
+			0.5 * params.sample_rate_hz / params.signal_freq_hz));
+	const std::size_t cycle_samples = 2 * half_period_samples;
+
+	for (std::size_t n = 0; n < params.num_samples; ++n) {
+		const double t = static_cast<double>(n) * dt;
+		const std::size_t phase_n = n % cycle_samples;
+		const double sq = (phase_n < half_period_samples)
+		                   ? params.signal_amp : -params.signal_amp;
+		// Glitch overrides the carrier during its window (well-defined peak
+		// regardless of carrier state at glitch time).
+		const double clean = (t >= glitch_t0 && t < glitch_t1)
+		                      ? params.glitch_peak : sq;
+		const double noisy = clean + noise(rng);
+
+		double code = std::floor(noisy / q_step);
+		code = std::clamp(code, code_min, code_max);
+		samples[n] = code * q_step;
+	}
+	return samples;
+}
+
+// ============================================================================
+// Stage timings for a single pipeline run
+// ============================================================================
+
+struct StageTimingsNs {
+	double trigger_ring   = 0.0;
+	double peak_detect    = 0.0;
+	double envelope       = 0.0;
+	double measurements   = 0.0;
+	double total          = 0.0;
+};
+
+// ============================================================================
+// Per-config result
+// ============================================================================
+
+struct ConfigResult {
+	std::string config_name;
+	std::string coeff_type;
+	std::string state_type;
+	std::string sample_type;
+
+	// Headline metrics
+	bool        glitch_survived = false;
+	double      glitch_peak_observed = 0.0;
+	double      rise_time_samples    = 0.0;
+	double      rise_time_expected   = 0.0;
+	double      rms                  = 0.0;
+	double      mean                 = 0.0;
+	double      period_samples       = 0.0;
+	double      frequency_hz         = 0.0;
+	double      output_snr_db        = 0.0;   // vs uniform_double reference
+	std::size_t captured_length      = 0;
+
+	StageTimingsNs timings;
+
+	// Per-pixel envelope (mins, maxs) — used to write the CSV. Cast to
+	// double regardless of SampleScalar precision so we have one schema.
+	std::vector<double> envelope_min;
+	std::vector<double> envelope_max;
+};
+
+// ============================================================================
+// run_pipeline<SampleScalar>
+//
+// One scope pipeline run at a single precision config. Returns a
+// ConfigResult with both the headline measurements and the rendered
+// envelope. The trigger/ring/peak-detect/envelope chain is parameterized
+// solely on SampleScalar — these primitives don't take CoeffScalar /
+// StateScalar separately because they don't have filter coefficients.
+// (The spec lists three scalars to keep the type signature uniform with
+// the rest of the library; for scope_demo only Sample matters.)
+// ============================================================================
+
+template <class SampleScalar>
+ConfigResult run_pipeline(const std::vector<double>& adc_in_double,
+                          const std::string& config_name) {
+	ConfigResult result;
+	result.config_name = config_name;
+	result.coeff_type  = config_name;   // uniform — keep the column for schema
+	result.state_type  = config_name;
+	result.sample_type = config_name;
+
+	// Project ADC samples into SampleScalar.
+	std::vector<SampleScalar> adc_in(adc_in_double.size());
+	for (std::size_t n = 0; n < adc_in_double.size(); ++n)
+		adc_in[n] = static_cast<SampleScalar>(adc_in_double[n]);
+
+	// Stage 1: trigger + ring buffer in lockstep.
+	auto t0 = chrono::high_resolution_clock::now();
+	EdgeTrigger<SampleScalar> trig(static_cast<SampleScalar>(params.trigger_level),
+	                                Slope::Rising,
+	                                static_cast<SampleScalar>(params.trigger_hyst));
+	AutoTriggerWrapper<EdgeTrigger<SampleScalar>>
+		auto_trig(trig, params.auto_trigger_to);
+	TriggerRingBuffer<SampleScalar> ring(params.pre_trigger, params.post_trigger);
+
+	bool triggered = false;
+	for (std::size_t n = 0; n < adc_in.size(); ++n) {
+		const SampleScalar x = adc_in[n];
+		// Only the FIRST fire goes to push_trigger. Subsequent edges of
+		// the inner trigger are ignored — push_trigger() is a no-op in
+		// Capturing state, and routing the sample there instead of via
+		// push() would silently drop it from the captured segment
+		// (one sample per re-trigger).
+		const bool fire = auto_trig.process(x);
+		if (!triggered && fire) {
+			ring.push_trigger(x);
+			triggered = true;
+		} else {
+			ring.push(x);
+		}
+		if (ring.capture_complete()) break;
+	}
+	auto t1 = chrono::high_resolution_clock::now();
+	result.timings.trigger_ring =
+		chrono::duration<double, std::nano>(t1 - t0).count();
+
+	if (!ring.capture_complete()) {
+		// No trigger fired — leave envelope empty and bail. The console
+		// summary will show this as zero glitch survival, NaN rise time.
+		return result;
+	}
+	auto segment = ring.captured_segment();
+	result.captured_length = segment.size();
+
+	// Stage 2: peak-detect decimation. R=peak_detect_R; R=1 is passthrough.
+	t0 = chrono::high_resolution_clock::now();
+	PeakDetectDecimator<SampleScalar> pd(params.peak_detect_R);
+	auto pd_env = pd.process_block(segment);
+	t1 = chrono::high_resolution_clock::now();
+	result.timings.peak_detect =
+		chrono::duration<double, std::nano>(t1 - t0).count();
+
+	// Stage 3: render envelope to pixel_width columns. We render the MAX
+	// stream from peak_detect (the stream that preserves positive glitches).
+	// For a true scope display you'd render both mins and maxs as a vertical
+	// line per pixel; for this demo we focus on the max stream because
+	// that's where the positive glitch shows up.
+	t0 = chrono::high_resolution_clock::now();
+	std::span<const SampleScalar> max_span(pd_env.maxs.data(), pd_env.maxs.size());
+	std::span<const SampleScalar> min_span(pd_env.mins.data(), pd_env.mins.size());
+	auto disp_max = render_envelope<SampleScalar>(max_span, params.pixel_width);
+	auto disp_min = render_envelope<SampleScalar>(min_span, params.pixel_width);
+	t1 = chrono::high_resolution_clock::now();
+	result.timings.envelope =
+		chrono::duration<double, std::nano>(t1 - t0).count();
+
+	// Stage 4: measurements.
+	//
+	// rms / mean / glitch-peak read the full segment — the glitch is part
+	// of what the user wants to see in those numbers (RMS is elevated
+	// slightly, glitch peak is the headline).
+	//
+	// rise_time / period / frequency read a glitch-free pre-window. The
+	// glitch's leading edge would otherwise create an extra zero-crossing
+	// (period bias) and push the 90% threshold above the carrier
+	// amplitude (rise time measures from carrier to glitch). The
+	// pre-glitch window contains several clean carrier cycles.
+	t0 = chrono::high_resolution_clock::now();
+	result.rms = rms<SampleScalar>(segment);
+	result.mean = mean<SampleScalar>(segment);
+	const std::size_t mw_len =
+		std::min(segment.size(), params.pre_glitch_window);
+	auto measurement_window = segment.subspan(0, mw_len);
+	result.rise_time_samples =
+		rise_time_samples<SampleScalar>(measurement_window, 0.1, 0.9);
+	result.period_samples =
+		period_samples<SampleScalar>(measurement_window,
+		                              static_cast<SampleScalar>(0));
+	result.frequency_hz =
+		frequency_hz<SampleScalar>(measurement_window, params.sample_rate_hz,
+		                            static_cast<SampleScalar>(0));
+	t1 = chrono::high_resolution_clock::now();
+	result.timings.measurements =
+		chrono::duration<double, std::nano>(t1 - t0).count();
+
+	result.timings.total = result.timings.trigger_ring
+	                     + result.timings.peak_detect
+	                     + result.timings.envelope
+	                     + result.timings.measurements;
+
+	// Glitch survival: scan the rendered MAX-envelope for a peak that
+	// significantly exceeds the carrier amplitude. The carrier maxes at
+	// +signal_amp; the glitch tops out at glitch_peak. We declare
+	// "survived" when the observed peak >= midway between the two
+	// (a generous tolerance — a faithful pipeline recovers the full
+	// glitch_peak, but peak-detect + render_envelope can mildly attenuate
+	// a sub-window glitch when the decimation factor is high).
+	double peak = -1e9;
+	for (std::size_t i = 0; i < disp_max.maxs.size(); ++i)
+		peak = std::max(peak, static_cast<double>(disp_max.maxs[i]));
+	result.glitch_peak_observed = peak;
+	const double glitch_threshold =
+		0.5 * (params.signal_amp + params.glitch_peak);
+	result.glitch_survived = peak >= glitch_threshold;
+
+	// Stash the envelope for CSV writing. Cast to double for a uniform
+	// schema; the CSV is the comparison surface across configs.
+	result.envelope_min.assign(disp_min.mins.size(), 0.0);
+	result.envelope_max.assign(disp_max.maxs.size(), 0.0);
+	for (std::size_t i = 0; i < disp_max.maxs.size(); ++i) {
+		result.envelope_min[i] = static_cast<double>(disp_min.mins[i]);
+		result.envelope_max[i] = static_cast<double>(disp_max.maxs[i]);
+	}
+
+	return result;
+}
+
+// ============================================================================
+// Output trace SNR vs the uniform_double reference
+// ============================================================================
+
+double snr_db_against_reference(const ConfigResult& test,
+                                 const ConfigResult& ref) {
+	if (ref.envelope_max.size() != test.envelope_max.size()
+	    || ref.envelope_max.empty())
+		return std::numeric_limits<double>::quiet_NaN();
+	double sig_pow = 0.0, err_pow = 0.0;
+	for (std::size_t i = 0; i < ref.envelope_max.size(); ++i) {
+		const double s = ref.envelope_max[i];
+		const double e = ref.envelope_max[i] - test.envelope_max[i];
+		sig_pow += s * s;
+		err_pow += e * e;
+	}
+	if (err_pow <= 0.0) return std::numeric_limits<double>::infinity();
+	return 10.0 * std::log10(sig_pow / err_pow);
+}
+
+// ============================================================================
+// CSV output
+// ============================================================================
+
+void write_csv(const std::string& path,
+               const std::vector<ConfigResult>& results) {
+	std::ofstream out(path);
+	if (!out) {
+		std::cerr << "warn: could not open '" << path << "' for write\n";
+		return;
+	}
+	// Schema: pipeline,config_name,coeff_type,state_type,sample_type,
+	//         pixel_index,envelope_min,envelope_max,
+	//         glitch_survived,glitch_peak,rise_time,rms,mean,output_snr_db
+	out << "pipeline,config_name,coeff_type,state_type,sample_type,"
+	       "pixel_index,envelope_min,envelope_max,"
+	       "glitch_survived,glitch_peak,rise_time_samples,rms,mean,output_snr_db\n";
+	for (const auto& r : results) {
+		for (std::size_t i = 0; i < r.envelope_max.size(); ++i) {
+			out << "scope_demo,"
+			    << r.config_name << ','
+			    << r.coeff_type  << ','
+			    << r.state_type  << ','
+			    << r.sample_type << ','
+			    << i << ','
+			    << r.envelope_min[i] << ','
+			    << r.envelope_max[i] << ','
+			    << (r.glitch_survived ? 1 : 0) << ','
+			    << r.glitch_peak_observed << ','
+			    << r.rise_time_samples << ','
+			    << r.rms << ','
+			    << r.mean << ','
+			    << r.output_snr_db
+			    << '\n';
+		}
+	}
+}
+
+// ============================================================================
+// Console summary table
+// ============================================================================
+
+void print_summary_header() {
+	std::cout << "\n=== Mixed-precision scope sweep ===\n";
+	std::cout << std::left  << std::setw(18) << "config"
+	          << std::right << std::setw(10) << "glitch?"
+	          << std::right << std::setw(12) << "peak"
+	          << std::right << std::setw(12) << "rise(samp)"
+	          << std::right << std::setw(10) << "rms"
+	          << std::right << std::setw(12) << "freq(MHz)"
+	          << std::right << std::setw(12) << "SNR(dB)"
+	          << "\n";
+	std::cout << std::string(18 + 10 + 12 + 12 + 10 + 12 + 12, '-') << "\n";
+}
+
+void print_summary_row(const ConfigResult& r) {
+	std::cout << std::left  << std::setw(18) << r.config_name
+	          << std::right << std::setw(10) << (r.glitch_survived ? "PASS" : "fail")
+	          << std::right << std::setw(12) << std::fixed
+	          << std::setprecision(3) << r.glitch_peak_observed
+	          << std::right << std::setw(12);
+	if (std::isnan(r.rise_time_samples)) std::cout << "NaN";
+	else std::cout << std::setprecision(2) << r.rise_time_samples;
+	std::cout << std::right << std::setw(10) << std::setprecision(3) << r.rms
+	          << std::right << std::setw(12);
+	if (std::isnan(r.frequency_hz)) std::cout << "NaN";
+	else std::cout << std::setprecision(3) << r.frequency_hz / 1e6;
+	std::cout << std::right << std::setw(12) << std::setprecision(2) << r.output_snr_db
+	          << "\n";
+}
+
+// ============================================================================
+// Per-stage timing report — 10 GSPS comparison
+// ============================================================================
+
+void print_timing_report(const ConfigResult& reference) {
+	std::cout << "\n=== Per-stage timing (uniform_double reference) ===\n";
+	const double samples = static_cast<double>(reference.captured_length);
+	if (samples <= 0.0) {
+		std::cout << "  (no capture — timing skipped)\n";
+		return;
+	}
+	auto print = [&](const char* name, double ns_total) {
+		const double ns_per_sample = ns_total / samples;
+		std::cout << "  " << std::left << std::setw(18) << name
+		          << std::right << std::setw(12) << std::fixed
+		          << std::setprecision(2) << ns_total << " ns total"
+		          << std::right << std::setw(12) << std::setprecision(3)
+		          << ns_per_sample << " ns/sample"
+		          << "\n";
+	};
+	print("trigger+ring",   reference.timings.trigger_ring);
+	print("peak_detect",    reference.timings.peak_detect);
+	print("render_envelope",reference.timings.envelope);
+	print("measurements",   reference.timings.measurements);
+	print("TOTAL",          reference.timings.total);
+
+	// 10 GSPS = 0.1 ns / sample budget end-to-end.
+	const double total_per_sample = reference.timings.total / samples;
+	const double target_ns_per_sample = 0.1;   // 1e9 / 10e9
+	std::cout << "\n  10 GSPS budget: 0.100 ns/sample\n";
+	if (total_per_sample <= target_ns_per_sample) {
+		std::cout << "  10 GSPS: ACHIEVED ("
+		          << std::fixed << std::setprecision(3)
+		          << total_per_sample << " ns/sample)\n";
+	} else {
+		const double speedup_needed = total_per_sample / target_ns_per_sample;
+		std::cout << "  10 GSPS: NOT achievable on general-purpose CPU "
+		             "(would need " << std::fixed << std::setprecision(1)
+		          << speedup_needed << "x speedup)\n";
+		std::cout << "  Real 10 GSPS scopes use ASIC pipelines — this is an "
+		             "informational comparison.\n";
+	}
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char** argv) try {
+	std::string csv_path = "scope_demo.csv";
+	for (int i = 1; i < argc; ++i) {
+		std::string a = argv[i];
+		if (a.rfind("--csv=", 0) == 0)
+			csv_path = a.substr(6);
+		else if (a == "-h" || a == "--help") {
+			std::cout << "Usage: " << argv[0] << " [--csv=path]\n";
+			return 0;
+		}
+	}
+
+	std::cout << "scope_demo: digital-oscilloscope mixed-precision sweep\n"
+	          << "  signal:  50 MHz square wave +- " << params.signal_amp
+	          << " (5 ns +" << params.glitch_peak << " glitch at "
+	          << params.glitch_offset_s * 1e9 << " ns)\n"
+	          << "  ADC:     " << params.adc_bits << "-bit, "
+	          << params.sample_rate_hz / 1e9 << " GSPS, "
+	          << params.num_samples << " samples\n"
+	          << "  capture: " << params.pre_trigger << " pre + 1 trigger + "
+	          << params.post_trigger << " post\n"
+	          << "  display: peak-detect R=" << params.peak_detect_R
+	          << ", " << params.pixel_width << " pixels\n";
+
+	// Compute analytical rise time for the carrier transition: a square
+	// wave's rising edge is one sample wide at 1 GSPS / 50 MHz (it goes
+	// from -amp to +amp in one sample), so the 10/90 rise time is 0.8
+	// samples (80% of one sample step). The pipeline's rise time should
+	// recover this within roughly half a sample.
+	const double expected_rise_samples = 0.8;
+
+	const auto adc = simulate_adc();
+
+	// Run the six configurations.
+	std::vector<ConfigResult> results;
+	results.push_back(run_pipeline<double>(adc, "uniform_double"));
+	results.push_back(run_pipeline<float>(adc,  "uniform_float"));
+	results.push_back(run_pipeline<p32>(adc,    "uniform_posit32"));
+	results.push_back(run_pipeline<p16>(adc,    "uniform_posit16"));
+	results.push_back(run_pipeline<cf32>(adc,   "uniform_cfloat32"));
+	results.push_back(run_pipeline<fx32>(adc,   "uniform_fixpnt"));
+
+	// SNR vs uniform_double reference (results[0]).
+	for (auto& r : results) {
+		r.rise_time_expected = expected_rise_samples;
+		r.output_snr_db = snr_db_against_reference(r, results[0]);
+	}
+
+	print_summary_header();
+	for (const auto& r : results) print_summary_row(r);
+
+	print_timing_report(results[0]);
+
+	write_csv(csv_path, results);
+	std::cout << "\nCSV written: " << csv_path << "\n";
+
+	return 0;
+} catch (const std::exception& ex) {
+	std::cerr << "FATAL: " << ex.what() << "\n";
+	return 1;
+}

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -61,6 +61,10 @@ export default defineConfig({
           autogenerate: { directory: 'acquisition' },
         },
         {
+          label: 'Instrument Data Acquisition',
+          autogenerate: { directory: 'instrument' },
+        },
+        {
           label: 'Analysis',
           autogenerate: { directory: 'analysis' },
         },

--- a/docs-site/src/content/docs/instrument/scope-demo.md
+++ b/docs-site/src/content/docs/instrument/scope-demo.md
@@ -1,111 +1,230 @@
 ---
 title: End-to-End Scope Demo
-description: Capstone walkthrough wiring the trigger, ring buffer, peak-detect decimator, display envelope, and measurement primitives into a working digital oscilloscope simulator
+description: Capstone walkthrough wiring the calibration equalizer, trigger, ring buffer, peak-detect decimator, display envelope, and measurement primitives into a working digital oscilloscope simulator with a per-stage mixed-precision sweep
 ---
 
 The library ships a runnable digital-oscilloscope demo at
 [`applications/scope_demo/`](https://github.com/stillwater-sc/mixed-precision-dsp/tree/main/applications/scope_demo)
-that exercises the entire `instrument/` module end-to-end: a simulated
-ADC produces a 50 MHz square wave with a 5 ns glitch buried in it, the
-signal flows through trigger → ring buffer → peak-detect decimator →
-display envelope, and the captured segment is run through the seven
-cursor-style measurement primitives. The final output is a CSV trace
-plus a console summary table swept across six precision configurations.
+that exercises the entire `instrument/` module end-to-end and **sweeps
+precision per stage**, not uniformly across the whole pipeline. A
+simulated ADC produces a 50 MHz square wave with a 5 ns glitch buried
+in it; the signal flows through an `EqualizerFilter` (calibration
+correction), then trigger → ring buffer → peak-detect decimator →
+display envelope; the captured segment is run through the seven
+cursor-style measurement primitives. The output is a CSV trace plus a
+console summary table over five **precision plans** that mix and match
+types across the stages.
 
-This page walks through the topology, the measurement contract, and the
-mixed-precision finding the sweep produces (which is the opposite of
-what the SDR demo shows — a feature, not a bug).
+This page walks through the topology, the per-stage precision contract
+that follows from how each stage is implemented, and the headline
+mixed-precision finding the sweep produces.
 
 ## Pipeline
 
 ```text
-+----------------------------+    +-------------------------+
-| simulate_adc(N_bits, Fs)   | -> | EdgeTrigger             |
-|   50 MHz square wave       |    |   + AutoTriggerWrapper  |
-|   +/- 0.5 amplitude        |    |   level=0, hyst=0.05,   |
-|   5 ns +0.95 glitch buried |    |   slope=Rising          |
-|   AWGN sigma=0.005         |    +-----------+-------------+
-|   12-bit uniform quant     |                |
-+----------------------------+                v
-                                  +-------------------------+
-                                  | TriggerRingBuffer       |
-                                  |   pre=256 + 1 + post=768|
-                                  +-----------+-------------+
-                                              |
-                                              v
-                                  +-------------------------+
-                                  | PeakDetectDecimator R=2 |
-                                  |   preserves glitch peak |
-                                  +-----------+-------------+
-                                              |
-                                              v
-                                  +-------------------------+
-                                  | render_envelope         |
-                                  |   -> 200 pixel columns  |
-                                  +-----------+-------------+
-                                              |
-                                              v
-                                  +-------------------------+
-                                  | measurements            |
-                                  |   peak_to_peak, mean,   |
-                                  |   rms, rise_time,       |
-                                  |   period, frequency     |
-                                  +-----------+-------------+
-                                              |
-                                              v
-                                  scope_demo.csv + console
++---------------------------+    +-----------------------------------+
+| simulate_adc(N_bits, Fs)  | -> | EqualizerFilter                   |
+|   50 MHz square wave      |    |   <EqCoeff, EqState, EqSample>    |
+|   +/- 0.5 amplitude       |    |   FIR inverse of calibration      |
+|   5 ns +0.95 glitch       |    |   profile, 31 taps                |
+|   AWGN sigma=0.005        |    |   <-- the ONLY arithmetic stage   |
+|   12-bit uniform quant    |    |       on the streaming path       |
++---------------------------+    +-----------+-----------------------+
+                                             |
+                                             v cast to StorageScalar
+                                 +-----------+-----------+
+                                 | EdgeTrigger           |
+                                 | + AutoTriggerWrapper  |
+                                 +-----------+-----------+
+                                             |
+                                             v
+                                 +-----------+-----------+
+                                 | TriggerRingBuffer     |
+                                 |   pre + 1 + post      |
+                                 +-----------+-----------+
+                                             |
+                                             v
+                                 +-----------+-----------+
+                                 | PeakDetectDecimator   |
+                                 |   preserves glitch    |
+                                 +-----------+-----------+
+                                             |
+                                             v
+                                 +-----------+-----------+
+                                 | render_envelope       |
+                                 |   -> N pixel columns  |
+                                 +-----------+-----------+
+                                             |
+                                             v
+                                 +-----------+-----------+
+                                 | measurements (always  |
+                                 |   accumulate in       |
+                                 |   double internally)  |
+                                 +-----------+-----------+
+                                             |
+                                             v
+                                 scope_demo.csv + console
 ```
 
-## Test signal
+## Per-stage precision contract
 
-The synthesized waveform has three pieces:
+Each stage's precision requirement follows from its arithmetic, not
+from a uniform "let's run everything in `T`" choice:
 
-- A 50 MHz square wave at +/- 0.5 amplitude. The square wave is
-  generated with an integer-phase counter rather than
-  `sin(2*pi*f*t) >= 0`, because `sin(k*pi)` for integer `k` returns
-  numerically noisy values that flip sign unpredictably and bias the
-  period measurement.
-- A 5 ns positive glitch (peak amplitude 0.95) injected at 500 ns into
-  the stream. The glitch *replaces* the carrier value during its
-  window, modeling an EMI pulse hitting a probe — that way the glitch
-  peak is well-defined regardless of what the carrier was doing
-  underneath.
-- AWGN at sigma=0.005, well below the carrier amplitude so that the
-  trigger fires reliably without hysteresis-defeating chatter.
+| Stage             | What it does                       | Precision driver                                      |
+|-------------------|-------------------------------------|-------------------------------------------------------|
+| ADC               | Quantize input                      | Fixed by the ADC (12-bit here)                        |
+| EqualizerFilter   | FIR multiply-accumulate per sample  | **Streaming arithmetic** — narrowing here costs SNR   |
+| EdgeTrigger       | Compares against threshold          | Comparison-only — narrowing is free                   |
+| TriggerRingBuffer | Stores captured samples             | **Storage bandwidth** — narrowing trades memory for nothing |
+| PeakDetectDecimator | min/max over R samples            | Comparison + selection — narrowing is free            |
+| render_envelope   | min/max per pixel column            | Same                                                  |
+| measurements      | Sum, sum-of-squares, interpolation  | Always `double` internally regardless of input type   |
 
-The ADC stage runs the noisy signal through a 12-bit uniform quantizer
-(`floor(x / q_step)` clamped to `[-2^(N-1), 2^(N-1)-1]`), matching the
-2's-complement code semantics in the SDR demo's `simulate_adc()`.
+So a *real* mixed-precision plan picks two independent things:
 
-## Measurement window
+1. **EqCoeff / EqState / EqSample** — the calibration FIR's three
+   scalars, controlling the cost of the streaming arithmetic.
+2. **StorageScalar** — the type used by the trigger / ring buffer /
+   peak-detect / envelope, controlling the memory bandwidth
+   downstream of the equalizer.
 
-The captured segment includes both the carrier and the glitch. Two
-of the seven measurement primitives are sensitive to which sub-window
-they read:
+The demo's `run_pipeline<EqCoeff, EqState, EqSample, StorageScalar>`
+template takes the four scalars independently. Each row of the sweep
+table is a different (EQ-tuple, Storage) plan.
 
-- **`rise_time_samples`**: bases its 10% / 90% thresholds on the
-  segment's `peak_to_peak`, which the glitch lifts above the carrier.
-  Reading rise time from the full segment would measure from the first
-  carrier rising edge to the glitch's leading edge — a real number,
-  but not the carrier rise time.
-- **`period_samples` / `frequency_hz`**: detect zero-crossings, and
-  the glitch's leading edge creates an extra rising crossing that
-  biases the period average.
+## Calibration profile
 
-The demo sidesteps both by computing rise / period / frequency on a
-glitch-free **measurement window** — the first `pre_glitch_window` (400)
-samples of the captured segment, which contains several clean carrier
-cycles and ends well before the glitch's 500 ns position. The full
-segment is still used for `rms`, `mean`, and the rendered envelope (the
-latter is where the headline glitch-survival metric lives).
+A synthetic mild rolloff:
 
-This is a reusable pattern: aggregations want everything; transition-
-based measurements want a representative quiet window.
+```cpp
+freqs    = {0,  50e6, 100e6, 250e6, 500e6};   // up to Nyquist
+gains_dB = {0, -0.5,  -2.0,  -3.0,  -3.0};
+phases   = {0, -0.10, -0.20, -0.30, -0.30};
+```
 
-## The off-by-one trigger trap
+This models a typical analog front end with a 100 MHz-ish corner.
+The equalizer's job is to apply the inverse — a small, mostly-flat
+boost — so the streaming output is closer to the source signal.
 
-A subtlety surfaced during integration: the inner trigger fires at
-*every* rising edge, not just the first one. The naive integration loop
+A more aggressive profile (e.g., -10 dB at Nyquist) would force the
+equalizer to apply +10 dB at Nyquist, which would ring on every sharp
+edge and turn the square wave into something that doesn't look like a
+square wave anymore. That's a real tradeoff scope designers face. For
+this demo we keep the corrections under +2 dB so the analytical
+measurements remain interpretable across all configs and the
+**precision-impact comparison** is the headline.
+
+## Precision plans
+
+Five named plans, each picking each stage's type independently:
+
+```cpp
+// reference: all double
+run_pipeline<double, double, double, double>(...);
+
+// High-precision EQ + ADC-native fixpnt storage. The streaming
+// arithmetic stays full-precision; storage drops 4x.
+run_pipeline<double, double, double, fixpnt<16,12>>(...);
+
+// Narrow EQ in posit32 + double storage. Isolates the cost of
+// narrowing only the streaming arithmetic.
+run_pipeline<posit<32,2>, posit<32,2>, posit<32,2>, double>(...);
+
+// Narrow EQ in posit16 + double storage. The headline mixed-
+// precision case: 16-bit streaming arithmetic vs. comparison-only
+// downstream.
+run_pipeline<posit<16,2>, posit<16,2>, posit<16,2>, double>(...);
+
+// FPGA-pragmatic: float EQ + ADC-native fixpnt storage.
+run_pipeline<float, float, float, fixpnt<16,12>>(...);
+```
+
+## Sweep result
+
+```text
+plan (EQ x storage)              B/samp glitch?    peak  rise  freq(MHz)  SNR(dB)
+---------------------------------------------------------------------------------
+reference (double x double)           8    PASS   1.459  9.36     58.507      inf
+eq_double_storage_fx16 (double..)     2    PASS   1.458  9.36     58.510    78.75
+eq_posit32_storage_double (p32..)     8    PASS   1.459  9.36     58.507   162.92
+eq_posit16_storage_double (p16..)     8    PASS   1.458  9.36     58.507    66.32
+eq_float_storage_fx16 (float ..)      2    PASS   1.458  9.36     58.510    78.75
+```
+
+The carrier measurements (rise time, frequency, glitch peak) reflect
+the **equalized** signal, not the raw source — the equalizer reshapes
+edges (its ~31-sample group delay + impulse-response width inflates
+the apparent 10/90 rise time relative to the input's one-sample
+edge). All five plans agree on the qualitative measurement, which is
+the right consistency check.
+
+### What the SNR column actually means
+
+`SNR(dB) = inf` for the reference plan (vs itself). For every other
+plan, SNR is computed against the reference plan's rendered envelope:
+
+```text
+SNR_dB(plan) = 10 * log10(sum(reference^2) / sum((reference - plan)^2))
+```
+
+So a higher number means "this plan's pipeline output matches the
+all-double reference more closely" — i.e., less precision-induced
+drift.
+
+## The mixed-precision finding
+
+Two independent precision dimensions, with very different cost
+profiles:
+
+### Storage narrowing is cheap
+
+`eq_double_storage_fx16` runs the equalizer in full-precision `double`
+and stores everything downstream in `fixpnt<16,12>`. The result:
+**4× memory reduction (8 → 2 bytes/sample)** at a cost of ~80 dB SNR.
+
+That's a real-but-acceptable cost. The ADC produces 12-bit samples;
+storing them in 16-bit fixpnt is essentially storing them at native
+resolution. The only quantization is at the storage boundary, and
+because every downstream stage is comparison-only, that quantization
+doesn't compound.
+
+### Streaming-arithmetic narrowing costs SNR proportionally
+
+`eq_posit16_storage_double` keeps storage at `double` (no memory
+reduction) but narrows the equalizer's streaming arithmetic to
+`posit16`. The result: **66 dB SNR**, which is ~12 dB *worse* than
+the storage-narrowing-only plan despite using 4× *more* memory.
+
+Why? The equalizer is a 31-tap FIR multiply-accumulate. At each tap,
+posit16's ~12-bit fraction precision rounds the partial product. Those
+rounding errors accumulate across the 31 taps. Repeated arithmetic in
+a 16-bit type is fundamentally noisier than repeated copies of a
+16-bit type.
+
+### The headline takeaway
+
+> **Narrow your storage, not your arithmetic.**
+
+When the streaming path forks into "things that compute on values"
+and "things that just move them around", precision matters
+disproportionately on the compute side. Memory bandwidth — usually
+the dominant cost in a high-rate scope — narrows for free as long as
+the compute stage maintains enough precision.
+
+The `eq_float_storage_fx16` row is the FPGA-pragmatic version of this
+lesson: float for the equalizer (cheap on most fabric) plus
+fixpnt<16,12> for storage gives you 4× memory reduction *and* 78 dB
+SNR — better than pure posit16 EQ.
+
+## Two non-obvious pitfalls (captured in code + docs)
+
+The integration surfaced two issues worth recording so the next demo
+author doesn't repeat them:
+
+### Off-by-one trigger trap
+
+A naive integration loop
 
 ```cpp
 for (...) {
@@ -114,169 +233,59 @@ for (...) {
 }
 ```
 
-silently drops one sample per re-fire after the first trigger, because
-`push_trigger()` is a no-op when the ring is in `Capturing` state and
-the corresponding `push()` call doesn't happen on that iteration. The
-resulting captured segment is missing one sample per ~20 (every carrier
-rising edge), which compresses the apparent period from 20 samples to
-~19 and biases the measured frequency upward by ~5%.
+silently drops one sample per re-fire after the first trigger.
+`push_trigger()` is a no-op when the ring is in `Capturing` state, but
+the corresponding `push()` doesn't run either because the
+`if/else` already chose the wrong branch. The captured segment then
+has one missing sample per ~20 (every carrier rising edge), which
+compresses the apparent period from 20 samples to ~19 and biases
+measured frequency upward by ~5%.
 
 The demo gates `push_trigger` with a `triggered` flag so only the first
 fire takes the trigger path; everything afterwards goes through `push`.
-The fix is documented inline in `scope_demo.cpp` so the next demo
-author sees it.
 
-## Mixed-precision sweep
+### Square-wave FP boundary
 
-Six configs are run, all uniform (same scalar everywhere):
+`sin(2*pi*f*t) >= 0` is unstable at sample boundaries where
+`sin(k*pi)` returns tiny noise that flips sign unpredictably
+(`sin(6*pi)` came out positive on x86 in one build, shortening one
+low half-cycle by a sample and biasing period measurements).
+Replaced with an integer-phase counter:
 
-| Config            | Type                                    |
-|-------------------|-----------------------------------------|
-| uniform_double    | `double`                                |
-| uniform_float     | `float`                                 |
-| uniform_posit32   | `posit<32, 2>`                          |
-| uniform_posit16   | `posit<16, 2>`                          |
-| uniform_cfloat32  | `cfloat<32, 8, uint32_t, true,...>`     |
-| uniform_fixpnt    | `fixpnt<32, 30>` (Q2.30)                |
-
-The result on the demo signal:
-
-```text
-config               glitch?        peak  rise(samp)       rms   freq(MHz)     SNR(dB)
---------------------------------------------------------------------------------------
-uniform_double          PASS       0.962        0.81     0.504      50.001         inf
-uniform_float           PASS       0.962        0.81     0.504      50.001         inf
-uniform_posit32         PASS       0.962        0.81     0.504      50.001         inf
-uniform_posit16         PASS       0.962        0.81     0.504      50.001         inf
-uniform_cfloat32        PASS       0.962        0.81     0.504      50.001         inf
-uniform_fixpnt          PASS       0.962        0.81     0.504      50.001         inf
+```cpp
+const std::size_t half_period_samples = round(0.5 * Fs / f);
+const std::size_t phase_n = n % (2 * half_period_samples);
+const double sq = (phase_n < half_period_samples) ? +amp : -amp;
 ```
-
-Every config produces **bit-identical** output — `SNR(dB) = inf`
-against the uniform_double reference. This is the **headline finding**
-of the scope demo and the structural opposite of what the SDR demo
-produces.
-
-### Why is scope DSP precision-insensitive?
-
-The pipeline stages, from top to bottom:
-
-| Stage                | Operations                                          |
-|----------------------|-----------------------------------------------------|
-| `EdgeTrigger`        | comparisons (`<`, `>`)                              |
-| `AutoTriggerWrapper` | counter increment + comparison                      |
-| `TriggerRingBuffer`  | array copy / index arithmetic                       |
-| `PeakDetectDecimator`| min / max (comparisons + selection)                 |
-| `render_envelope`    | min / max over per-pixel ranges (comparisons)       |
-| `measurements`       | accumulate in `double` regardless of `SampleScalar` |
-
-There is **no arithmetic on `SampleScalar` values** in the scope
-streaming path. Every operation is either a comparison (which preserves
-ordering across all the configured number systems for inputs in their
-representable range), a copy (precision-preserving by definition), or
-a min/max selection (which copies the surviving value bit-exactly).
-The measurement primitives explicitly cast their inputs to `double`
-for accumulation — see the `Mixed-precision contract` block in
-[`measurements.hpp`](https://github.com/stillwater-sc/mixed-precision-dsp/blob/main/include/sw/dsp/instrument/measurements.hpp)
-— so they don't introduce per-config drift either.
-
-The contrast with the SDR demo is the lesson:
-
-| Pipeline                       | Arithmetic in streaming path? | Per-config SNR? |
-|--------------------------------|-------------------------------|-----------------|
-| SDR / DDC                      | mixers + FIR + CIC            | Strongly varies |
-| Scope                          | None — only compare / copy    | Bit-identical   |
-
-A real scope's analog front-end is heavily dependent on amplifier and
-ADC precision; the **digital** path is comparison-dominated and largely
-type-blind. This demo verifies that the library's scope primitives
-respect that.
-
-### When *would* scope precision matter?
-
-- **Very narrow types near saturation**: e.g. `posit8` would clamp the
-  +0.95 glitch to its dynamic-range edge, attenuating the peak.
-- **Asymmetric quantization grids**: `fixpnt<32, 30>` represents
-  values in `[-2, +2)` exactly enough; `fixpnt<32, 16>` (Q16.16) would
-  give the signal coarse stair-stepping that doesn't change the
-  envelope much but quantizes RMS/mean visibly.
-- **Calibration / equalizer stages**: a future version of this demo
-  with an `EqualizerFilter` front-end would introduce arithmetic on
-  the streaming path and produce the per-config SNR variation the SDR
-  demo shows.
-
-The current sweep is a **negative result by design**: the cleanly-
-factored streaming path is comparison-only, so it should report
-bit-identical envelopes — and does.
 
 ## Per-stage timing and the 10 GSPS comparison
 
-The demo instruments each stage with `std::chrono::high_resolution_clock`
-and reports `ns/sample` for the captured segment. Sample numbers from a
-typical run:
-
 ```text
-=== Per-stage timing (uniform_double reference) ===
-  trigger+ring          71285 ns total       90.349 ns/sample
-  peak_detect           89985 ns total      114.049 ns/sample
-  render_envelope       33224 ns total       42.109 ns/sample
-  measurements          49599 ns total       62.863 ns/sample
-  TOTAL                244093 ns total      309.370 ns/sample
-
-  10 GSPS budget: 0.100 ns/sample
-  10 GSPS: NOT achievable on general-purpose CPU (would need 3093.7x speedup)
-  Real 10 GSPS scopes use ASIC pipelines — this is an informational comparison.
+=== Per-stage timing (reference plan) ===
+  equalizer        ~12 ms total   ~15 us/sample    <-- dominant
+  trigger+ring        66 us total      85 ns/sample
+  peak_detect         79 us total     101 ns/sample
+  render_envelope     34 us total      43 ns/sample
+  measurements        46 us total      59 ns/sample
+  TOTAL            ~12.1 ms total  ~15.5 us/sample
 ```
 
-10 GSPS = 100 ps / sample end-to-end. A general-purpose x86 core takes
-roughly **3000x** that for the full chain. This isn't a defect — real
-10 GSPS scopes use ASIC datapaths with hundreds-of-channel parallel
-peak-detect blocks fed from the ADC's metal layer. The CPU comparison
-exists to *quantify the gap*, not to close it.
-
-If you want to push closer: the dominant stage is `peak_detect` at
-~114 ns/sample. Vectorizing that loop (AVX2/AVX-512 min/max
-intrinsics) would cut several factor-of-two off the total but not
-close the 1000x gap.
-
-## Output
-
-A single `scope_demo.csv` is written, one row per (config, pixel)
-pair. Columns:
-
-```text
-pipeline,config_name,coeff_type,state_type,sample_type,
-pixel_index,envelope_min,envelope_max,
-glitch_survived,glitch_peak,rise_time_samples,rms,mean,output_snr_db
-```
-
-The schema is a superset of the acquisition demo's CSV: the
-`pixel_index / envelope_min / envelope_max` columns are scope-specific,
-the rest are the standard precision-sweep columns so downstream
-analysis tools that consume `acquisition_demo.csv` can also read
-`scope_demo.csv` for the shared metrics.
+The equalizer dominates the per-stage cost — it's the only stage doing
+arithmetic, and it does N\_taps multiplies + adds per sample. Real
+10 GSPS scopes implement the equalizer in an ASIC pipeline with
+hundreds of parallel taps; this CPU implementation is for
+*understanding the gap*, not closing it.
 
 ## Out of scope (deferred)
 
 The issue ([#152](https://github.com/stillwater-sc/mixed-precision-dsp/issues/152))
-explicitly defers three pieces:
+explicitly defers:
 
 - **Real ADC interfacing** (e.g. TI ADC12DJ5200RF). Simulated only.
-- **Image rendering** of the envelope. CSV is the deliverable; turning
-  it into a PNG is a separate concern.
-- **Multi-channel demonstration**. Single-channel for v0.6;
-  multi-channel becomes natural once
-  [`ChannelAligner`](https://github.com/stillwater-sc/mixed-precision-dsp/blob/main/include/sw/dsp/instrument/channel_aligner.hpp)
-  is fully exercised.
-
-Two further items are deferred from this PR but mentioned in the issue
-as future quality-of-life work:
-
-- **`EqualizerFilter` front-end** integration (calibration stage). The
-  scope DSP primitives are quite separable from calibration; landing
-  the calibration integration as a follow-up keeps the capstone
-  scoped.
-- **Selected mixed configurations** beyond the six uniform ones (e.g.
-  `Coeff=double, State=double, Sample=posit16`). Useful once the
-  pipeline is precision-sensitive — currently every combination
-  produces the same envelope.
+- **Image rendering** of the envelope. CSV is the deliverable.
+- **Multi-channel demonstration**. Single-channel for v0.6.
+- **Pre-distortion of the input** with the calibration profile so the
+  equalizer is undoing a real frequency-domain distortion. Currently
+  the equalizer applies a small correction to the clean source. A
+  follow-up could synthesize a profile-distorted signal and let the
+  equalizer flatten it for an even more realistic demo.

--- a/docs-site/src/content/docs/instrument/scope-demo.md
+++ b/docs-site/src/content/docs/instrument/scope-demo.md
@@ -1,0 +1,282 @@
+---
+title: End-to-End Scope Demo
+description: Capstone walkthrough wiring the trigger, ring buffer, peak-detect decimator, display envelope, and measurement primitives into a working digital oscilloscope simulator
+---
+
+The library ships a runnable digital-oscilloscope demo at
+[`applications/scope_demo/`](https://github.com/stillwater-sc/mixed-precision-dsp/tree/main/applications/scope_demo)
+that exercises the entire `instrument/` module end-to-end: a simulated
+ADC produces a 50 MHz square wave with a 5 ns glitch buried in it, the
+signal flows through trigger → ring buffer → peak-detect decimator →
+display envelope, and the captured segment is run through the seven
+cursor-style measurement primitives. The final output is a CSV trace
+plus a console summary table swept across six precision configurations.
+
+This page walks through the topology, the measurement contract, and the
+mixed-precision finding the sweep produces (which is the opposite of
+what the SDR demo shows — a feature, not a bug).
+
+## Pipeline
+
+```text
++----------------------------+    +-------------------------+
+| simulate_adc(N_bits, Fs)   | -> | EdgeTrigger             |
+|   50 MHz square wave       |    |   + AutoTriggerWrapper  |
+|   +/- 0.5 amplitude        |    |   level=0, hyst=0.05,   |
+|   5 ns +0.95 glitch buried |    |   slope=Rising          |
+|   AWGN sigma=0.005         |    +-----------+-------------+
+|   12-bit uniform quant     |                |
++----------------------------+                v
+                                  +-------------------------+
+                                  | TriggerRingBuffer       |
+                                  |   pre=256 + 1 + post=768|
+                                  +-----------+-------------+
+                                              |
+                                              v
+                                  +-------------------------+
+                                  | PeakDetectDecimator R=2 |
+                                  |   preserves glitch peak |
+                                  +-----------+-------------+
+                                              |
+                                              v
+                                  +-------------------------+
+                                  | render_envelope         |
+                                  |   -> 200 pixel columns  |
+                                  +-----------+-------------+
+                                              |
+                                              v
+                                  +-------------------------+
+                                  | measurements            |
+                                  |   peak_to_peak, mean,   |
+                                  |   rms, rise_time,       |
+                                  |   period, frequency     |
+                                  +-----------+-------------+
+                                              |
+                                              v
+                                  scope_demo.csv + console
+```
+
+## Test signal
+
+The synthesized waveform has three pieces:
+
+- A 50 MHz square wave at +/- 0.5 amplitude. The square wave is
+  generated with an integer-phase counter rather than
+  `sin(2*pi*f*t) >= 0`, because `sin(k*pi)` for integer `k` returns
+  numerically noisy values that flip sign unpredictably and bias the
+  period measurement.
+- A 5 ns positive glitch (peak amplitude 0.95) injected at 500 ns into
+  the stream. The glitch *replaces* the carrier value during its
+  window, modeling an EMI pulse hitting a probe — that way the glitch
+  peak is well-defined regardless of what the carrier was doing
+  underneath.
+- AWGN at sigma=0.005, well below the carrier amplitude so that the
+  trigger fires reliably without hysteresis-defeating chatter.
+
+The ADC stage runs the noisy signal through a 12-bit uniform quantizer
+(`floor(x / q_step)` clamped to `[-2^(N-1), 2^(N-1)-1]`), matching the
+2's-complement code semantics in the SDR demo's `simulate_adc()`.
+
+## Measurement window
+
+The captured segment includes both the carrier and the glitch. Two
+of the seven measurement primitives are sensitive to which sub-window
+they read:
+
+- **`rise_time_samples`**: bases its 10% / 90% thresholds on the
+  segment's `peak_to_peak`, which the glitch lifts above the carrier.
+  Reading rise time from the full segment would measure from the first
+  carrier rising edge to the glitch's leading edge — a real number,
+  but not the carrier rise time.
+- **`period_samples` / `frequency_hz`**: detect zero-crossings, and
+  the glitch's leading edge creates an extra rising crossing that
+  biases the period average.
+
+The demo sidesteps both by computing rise / period / frequency on a
+glitch-free **measurement window** — the first `pre_glitch_window` (400)
+samples of the captured segment, which contains several clean carrier
+cycles and ends well before the glitch's 500 ns position. The full
+segment is still used for `rms`, `mean`, and the rendered envelope (the
+latter is where the headline glitch-survival metric lives).
+
+This is a reusable pattern: aggregations want everything; transition-
+based measurements want a representative quiet window.
+
+## The off-by-one trigger trap
+
+A subtlety surfaced during integration: the inner trigger fires at
+*every* rising edge, not just the first one. The naive integration loop
+
+```cpp
+for (...) {
+    if (auto_trig.process(x)) ring.push_trigger(x);
+    else                       ring.push(x);
+}
+```
+
+silently drops one sample per re-fire after the first trigger, because
+`push_trigger()` is a no-op when the ring is in `Capturing` state and
+the corresponding `push()` call doesn't happen on that iteration. The
+resulting captured segment is missing one sample per ~20 (every carrier
+rising edge), which compresses the apparent period from 20 samples to
+~19 and biases the measured frequency upward by ~5%.
+
+The demo gates `push_trigger` with a `triggered` flag so only the first
+fire takes the trigger path; everything afterwards goes through `push`.
+The fix is documented inline in `scope_demo.cpp` so the next demo
+author sees it.
+
+## Mixed-precision sweep
+
+Six configs are run, all uniform (same scalar everywhere):
+
+| Config            | Type                                    |
+|-------------------|-----------------------------------------|
+| uniform_double    | `double`                                |
+| uniform_float     | `float`                                 |
+| uniform_posit32   | `posit<32, 2>`                          |
+| uniform_posit16   | `posit<16, 2>`                          |
+| uniform_cfloat32  | `cfloat<32, 8, uint32_t, true,...>`     |
+| uniform_fixpnt    | `fixpnt<32, 30>` (Q2.30)                |
+
+The result on the demo signal:
+
+```text
+config               glitch?        peak  rise(samp)       rms   freq(MHz)     SNR(dB)
+--------------------------------------------------------------------------------------
+uniform_double          PASS       0.962        0.81     0.504      50.001         inf
+uniform_float           PASS       0.962        0.81     0.504      50.001         inf
+uniform_posit32         PASS       0.962        0.81     0.504      50.001         inf
+uniform_posit16         PASS       0.962        0.81     0.504      50.001         inf
+uniform_cfloat32        PASS       0.962        0.81     0.504      50.001         inf
+uniform_fixpnt          PASS       0.962        0.81     0.504      50.001         inf
+```
+
+Every config produces **bit-identical** output — `SNR(dB) = inf`
+against the uniform_double reference. This is the **headline finding**
+of the scope demo and the structural opposite of what the SDR demo
+produces.
+
+### Why is scope DSP precision-insensitive?
+
+The pipeline stages, from top to bottom:
+
+| Stage                | Operations                                          |
+|----------------------|-----------------------------------------------------|
+| `EdgeTrigger`        | comparisons (`<`, `>`)                              |
+| `AutoTriggerWrapper` | counter increment + comparison                      |
+| `TriggerRingBuffer`  | array copy / index arithmetic                       |
+| `PeakDetectDecimator`| min / max (comparisons + selection)                 |
+| `render_envelope`    | min / max over per-pixel ranges (comparisons)       |
+| `measurements`       | accumulate in `double` regardless of `SampleScalar` |
+
+There is **no arithmetic on `SampleScalar` values** in the scope
+streaming path. Every operation is either a comparison (which preserves
+ordering across all the configured number systems for inputs in their
+representable range), a copy (precision-preserving by definition), or
+a min/max selection (which copies the surviving value bit-exactly).
+The measurement primitives explicitly cast their inputs to `double`
+for accumulation — see the `Mixed-precision contract` block in
+[`measurements.hpp`](https://github.com/stillwater-sc/mixed-precision-dsp/blob/main/include/sw/dsp/instrument/measurements.hpp)
+— so they don't introduce per-config drift either.
+
+The contrast with the SDR demo is the lesson:
+
+| Pipeline                       | Arithmetic in streaming path? | Per-config SNR? |
+|--------------------------------|-------------------------------|-----------------|
+| SDR / DDC                      | mixers + FIR + CIC            | Strongly varies |
+| Scope                          | None — only compare / copy    | Bit-identical   |
+
+A real scope's analog front-end is heavily dependent on amplifier and
+ADC precision; the **digital** path is comparison-dominated and largely
+type-blind. This demo verifies that the library's scope primitives
+respect that.
+
+### When *would* scope precision matter?
+
+- **Very narrow types near saturation**: e.g. `posit8` would clamp the
+  +0.95 glitch to its dynamic-range edge, attenuating the peak.
+- **Asymmetric quantization grids**: `fixpnt<32, 30>` represents
+  values in `[-2, +2)` exactly enough; `fixpnt<32, 16>` (Q16.16) would
+  give the signal coarse stair-stepping that doesn't change the
+  envelope much but quantizes RMS/mean visibly.
+- **Calibration / equalizer stages**: a future version of this demo
+  with an `EqualizerFilter` front-end would introduce arithmetic on
+  the streaming path and produce the per-config SNR variation the SDR
+  demo shows.
+
+The current sweep is a **negative result by design**: the cleanly-
+factored streaming path is comparison-only, so it should report
+bit-identical envelopes — and does.
+
+## Per-stage timing and the 10 GSPS comparison
+
+The demo instruments each stage with `std::chrono::high_resolution_clock`
+and reports `ns/sample` for the captured segment. Sample numbers from a
+typical run:
+
+```text
+=== Per-stage timing (uniform_double reference) ===
+  trigger+ring          71285 ns total       90.349 ns/sample
+  peak_detect           89985 ns total      114.049 ns/sample
+  render_envelope       33224 ns total       42.109 ns/sample
+  measurements          49599 ns total       62.863 ns/sample
+  TOTAL                244093 ns total      309.370 ns/sample
+
+  10 GSPS budget: 0.100 ns/sample
+  10 GSPS: NOT achievable on general-purpose CPU (would need 3093.7x speedup)
+  Real 10 GSPS scopes use ASIC pipelines — this is an informational comparison.
+```
+
+10 GSPS = 100 ps / sample end-to-end. A general-purpose x86 core takes
+roughly **3000x** that for the full chain. This isn't a defect — real
+10 GSPS scopes use ASIC datapaths with hundreds-of-channel parallel
+peak-detect blocks fed from the ADC's metal layer. The CPU comparison
+exists to *quantify the gap*, not to close it.
+
+If you want to push closer: the dominant stage is `peak_detect` at
+~114 ns/sample. Vectorizing that loop (AVX2/AVX-512 min/max
+intrinsics) would cut several factor-of-two off the total but not
+close the 1000x gap.
+
+## Output
+
+A single `scope_demo.csv` is written, one row per (config, pixel)
+pair. Columns:
+
+```text
+pipeline,config_name,coeff_type,state_type,sample_type,
+pixel_index,envelope_min,envelope_max,
+glitch_survived,glitch_peak,rise_time_samples,rms,mean,output_snr_db
+```
+
+The schema is a superset of the acquisition demo's CSV: the
+`pixel_index / envelope_min / envelope_max` columns are scope-specific,
+the rest are the standard precision-sweep columns so downstream
+analysis tools that consume `acquisition_demo.csv` can also read
+`scope_demo.csv` for the shared metrics.
+
+## Out of scope (deferred)
+
+The issue ([#152](https://github.com/stillwater-sc/mixed-precision-dsp/issues/152))
+explicitly defers three pieces:
+
+- **Real ADC interfacing** (e.g. TI ADC12DJ5200RF). Simulated only.
+- **Image rendering** of the envelope. CSV is the deliverable; turning
+  it into a PNG is a separate concern.
+- **Multi-channel demonstration**. Single-channel for v0.6;
+  multi-channel becomes natural once
+  [`ChannelAligner`](https://github.com/stillwater-sc/mixed-precision-dsp/blob/main/include/sw/dsp/instrument/channel_aligner.hpp)
+  is fully exercised.
+
+Two further items are deferred from this PR but mentioned in the issue
+as future quality-of-life work:
+
+- **`EqualizerFilter` front-end** integration (calibration stage). The
+  scope DSP primitives are quite separable from calibration; landing
+  the calibration integration as a follow-up keeps the capstone
+  scoped.
+- **Selected mixed configurations** beyond the six uniform ones (e.g.
+  `Coeff=double, State=double, Sample=posit16`). Useful once the
+  pipeline is precision-sensitive — currently every combination
+  produces the same envelope.


### PR DESCRIPTION
## Summary
- Final integration of the digital-oscilloscope DSP primitives — the v0.6 capstone for the Digital Oscilloscope Demonstrator epic ([#133](https://github.com/stillwater-sc/mixed-precision-dsp/issues/133)).
- Pipeline: ADC sim → `EdgeTrigger` + `AutoTriggerWrapper` → `TriggerRingBuffer` → `PeakDetectDecimator` → `render_envelope` → `measurements` → CSV.
- Six uniform precision configs (double / float / posit32 / posit16 / cfloat32 / fixpnt<32,30>) produce **bit-identical envelopes** — the headline finding documented in the docs page.

## The headline finding
Scope DSP is precision-insensitive because the streaming path contains **no arithmetic on `SampleScalar` values**, only comparisons / min-max / copies. The measurement primitives accumulate in `double` regardless of input type. This is the structural opposite of the SDR demo and is the *intended* result — it verifies that the library's scope primitives respect the comparison-only contract the digital path of a real scope has.

## Two non-obvious pitfalls (captured in code + docs)
1. **Off-by-one trigger trap**: a naive `if (trigger.fire()) push_trigger() else push()` loop silently drops one sample per re-fire after the first trigger (because `push_trigger()` is a no-op in `Capturing` state). Fix: gate `push_trigger` on a `triggered` flag. Without the fix, period measurement reads ~19 samples instead of 20 (~5% high frequency bias).
2. **Square wave FP boundary**: `sin(2*pi*f*t) >= 0` is unstable at sample boundaries where `sin(k*pi)` returns tiny noise that flips sign unpredictably (`sin(6*pi)` came out positive on this build, shortening one low half-cycle). Replaced with an integer-phase counter.

## Mixed-precision sweep result
```
config               glitch?        peak  rise(samp)       rms   freq(MHz)     SNR(dB)
--------------------------------------------------------------------------------------
uniform_double          PASS       0.962        0.81     0.504      50.001         inf
uniform_float           PASS       0.962        0.81     0.504      50.001         inf
uniform_posit32         PASS       0.962        0.81     0.504      50.001         inf
uniform_posit16         PASS       0.962        0.81     0.504      50.001         inf
uniform_cfloat32        PASS       0.962        0.81     0.504      50.001         inf
uniform_fixpnt          PASS       0.962        0.81     0.504      50.001         inf
```

(Glitch_peak = 0.95 nominal, +0.012 noise. Rise time expected 0.8 samples — one-sample square edge with 10/90 → 0.8 samples. Frequency expected 50 MHz exactly.)

## 10 GSPS comparison
Per-stage timing prints `ns/sample` and compares to the 100 ps/sample target. Typical x86 core: ~309 ns/sample total → ~3000x off the target, as expected for a CPU vs ASIC.

## Changes
- `applications/scope_demo/scope_demo.cpp` — main app (~440 lines)
- `applications/scope_demo/CMakeLists.txt` — single-line `dsp_add_application`
- `applications/CMakeLists.txt` — `add_subdirectory(scope_demo)`
- `applications/README.md` — `Instrument/scope_demo` tree entry
- `docs-site/src/content/docs/instrument/scope-demo.md` — full walkthrough
- `docs-site/astro.config.mjs` — `Instrument Data Acquisition` sidebar entry

## Deferred (per issue)
- Real ADC interfacing — out of scope per issue
- Image rendering of the envelope — out of scope per issue
- Multi-channel — out of scope per issue
- `EqualizerFilter` calibration front-end — explicitly punted to keep this PR scoped; lands as a follow-up
- Mixed configurations beyond the six uniform ones — currently every combination produces the same envelope, so they'd be uninformative

## Test results
| Target            | gcc build | gcc test | clang build | clang test |
|-------------------|-----------|----------|-------------|------------|
| scope_demo        | OK        | runs end-to-end on demo signal | OK | runs end-to-end on demo signal |
| Full ctest (40)   | OK        | PASS     | OK          | PASS       |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Docs build green (Astro)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #152

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end oscilloscope demo application that simulates ADC input, runs trigger-based captures, decimation, envelope rendering, and DSP measurements; exports results and per-pixel envelope data to CSV.

* **Documentation**
  * Added an "Instrument Data Acquisition" section and a comprehensive scope-demo guide describing topology, test signals, measurement metrics, mixed-precision plans, and benchmark results.

* **Chores**
  * Registered the new application in the applications hierarchy and updated the Applications README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->