### PR TITLE
feat(spectrum): trace averaging modes (linear / exp / max-hold / min-hold / max-hold-N)

### DIFF
--- a/include/sw/dsp/spectrum/trace_averaging.hpp
+++ b/include/sw/dsp/spectrum/trace_averaging.hpp
@@ -102,7 +102,12 @@ public:
 				"TraceAverager: trace_length must be > 0");
 		switch (mode_) {
 			case Mode::Linear:
-				sum_.assign(trace_length, 0.0);
+				// dense_vector doesn't support .resize() / .assign(),
+				// so size is fixed at construction. Default-constructed
+				// sum_ is zero-sized; assign a properly-sized instance
+				// here. Other modes leave sum_ at size zero (it's
+				// never read for them).
+				sum_ = mtl::vec::dense_vector<double>(trace_length);
 				break;
 			case Mode::Exponential:
 				if (!(config > 0.0 && config <= 1.0))
@@ -263,6 +268,12 @@ private:
 		// Ring buffer entries don't need explicit zeroing because the
 		// `valid` bound in MaxHoldN's accept_sweep keeps the read
 		// confined to written entries.
+		// denormal_'s alternating-sign tracker keeps state across
+		// accept_sweep calls; reset() is supposed to return us to
+		// fresh-construction state, so reseed denormal_ as well.
+		// Otherwise a fresh and a reset averager would diverge by the
+		// 1e-8 AC sign on the first Exponential update after reset.
+		denormal_ = DenormalPrevention<SampleScalar>{};
 	}
 
 	std::size_t trace_length_;
@@ -272,8 +283,8 @@ private:
 	std::size_t sweeps_   = 0;
 	std::size_t ring_pos_ = 0;       // MaxHoldN write head
 
-	mtl::vec::dense_vector<SampleScalar>            current_;
-	std::vector<double>                              sum_;       // Linear
+	mtl::vec::dense_vector<SampleScalar>             current_;
+	mtl::vec::dense_vector<double>                   sum_;       // Linear
 	std::vector<mtl::vec::dense_vector<SampleScalar>> ring_;     // MaxHoldN
 	DenormalPrevention<SampleScalar>                 denormal_;  // Exponential IIR
 };

--- a/include/sw/dsp/spectrum/trace_averaging.hpp
+++ b/include/sw/dsp/spectrum/trace_averaging.hpp
@@ -37,7 +37,11 @@
 //     to SampleScalar on read.
 //   - Exponential: arithmetic in SampleScalar (single-pole IIR per
 //     bin); narrow types may show drift toward the alpha-quantization
-//     step, same dynamic as any leaky integrator.
+//     step, same dynamic as any leaky integrator. The IIR loop
+//     applies DenormalPrevention<SampleScalar> (a tiny alternating
+//     AC injection) on each update — no-op for posit / fixpnt, flushes
+//     denormals on IEEE float / double. Same pattern as the IIR
+//     stages in acquisition/nco.hpp and acquisition/halfband.hpp.
 //   - MaxHold / MinHold / MaxHoldN: comparison-only, precision-blind.
 //     The stored values are bit-exact copies of the input.
 //
@@ -52,6 +56,7 @@
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <cmath>
 #include <cstddef>
 #include <span>
 #include <stdexcept>
@@ -59,6 +64,7 @@
 #include <vector>
 #include <mtl/vec/dense_vector.hpp>
 #include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/math/denormal.hpp>
 
 namespace sw::dsp::spectrum {
 
@@ -109,9 +115,18 @@ public:
 			case Mode::MinHold:
 				break;
 			case Mode::MaxHoldN:
+				// Two checks: N >= 1 catches negatives, zero, and NaN
+				// (NaN >= 1 is false). Then config == floor(config)
+				// catches non-integer values like 2.5 — without this
+				// they'd silently truncate via the static_cast. NaN also
+				// fails this second check (NaN != NaN).
 				if (!(config >= 1.0))
 					throw std::invalid_argument(
 						"TraceAverager: MaxHoldN requires window N >= 1 (got "
+						+ std::to_string(config) + ")");
+				if (config != std::floor(config))
+					throw std::invalid_argument(
+						"TraceAverager: MaxHoldN requires integer-valued window N (got "
 						+ std::to_string(config) + ")");
 				window_n_ = static_cast<std::size_t>(config);
 				ring_.resize(window_n_);
@@ -153,14 +168,20 @@ public:
 					for (std::size_t i = 0; i < trace_length_; ++i)
 						current_[i] = trace[i];
 				} else {
-					// y[i] = alpha*x[i] + (1-alpha)*y[i-1]
+					// y[i] = alpha*x[i] + (1-alpha)*y[i-1] + denormal AC
 					// Computed in SampleScalar; alpha multiplied via
 					// the SampleScalar(double) ctor for type uniformity.
+					// `+ denormal_.ac()` injects a tiny alternating value
+					// that flushes accumulator denormals on IEEE types
+					// (no-op on posit / fixpnt). Same pattern as the IIR
+					// stages in nco.hpp / halfband.hpp / src.hpp.
 					const SampleScalar a = static_cast<SampleScalar>(alpha_);
 					const SampleScalar one_minus_a =
 						static_cast<SampleScalar>(1.0 - alpha_);
 					for (std::size_t i = 0; i < trace_length_; ++i)
-						current_[i] = a * trace[i] + one_minus_a * current_[i];
+						current_[i] = a * trace[i]
+						            + one_minus_a * current_[i]
+						            + denormal_.ac();
 				}
 				++sweeps_;
 				break;
@@ -254,6 +275,7 @@ private:
 	mtl::vec::dense_vector<SampleScalar>            current_;
 	std::vector<double>                              sum_;       // Linear
 	std::vector<mtl::vec::dense_vector<SampleScalar>> ring_;     // MaxHoldN
+	DenormalPrevention<SampleScalar>                 denormal_;  // Exponential IIR
 };
 
 } // namespace sw::dsp::spectrum

--- a/include/sw/dsp/spectrum/trace_averaging.hpp
+++ b/include/sw/dsp/spectrum/trace_averaging.hpp
@@ -1,0 +1,259 @@
+#pragma once
+// trace_averaging.hpp: spectrum-analyzer trace averaging modes.
+//
+// Where detector modes reduce *within* a bin (#177), trace averaging
+// reduces *across sweeps*. The same five-mode set found on commercial
+// analyzers:
+//
+//   Linear      - cumulative unweighted mean of all sweeps since reset.
+//                 The classic noise-floor smoother. O(1) memory beyond
+//                 the trace buffer; running sum accumulates in double
+//                 to keep narrow SampleScalar types from drifting.
+//   Exponential - single-pole IIR: y[n] = alpha*x[n] + (1-alpha)*y[n-1].
+//                 The "live" smoother that keeps tracking changes.
+//                 alpha in (0, 1]; lower alpha = more smoothing,
+//                 longer settling time.
+//   MaxHold     - element-wise max across all sweeps since reset.
+//                 Comparison-only, precision-blind.
+//   MinHold     - element-wise min across all sweeps since reset.
+//   MaxHoldN    - max-hold over a rolling window of the last N sweeps.
+//                 Stores N traces in a ring buffer; on each accept,
+//                 the output is the element-wise max over the ring.
+//                 Memory O(N * trace_length), time O(N * trace_length)
+//                 per accept.
+//
+// Linear is intentionally cumulative (not windowed). A windowed linear
+// average would need a ring buffer of N traces, identical in cost to
+// MaxHoldN but for a different reduction. Callers wanting "Linear N"
+// can approximate with Exponential at alpha = 1/N (matches the
+// effective time constant of an N-sweep moving average) and accept the
+// IIR boundary characteristics, or call accept_sweep() N times then
+// reset() for a strict batch. The simpler cumulative form serves the
+// noise-floor measurement use case directly.
+//
+// Mixed-precision contract:
+//   - Linear: running sum accumulates in double; current_trace() is
+//     filled by dividing the sum by sweeps_accumulated() and casting
+//     to SampleScalar on read.
+//   - Exponential: arithmetic in SampleScalar (single-pole IIR per
+//     bin); narrow types may show drift toward the alpha-quantization
+//     step, same dynamic as any leaky integrator.
+//   - MaxHold / MinHold / MaxHoldN: comparison-only, precision-blind.
+//     The stored values are bit-exact copies of the input.
+//
+// Edge cases:
+//   - Empty input span -> std::invalid_argument.
+//   - Length mismatch (input.size() != trace_length) -> invalid_argument.
+//   - Reading current_trace() before any accept_sweep() returns the
+//     mode's initial state (zeros for all modes; the value isn't
+//     meaningful until at least one sweep has been accepted, and
+//     sweeps_accumulated() == 0 distinguishes that case).
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp::spectrum {
+
+template <DspOrderedField SampleScalar>
+	requires ConvertibleToDouble<SampleScalar>
+class TraceAverager {
+public:
+	using sample_scalar = SampleScalar;
+
+	enum class Mode {
+		Linear,
+		Exponential,
+		MaxHold,
+		MinHold,
+		MaxHoldN
+	};
+
+	// trace_length: number of bins per sweep (must be > 0).
+	// mode:         averaging mode (see enum above).
+	// config:       mode-specific scalar parameter:
+	//                 MaxHoldN     -> window N >= 1 (cast from double)
+	//                 Exponential  -> alpha in (0, 1]
+	//                 Linear / MaxHold / MinHold -> ignored
+	//               Using `double` rather than std::size_t to carry
+	//               either an integer window or a fractional alpha
+	//               through one constructor argument.
+	TraceAverager(std::size_t trace_length,
+	              Mode mode,
+	              double config = 0.0)
+		: trace_length_(trace_length),
+		  mode_(mode),
+		  current_(trace_length) {
+		if (trace_length == 0)
+			throw std::invalid_argument(
+				"TraceAverager: trace_length must be > 0");
+		switch (mode_) {
+			case Mode::Linear:
+				sum_.assign(trace_length, 0.0);
+				break;
+			case Mode::Exponential:
+				if (!(config > 0.0 && config <= 1.0))
+					throw std::invalid_argument(
+						"TraceAverager: Exponential requires alpha in (0, 1] (got "
+						+ std::to_string(config) + ")");
+				alpha_ = config;
+				break;
+			case Mode::MaxHold:
+			case Mode::MinHold:
+				break;
+			case Mode::MaxHoldN:
+				if (!(config >= 1.0))
+					throw std::invalid_argument(
+						"TraceAverager: MaxHoldN requires window N >= 1 (got "
+						+ std::to_string(config) + ")");
+				window_n_ = static_cast<std::size_t>(config);
+				ring_.resize(window_n_);
+				for (auto& t : ring_)
+					t = mtl::vec::dense_vector<SampleScalar>(trace_length);
+				break;
+		}
+		reset_state();
+	}
+
+	// Push a new sweep into the averager. Throws on length mismatch.
+	void accept_sweep(std::span<const SampleScalar> trace) {
+		if (trace.size() != trace_length_)
+			throw std::invalid_argument(
+				"TraceAverager::accept_sweep: trace length "
+				+ std::to_string(trace.size())
+				+ " does not match averager's trace_length "
+				+ std::to_string(trace_length_));
+
+		switch (mode_) {
+			case Mode::Linear:
+				for (std::size_t i = 0; i < trace_length_; ++i)
+					sum_[i] += static_cast<double>(trace[i]);
+				++sweeps_;
+				// current_ holds the running mean, recomputed on every
+				// accept. For mixed precision this is the cleanest
+				// place to do the divide-and-cast: the accumulator
+				// stays in double, current_ stays in SampleScalar.
+				for (std::size_t i = 0; i < trace_length_; ++i)
+					current_[i] = static_cast<SampleScalar>(
+						sum_[i] / static_cast<double>(sweeps_));
+				break;
+
+			case Mode::Exponential:
+				if (sweeps_ == 0) {
+					// First sweep seeds the IIR state directly. Blending
+					// with zero would mistakenly drag the first output
+					// toward zero by (1 - alpha).
+					for (std::size_t i = 0; i < trace_length_; ++i)
+						current_[i] = trace[i];
+				} else {
+					// y[i] = alpha*x[i] + (1-alpha)*y[i-1]
+					// Computed in SampleScalar; alpha multiplied via
+					// the SampleScalar(double) ctor for type uniformity.
+					const SampleScalar a = static_cast<SampleScalar>(alpha_);
+					const SampleScalar one_minus_a =
+						static_cast<SampleScalar>(1.0 - alpha_);
+					for (std::size_t i = 0; i < trace_length_; ++i)
+						current_[i] = a * trace[i] + one_minus_a * current_[i];
+				}
+				++sweeps_;
+				break;
+
+			case Mode::MaxHold:
+				if (sweeps_ == 0) {
+					for (std::size_t i = 0; i < trace_length_; ++i)
+						current_[i] = trace[i];
+				} else {
+					for (std::size_t i = 0; i < trace_length_; ++i)
+						if (trace[i] > current_[i]) current_[i] = trace[i];
+				}
+				++sweeps_;
+				break;
+
+			case Mode::MinHold:
+				if (sweeps_ == 0) {
+					for (std::size_t i = 0; i < trace_length_; ++i)
+						current_[i] = trace[i];
+				} else {
+					for (std::size_t i = 0; i < trace_length_; ++i)
+						if (trace[i] < current_[i]) current_[i] = trace[i];
+				}
+				++sweeps_;
+				break;
+
+			case Mode::MaxHoldN: {
+				// Push the new sweep into the ring at ring_pos_; the
+				// oldest sweep there is overwritten. Then compute the
+				// element-wise max over the (up to window_n_) valid
+				// ring entries. Until window_n_ sweeps have been seen
+				// the ring is partially populated; iterate over the
+				// valid prefix only.
+				for (std::size_t i = 0; i < trace_length_; ++i)
+					ring_[ring_pos_][i] = trace[i];
+				ring_pos_ = (ring_pos_ + 1) % window_n_;
+				++sweeps_;
+				const std::size_t valid =
+					sweeps_ < window_n_ ? sweeps_ : window_n_;
+				// Seed current_ from the first valid ring entry, then
+				// max in the rest. Using `valid` as the bound prevents
+				// uninitialized ring entries from corrupting the output
+				// during ring fill-up.
+				for (std::size_t i = 0; i < trace_length_; ++i)
+					current_[i] = ring_[0][i];
+				for (std::size_t k = 1; k < valid; ++k)
+					for (std::size_t i = 0; i < trace_length_; ++i)
+						if (ring_[k][i] > current_[i])
+							current_[i] = ring_[k][i];
+				break;
+			}
+		}
+	}
+
+	// Read the current accumulated trace. Length always equals
+	// trace_length(); content is meaningless when sweeps_accumulated() == 0.
+	[[nodiscard]] std::span<const SampleScalar> current_trace() const {
+		return std::span<const SampleScalar>(current_.data(), trace_length_);
+	}
+
+	// Discard accumulated state and return to the construction-time
+	// initial state. Mode and config (alpha / window_n) are preserved.
+	void reset() { reset_state(); }
+
+	[[nodiscard]] std::size_t sweeps_accumulated() const { return sweeps_; }
+	[[nodiscard]] std::size_t trace_length()       const { return trace_length_; }
+	[[nodiscard]] Mode        mode()               const { return mode_; }
+
+private:
+	void reset_state() {
+		sweeps_ = 0;
+		ring_pos_ = 0;
+		// Zero current_ so a read-before-accept returns a defined value.
+		for (std::size_t i = 0; i < trace_length_; ++i)
+			current_[i] = SampleScalar{};
+		if (mode_ == Mode::Linear) {
+			for (std::size_t i = 0; i < trace_length_; ++i) sum_[i] = 0.0;
+		}
+		// Ring buffer entries don't need explicit zeroing because the
+		// `valid` bound in MaxHoldN's accept_sweep keeps the read
+		// confined to written entries.
+	}
+
+	std::size_t trace_length_;
+	Mode        mode_;
+	std::size_t window_n_ = 0;       // MaxHoldN
+	double      alpha_    = 0.0;     // Exponential
+	std::size_t sweeps_   = 0;
+	std::size_t ring_pos_ = 0;       // MaxHoldN write head
+
+	mtl::vec::dense_vector<SampleScalar>            current_;
+	std::vector<double>                              sum_;       // Linear
+	std::vector<mtl::vec::dense_vector<SampleScalar>> ring_;     // MaxHoldN
+};
+
+} // namespace sw::dsp::spectrum

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,7 +68,8 @@ dsp_add_test(test_bluestein       "Tests/Spectral")
 # Spectrum = analyzer-specific stages between those transforms and the
 # trace memory).
 # =============================================================================
-dsp_add_test(test_spectrum_detectors "Tests/Spectrum")
+dsp_add_test(test_spectrum_detectors        "Tests/Spectrum")
+dsp_add_test(test_spectrum_trace_averaging  "Tests/Spectrum")
 
 # =============================================================================
 # Conditioning — AGC, compressor, envelope, sample-rate conversion, noise shaping

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,8 +41,9 @@ Tests/
 │   ├── test_fft
 │   ├── test_spectral            Z-transform, Laplace, PSD, spectrogram
 │   └── test_bluestein           Chirp-z arbitrary-length DFT
-├── Spectrum/                    Spectrum-analyzer-specific primitives
-│   └── test_spectrum_detectors  Peak / sample / average / RMS / neg-peak
+├── Spectrum/                       Spectrum-analyzer-specific primitives
+│   ├── test_spectrum_detectors        Peak / sample / average / RMS / neg-peak
+│   └── test_spectrum_trace_averaging  Linear / exp / max-hold / min-hold / max-N
 ├── Conditioning/
 │   ├── test_conditioning        AGC, compressor, envelope detector
 │   ├── test_src                 Rational sample-rate conversion

--- a/tests/test_spectrum_trace_averaging.cpp
+++ b/tests/test_spectrum_trace_averaging.cpp
@@ -1,0 +1,298 @@
+// test_spectrum_trace_averaging.cpp: tests for the spectrum-analyzer
+// trace-averaging modes (linear / exponential / max-hold / min-hold /
+// max-hold-N).
+//
+// Coverage:
+//   - Linear convergence: cumulative mean approaches the true mean
+//     when the input is signal + zero-mean noise
+//   - Exponential settling: alpha=0.1 step response settles toward the
+//     new value at a known rate
+//   - MaxHold preserves peaks across sweeps
+//   - MinHold preserves troughs across sweeps
+//   - MaxHoldN forgets a peak after the rolling window slides past it
+//   - reset() clears state; sweeps_accumulated() reports correctly
+//   - Validation: empty input, length mismatch, invalid alpha, invalid N
+//   - Mixed-precision sanity: float input gives reasonable averages
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <random>
+#include <span>
+#include <stdexcept>
+#include <string>
+
+#include <sw/dsp/spectrum/trace_averaging.hpp>
+
+using namespace sw::dsp::spectrum;
+using DA = TraceAverager<double>;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+static bool approx(double a, double b, double tol) {
+	return std::abs(a - b) <= tol;
+}
+
+// ============================================================================
+// Linear: cumulative mean converges to the true signal under noise
+// ============================================================================
+
+void test_linear_converges_to_truth() {
+	const std::size_t N_BINS  = 8;
+	const std::size_t N_SWEEPS = 1000;
+	const double truth = 5.0;
+
+	DA avg(N_BINS, DA::Mode::Linear);
+	std::mt19937 rng(0xACDC);
+	std::normal_distribution<double> noise(0.0, 1.0);
+
+	std::array<double, 8> sweep{};
+	for (std::size_t s = 0; s < N_SWEEPS; ++s) {
+		for (std::size_t i = 0; i < N_BINS; ++i)
+			sweep[i] = truth + noise(rng);
+		avg.accept_sweep(std::span<const double>{sweep});
+	}
+	REQUIRE(avg.sweeps_accumulated() == N_SWEEPS);
+	auto out = avg.current_trace();
+	for (std::size_t i = 0; i < N_BINS; ++i) {
+		// stddev of the sample mean is sigma / sqrt(N) = 1/sqrt(1000) ~= 0.032,
+		// so |mean - truth| should be well under 0.2 for any one bin.
+		REQUIRE(approx(out[i], truth, 0.2));
+	}
+	std::cout << "  linear_converges_to_truth: passed (out[0]=" << out[0] << ")\n";
+}
+
+// ============================================================================
+// Exponential: settles toward a new value at a known rate
+// ============================================================================
+
+void test_exponential_step_settling() {
+	// alpha=0.1: after k sweeps of constant input, the running output is
+	// 1 - (1-alpha)^k of the way from 0 to the input. After ~50 sweeps,
+	// (1-0.1)^50 ~= 0.005, so the output should be within 0.5% of input.
+	//
+	// First-sweep seeding rule: y[0] = x[0] (no blend with zero), so we
+	// expect y[0] = step value exactly.
+	const double STEP = 10.0;
+	DA avg(1, DA::Mode::Exponential, /*alpha=*/0.1);
+
+	std::array<double, 1> sweep = {STEP};
+	avg.accept_sweep(std::span<const double>{sweep});
+	REQUIRE(approx(avg.current_trace()[0], STEP, 1e-12));   // first-sweep seed
+
+	// 50 more sweeps at the same value: output stays at STEP.
+	for (int k = 0; k < 50; ++k)
+		avg.accept_sweep(std::span<const double>{sweep});
+	REQUIRE(approx(avg.current_trace()[0], STEP, 1e-9));
+
+	// Now drop the input to 0; after 50 sweeps the output should be
+	// near (1-0.1)^50 * STEP ~= 0.052.
+	std::array<double, 1> zero = {0.0};
+	for (int k = 0; k < 50; ++k)
+		avg.accept_sweep(std::span<const double>{zero});
+	const double expected = std::pow(0.9, 50) * STEP;
+	REQUIRE(approx(avg.current_trace()[0], expected, expected * 0.01));   // 1% tol
+	std::cout << "  exponential_step_settling: passed (decay= "
+	          << avg.current_trace()[0] << " vs expected " << expected << ")\n";
+}
+
+// ============================================================================
+// MaxHold: preserves peaks across sweeps
+// ============================================================================
+
+void test_max_hold_preserves_peaks() {
+	// Three sweeps, each with a peak at a different bin position.
+	// Output after all three should have all three peaks.
+	const std::size_t N = 5;
+	DA avg(N, DA::Mode::MaxHold);
+	std::array<double, 5> a = {1.0, 0.0, 0.0, 0.0, 0.0};
+	std::array<double, 5> b = {0.0, 0.0, 2.0, 0.0, 0.0};
+	std::array<double, 5> c = {0.0, 0.0, 0.0, 0.0, 3.0};
+	avg.accept_sweep(std::span<const double>{a});
+	avg.accept_sweep(std::span<const double>{b});
+	avg.accept_sweep(std::span<const double>{c});
+	auto out = avg.current_trace();
+	REQUIRE(out[0] == 1.0);
+	REQUIRE(out[1] == 0.0);
+	REQUIRE(out[2] == 2.0);
+	REQUIRE(out[3] == 0.0);
+	REQUIRE(out[4] == 3.0);
+	std::cout << "  max_hold_preserves_peaks: passed\n";
+}
+
+// ============================================================================
+// MinHold: preserves troughs (negative peaks)
+// ============================================================================
+
+void test_min_hold_preserves_troughs() {
+	const std::size_t N = 4;
+	DA avg(N, DA::Mode::MinHold);
+	std::array<double, 4> a = {0.0, -1.0, 0.0, 0.0};
+	std::array<double, 4> b = {-2.0, 0.0, 0.0, 0.0};
+	std::array<double, 4> c = {0.0, 0.0, 0.0, -3.0};
+	avg.accept_sweep(std::span<const double>{a});
+	avg.accept_sweep(std::span<const double>{b});
+	avg.accept_sweep(std::span<const double>{c});
+	auto out = avg.current_trace();
+	REQUIRE(out[0] == -2.0);
+	REQUIRE(out[1] == -1.0);
+	REQUIRE(out[2] == 0.0);
+	REQUIRE(out[3] == -3.0);
+	std::cout << "  min_hold_preserves_troughs: passed\n";
+}
+
+// ============================================================================
+// MaxHoldN: forgets old peaks after the rolling window slides past
+// ============================================================================
+
+void test_max_hold_n_forgets_old_peaks() {
+	// Window N=3: a peak inserted at sweep 0 should disappear from the
+	// output after 3 sweeps of zero, because the ring no longer contains
+	// the peak. (Sweeps 0, 1, 2 cover the peak; from sweep 3 onward the
+	// peak has been overwritten.)
+	const std::size_t N_BINS = 4;
+	DA avg(N_BINS, DA::Mode::MaxHoldN, /*window=*/3.0);
+
+	std::array<double, 4> peak  = {0.0, 0.0, 5.0, 0.0};
+	std::array<double, 4> zero4 = {0.0, 0.0, 0.0, 0.0};
+
+	// Sweep 0: peak. Output reflects peak.
+	avg.accept_sweep(std::span<const double>{peak});
+	REQUIRE(avg.current_trace()[2] == 5.0);
+
+	// Sweeps 1-2: zeros. Window still includes sweep 0; peak persists.
+	avg.accept_sweep(std::span<const double>{zero4});
+	avg.accept_sweep(std::span<const double>{zero4});
+	REQUIRE(avg.current_trace()[2] == 5.0);
+
+	// Sweep 3: zeros. Ring is now [zero, zero, zero] (sweep 0 evicted).
+	// Peak is gone.
+	avg.accept_sweep(std::span<const double>{zero4});
+	REQUIRE(avg.current_trace()[2] == 0.0);
+	REQUIRE(avg.sweeps_accumulated() == 4);
+	std::cout << "  max_hold_n_forgets_old_peaks: passed\n";
+}
+
+// ============================================================================
+// reset() clears state
+// ============================================================================
+
+void test_reset_clears_state() {
+	DA avg(3, DA::Mode::Linear);
+	std::array<double, 3> a = {1.0, 2.0, 3.0};
+	avg.accept_sweep(std::span<const double>{a});
+	avg.accept_sweep(std::span<const double>{a});
+	REQUIRE(avg.sweeps_accumulated() == 2);
+	REQUIRE(approx(avg.current_trace()[1], 2.0, 1e-12));
+
+	avg.reset();
+	REQUIRE(avg.sweeps_accumulated() == 0);
+	for (auto v : avg.current_trace()) REQUIRE(v == 0.0);
+
+	// Re-accumulating after reset starts from zero state.
+	std::array<double, 3> b = {10.0, 20.0, 30.0};
+	avg.accept_sweep(std::span<const double>{b});
+	REQUIRE(approx(avg.current_trace()[0], 10.0, 1e-12));
+	REQUIRE(avg.sweeps_accumulated() == 1);
+	std::cout << "  reset_clears_state: passed\n";
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+void test_construction_validation() {
+	bool t1 = false, t2 = false, t3 = false, t4 = false, t5 = false;
+
+	try { DA(0, DA::Mode::Linear); }
+	catch (const std::invalid_argument&) { t1 = true; }
+	REQUIRE(t1);
+
+	// Exponential: alpha out of range (zero, negative, > 1).
+	try { DA(4, DA::Mode::Exponential, 0.0); }
+	catch (const std::invalid_argument&) { t2 = true; }
+	REQUIRE(t2);
+
+	try { DA(4, DA::Mode::Exponential, -0.1); }
+	catch (const std::invalid_argument&) { t3 = true; }
+	REQUIRE(t3);
+
+	try { DA(4, DA::Mode::Exponential, 1.5); }
+	catch (const std::invalid_argument&) { t4 = true; }
+	REQUIRE(t4);
+
+	// MaxHoldN: window N < 1
+	try { DA(4, DA::Mode::MaxHoldN, 0.0); }
+	catch (const std::invalid_argument&) { t5 = true; }
+	REQUIRE(t5);
+
+	std::cout << "  construction_validation: passed\n";
+}
+
+void test_accept_sweep_length_mismatch_throws() {
+	DA avg(8, DA::Mode::MaxHold);
+	std::array<double, 7> wrong{};
+	bool threw = false;
+	try { avg.accept_sweep(std::span<const double>{wrong}); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  accept_sweep_length_mismatch_throws: passed\n";
+}
+
+// ============================================================================
+// Mixed-precision sanity: float input
+// ============================================================================
+
+void test_float_linear() {
+	using FA = TraceAverager<float>;
+	FA avg(4, FA::Mode::Linear);
+	std::array<float, 4> a = {1.0f, 2.0f, 3.0f, 4.0f};
+	std::array<float, 4> b = {3.0f, 4.0f, 5.0f, 6.0f};
+	avg.accept_sweep(std::span<const float>{a});
+	avg.accept_sweep(std::span<const float>{b});
+	auto out = avg.current_trace();
+	// Means should be (1+3)/2=2, (2+4)/2=3, (3+5)/2=4, (4+6)/2=5.
+	REQUIRE(approx(static_cast<double>(out[0]), 2.0, 1e-6));
+	REQUIRE(approx(static_cast<double>(out[1]), 3.0, 1e-6));
+	REQUIRE(approx(static_cast<double>(out[2]), 4.0, 1e-6));
+	REQUIRE(approx(static_cast<double>(out[3]), 5.0, 1e-6));
+	std::cout << "  float_linear: passed\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_spectrum_trace_averaging\n";
+
+		test_linear_converges_to_truth();
+		test_exponential_step_settling();
+		test_max_hold_preserves_peaks();
+		test_min_hold_preserves_troughs();
+		test_max_hold_n_forgets_old_peaks();
+
+		test_reset_clears_state();
+
+		test_construction_validation();
+		test_accept_sweep_length_mismatch_throws();
+
+		test_float_linear();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}

--- a/tests/test_spectrum_trace_averaging.cpp
+++ b/tests/test_spectrum_trace_averaging.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iostream>
+#include <limits>
 #include <random>
 #include <span>
 #include <stdexcept>
@@ -89,10 +90,14 @@ void test_exponential_step_settling() {
 	avg.accept_sweep(std::span<const double>{sweep});
 	REQUIRE(approx(avg.current_trace()[0], STEP, 1e-12));   // first-sweep seed
 
-	// 50 more sweeps at the same value: output stays at STEP.
+	// 50 more sweeps at the same value: output stays at STEP. Tolerance
+	// is loose because the denormal AC injection (alternating +/- 1e-8
+	// per step) introduces small transient ripple even at steady state;
+	// the mean error is zero but the instantaneous error is bounded by
+	// ~1e-7 for alpha = 0.1.
 	for (int k = 0; k < 50; ++k)
 		avg.accept_sweep(std::span<const double>{sweep});
-	REQUIRE(approx(avg.current_trace()[0], STEP, 1e-9));
+	REQUIRE(approx(avg.current_trace()[0], STEP, 1e-6));
 
 	// Now drop the input to 0; after 50 sweeps the output should be
 	// near (1-0.1)^50 * STEP ~= 0.052.
@@ -211,7 +216,7 @@ void test_reset_clears_state() {
 // ============================================================================
 
 void test_construction_validation() {
-	bool t1 = false, t2 = false, t3 = false, t4 = false, t5 = false;
+	bool t1=false, t2=false, t3=false, t4=false, t5=false, t6=false, t7=false;
 
 	try { DA(0, DA::Mode::Linear); }
 	catch (const std::invalid_argument&) { t1 = true; }
@@ -234,6 +239,19 @@ void test_construction_validation() {
 	try { DA(4, DA::Mode::MaxHoldN, 0.0); }
 	catch (const std::invalid_argument&) { t5 = true; }
 	REQUIRE(t5);
+
+	// MaxHoldN: fractional window (would silently truncate via static_cast
+	// without explicit integer-valued validation).
+	try { DA(4, DA::Mode::MaxHoldN, 2.5); }
+	catch (const std::invalid_argument&) { t6 = true; }
+	REQUIRE(t6);
+
+	// MaxHoldN: NaN window (NaN >= 1 is false, so the first check fires;
+	// belt-and-suspenders).
+	try { DA(4, DA::Mode::MaxHoldN,
+	         std::numeric_limits<double>::quiet_NaN()); }
+	catch (const std::invalid_argument&) { t7 = true; }
+	REQUIRE(t7);
 
 	std::cout << "  construction_validation: passed\n";
 }


### PR DESCRIPTION
## Summary
- Second sub-issue under #134 (Epic: Spectrum Analyzer Demonstrator). Adds the sweep-to-sweep accumulation stage of the analyzer.
- Where detector modes (#177) reduce *within* a bin, trace averaging reduces *across* sweeps.

## API
```cpp
template <DspOrderedField SampleScalar>
class TraceAverager {
public:
    enum class Mode { Linear, Exponential, MaxHold, MinHold, MaxHoldN };
    TraceAverager(std::size_t trace_length, Mode mode, double config = 0.0);

    void accept_sweep(std::span<const SampleScalar> trace);
    std::span<const SampleScalar> current_trace() const;
    void reset();
    std::size_t sweeps_accumulated() const;
};
```

## Design notes
- **Constructor `config` parameter**: deviates slightly from the issue draft's `std::size_t window_n = 0`. Reason: `window_n` can't carry a fractional alpha for Exponential mode. `double config` carries either the window N (MaxHoldN, cast to size_t) or alpha (Exponential, in (0, 1]). Validated in the constructor.
- **Linear is cumulative, not windowed**. A windowed linear average needs a ring buffer of N traces, identical in cost to MaxHoldN but for a different reduction. Cumulative serves the noise-floor measurement use case directly; callers wanting "Linear N" can approximate via Exponential at α=1/N. Documented in the header.
- **First-sweep seeding** for Exponential / MaxHold / MinHold: y[0] = x[0], not blended with zero. Otherwise the first output is incorrectly dragged toward zero by (1−α) (Exponential) or clamped against the zero-init state (MaxHold/MinHold of mixed-sign signals).

## Mixed-precision contract
- Linear: running sum accumulates in `double`; output cast to SampleScalar.
- Exponential: arithmetic in SampleScalar (single-pole IIR per bin).
- MaxHold / MinHold / MaxHoldN: comparison-only, precision-blind.

## Changes
- `include/sw/dsp/spectrum/trace_averaging.hpp` — new module (~190 lines)
- `tests/test_spectrum_trace_averaging.cpp` — 9 sub-tests (~250 lines)
- `tests/CMakeLists.txt` — register test under Tests/Spectrum
- `tests/README.md` — Spectrum entry updated

## Test results
| Target                                  | gcc build | gcc test | clang build | clang test |
|-----------------------------------------|-----------|----------|-------------|------------|
| test_spectrum_trace_averaging           | OK        | 9/9 PASS | OK          | 9/9 PASS   |
| Full ctest (42 tests)                   | OK        | 42/42    | OK          | 42/42      |

Coverage: linear convergence under noise (mean within σ/√N), exponential step settling at α=0.1 matching the analytical (1−α)^k decay, max-hold preserves peaks across sweeps, min-hold preserves troughs, max-hold-N forgets old peaks after the rolling window slides past, reset clears state, construction validation for invalid inputs, float-input sanity.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #178

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trace averaging for spectrum sweeps with five modes: linear cumulative, exponential smoothing, max-hold, min-hold, and rolling-window max; preserves mode/config across resets and reports accumulated sweeps.

* **Tests**
  * Added comprehensive tests covering all modes, parameter validation, reset behavior, input-length error handling, eviction for rolling window, and mixed-precision checks.

* **Documentation**
  * Updated test docs to describe the new averaging modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->