### PR TITLE
feat(spectrum): marker / peak-find utilities

### DIFF
--- a/include/sw/dsp/spectrum/markers.hpp
+++ b/include/sw/dsp/spectrum/markers.hpp
@@ -169,9 +169,12 @@ template <DspOrderedField T>
 	              return a.bin < b.bin;
 	          });
 
-	// Step 3: greedy-select with min-separation.
+	// Step 3: greedy-select with min-separation. Reserve only what we
+	// could actually produce — capped by the number of candidates so a
+	// caller asking for top_n=10000 from a trace with 5 local maxes
+	// doesn't get a 10000-slot allocation.
 	std::vector<Marker> out;
-	out.reserve(top_n);
+	out.reserve(std::min(top_n, candidates.size()));
 	for (const auto& c : candidates) {
 		if (out.size() >= top_n) break;
 		bool too_close = false;
@@ -229,9 +232,18 @@ template <DspOrderedField T>
 			+ std::to_string(fundamental_hz) + ")");
 	if (trace.empty() || harmonics == 0) return {};
 
+	// Reserve only what we could possibly produce: the user-requested
+	// harmonics count, capped by trace.size() (we can't return more
+	// markers than the trace has bins). Avoids huge allocations when
+	// a caller passes harmonics = SIZE_MAX or similar.
 	std::vector<Marker> out;
-	out.reserve(harmonics);
-	for (std::size_t k = 2; k < 2 + harmonics; ++k) {
+	out.reserve(std::min(harmonics, trace.size()));
+	// Loop on an index `i` in [0, harmonics) and derive k = i + 2 inside
+	// the body. The earlier form `k < 2 + harmonics` could overflow for
+	// extreme harmonics values (2 + SIZE_MAX wraps). Indexing on i
+	// keeps the bound clean.
+	for (std::size_t i = 0; i < harmonics; ++i) {
+		const std::size_t k = i + 2;
 		const double target_freq = static_cast<double>(k) * fundamental_hz;
 		const double target_bin_d = target_freq / bin_freq_step_hz;
 		// Round to nearest. std::lround would also work; using

--- a/include/sw/dsp/spectrum/markers.hpp
+++ b/include/sw/dsp/spectrum/markers.hpp
@@ -246,12 +246,20 @@ template <DspOrderedField T>
 		const std::size_t k = i + 2;
 		const double target_freq = static_cast<double>(k) * fundamental_hz;
 		const double target_bin_d = target_freq / bin_freq_step_hz;
-		// Round to nearest. std::lround would also work; using
-		// floor(x + 0.5) avoids platform-specific banker's rounding.
-		const std::size_t target_bin =
-			static_cast<std::size_t>(std::floor(target_bin_d + 0.5));
-		if (target_bin >= trace.size()) break;   // remaining harmonics out of range
+		// Round to nearest in double. std::lround would also work;
+		// using floor(x + 0.5) avoids platform-specific banker's
+		// rounding.
+		const double rounded = std::floor(target_bin_d + 0.5);
+		// Guard the size_t cast: casting a non-finite or out-of-range
+		// double to size_t is implementation-defined (or UB on some
+		// platforms). For huge harmonics counts (k near SIZE_MAX),
+		// target_bin_d can be a finite-but-enormous double that the
+		// cast would silently wrap. Range-check in double space first.
+		if (!std::isfinite(rounded) || rounded < 0.0 ||
+		    rounded >= static_cast<double>(trace.size()))
+			break;   // remaining harmonics out of range
 
+		const std::size_t target_bin = static_cast<std::size_t>(rounded);
 		Marker m;
 		m.bin_index    = target_bin;
 		m.frequency_hz = static_cast<double>(target_bin) * bin_freq_step_hz;

--- a/include/sw/dsp/spectrum/markers.hpp
+++ b/include/sw/dsp/spectrum/markers.hpp
@@ -1,0 +1,254 @@
+#pragma once
+// markers.hpp: spectrum-analyzer marker / peak-find utilities.
+//
+// The "what's interesting in this trace?" stage. Three free functions
+// answer the analyst's headline questions:
+//
+//   find_peaks         - top-N strongest spectral lines, with a
+//                        minimum-separation rule to suppress local-max
+//                        chatter on noisy traces. Sub-bin frequency
+//                        position recovered via parabolic interpolation
+//                        across the three samples around each peak.
+//   harmonic_markers   - given a fundamental frequency, return markers
+//                        at the bins nearest k*fundamental for k=2..N.
+//                        No peak search around the target bin; the
+//                        caller composes with find_peaks if they want
+//                        peak-snapped harmonics.
+//   make_delta_marker  - difference of two markers (frequency and
+//                        amplitude). The delta-marker measurement
+//                        every commercial analyzer ships.
+//
+// All functions are stateless reducers over a span of trace samples.
+// The trace is typically already in a log scale (dB) by this stage,
+// so amplitude comparisons are meaningful as-is.
+//
+// Mixed-precision contract:
+//   - Amplitude comparisons (peak detection, top-N selection) run in
+//     T per DspOrderedField.
+//   - Sub-bin parabolic interpolation accumulates in double regardless
+//     of T; the returned `frequency_hz` is always double.
+//   - Marker / DeltaMarker fields are double for type-uniformity
+//     across the analyzer's reporting layer.
+//
+// Edge cases:
+//   - Empty trace -> returns empty vector (no peaks possible).
+//   - top_n == 0 -> returns empty vector.
+//   - harmonics == 0 -> returns empty vector.
+//   - trace.size() == 1 -> the single bin is a peak iff trace[0] is
+//     consulted (no neighbors to compare); we treat it as a peak with
+//     no sub-bin offset.
+//   - bin_freq_step_hz <= 0 -> std::invalid_argument.
+//   - fundamental_hz <= 0 -> std::invalid_argument.
+//   - Edge bins (i = 0 or N-1) are flagged as peaks if higher than
+//     their single neighbor; sub-bin interpolation is skipped (no
+//     parabola fits with only two points).
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp::spectrum {
+
+// A single marker on the trace: which bin, what frequency, what amplitude.
+//
+// `bin_index` is the integer bin nearest the marker. `frequency_hz`
+// reflects the sub-bin-interpolated position when applicable; for
+// markers at edge bins (or with degenerate parabolic fits) it equals
+// `bin_index * bin_freq_step_hz`.
+struct Marker {
+	std::size_t bin_index    = 0;
+	double      frequency_hz = 0.0;
+	double      amplitude    = 0.0;
+};
+
+// Two-marker measurement standard. Delta values are b minus a.
+struct DeltaMarker {
+	Marker a;
+	Marker b;
+	double delta_freq_hz   = 0.0;
+	double delta_amplitude = 0.0;
+};
+
+namespace detail {
+
+// Parabolic interpolation for sub-bin peak position. Given samples
+// y_left = y[i-1], y_center = y[i], y_right = y[i+1] around a local
+// max at bin i, the parabolic vertex sits at fractional offset
+//
+//     delta = 0.5 * (y_left - y_right) / (y_left - 2*y_center + y_right)
+//
+// from the center bin. delta is in [-0.5, +0.5] for a true local max.
+// If the denominator is degenerate (flat top), returns 0.
+inline double parabolic_offset(double y_left, double y_center, double y_right) {
+	const double denom = y_left - 2.0 * y_center + y_right;
+	// Exact-zero guard: see the same convention in
+	// instrument/measurements::interp_crossing.
+	if (denom == 0.0) return 0.0;
+	const double offset = 0.5 * (y_left - y_right) / denom;
+	// Clamp to [-0.5, +0.5] — values outside that range mean the
+	// quadratic fit is no longer locally a maximum (e.g., due to
+	// rounding noise on a flat region) and the integer bin position
+	// is the most honest answer.
+	if (offset < -0.5) return -0.5;
+	if (offset >  0.5) return  0.5;
+	return offset;
+}
+
+// Local-max detection: bin i is a peak iff it dominates its neighbors.
+// Edge bins (i=0 or i=N-1) need special handling — only one neighbor.
+template <typename T>
+inline bool is_local_max(std::span<const T> trace, std::size_t i) {
+	const std::size_t n = trace.size();
+	if (n == 0) return false;
+	if (n == 1) return true;
+	if (i == 0)        return trace[0]   > trace[1];
+	if (i == n - 1)    return trace[n-1] > trace[n-2];
+	return trace[i] > trace[i-1] && trace[i] > trace[i+1];
+}
+
+} // namespace detail
+
+// Top-N strongest peaks with a minimum-separation rule.
+//
+// Algorithm:
+//   1. Identify all local maxima in the trace (including edges).
+//   2. Sort them by amplitude descending.
+//   3. Greedy-select: take the strongest, then walk down the list and
+//      pick each next-strongest peak that's at least
+//      `min_separation_bins` away from any already-selected peak.
+//      Repeat until top_n peaks are selected or the list is exhausted.
+//
+// The greedy step is what suppresses local-max chatter on noisy
+// traces — without it a single broad peak straddling several adjacent
+// bins would consume all top_n slots.
+//
+// Returned markers are in descending amplitude order (selection order).
+// Sub-bin frequency interpolation is applied via a parabolic fit
+// across the three bins around each peak; edge bins skip interpolation.
+template <DspOrderedField T>
+	requires ConvertibleToDouble<T>
+[[nodiscard]] std::vector<Marker> find_peaks(
+		std::span<const T> trace,
+		double bin_freq_step_hz,
+		std::size_t top_n,
+		std::size_t min_separation_bins = 3) {
+	if (!(bin_freq_step_hz > 0.0))
+		throw std::invalid_argument(
+			"find_peaks: bin_freq_step_hz must be positive (got "
+			+ std::to_string(bin_freq_step_hz) + ")");
+	if (trace.empty() || top_n == 0) return {};
+
+	// Step 1: collect (bin_index, amplitude) pairs for every local max.
+	struct Candidate { std::size_t bin; double amp; };
+	std::vector<Candidate> candidates;
+	candidates.reserve(trace.size() / 4 + 4);   // rough upper bound
+	for (std::size_t i = 0; i < trace.size(); ++i) {
+		if (detail::is_local_max(trace, i))
+			candidates.push_back({i, static_cast<double>(trace[i])});
+	}
+
+	// Step 2: sort by amplitude descending. Use a stable order on ties
+	// (lower bin first) so the result is deterministic.
+	std::sort(candidates.begin(), candidates.end(),
+	          [](const Candidate& a, const Candidate& b) {
+	              if (a.amp != b.amp) return a.amp > b.amp;
+	              return a.bin < b.bin;
+	          });
+
+	// Step 3: greedy-select with min-separation.
+	std::vector<Marker> out;
+	out.reserve(top_n);
+	for (const auto& c : candidates) {
+		if (out.size() >= top_n) break;
+		bool too_close = false;
+		for (const auto& sel : out) {
+			const std::size_t d = c.bin > sel.bin_index
+			                       ? c.bin - sel.bin_index
+			                       : sel.bin_index - c.bin;
+			if (d < min_separation_bins) { too_close = true; break; }
+		}
+		if (too_close) continue;
+
+		// Sub-bin parabolic interpolation. Skip for edge bins.
+		Marker m;
+		m.bin_index = c.bin;
+		m.amplitude = c.amp;
+		double offset = 0.0;
+		if (c.bin > 0 && c.bin + 1 < trace.size()) {
+			offset = detail::parabolic_offset(
+				static_cast<double>(trace[c.bin - 1]),
+				c.amp,
+				static_cast<double>(trace[c.bin + 1]));
+		}
+		m.frequency_hz = (static_cast<double>(c.bin) + offset) * bin_freq_step_hz;
+		out.push_back(m);
+	}
+	return out;
+}
+
+// Markers at the bins nearest k * fundamental_hz for k = 2..harmonics.
+//
+// No peak search around the target bin: this returns the trace value
+// at the rounded bin position. If the harmonic has drifted off-bin
+// (real-world noise or quantization), the caller composes this with
+// find_peaks() to peak-snap each harmonic in a small neighborhood.
+//
+// Harmonics that fall past the trace's frequency range are silently
+// omitted from the result (no out-of-range error).
+template <DspOrderedField T>
+	requires ConvertibleToDouble<T>
+[[nodiscard]] std::vector<Marker> harmonic_markers(
+		std::span<const T> trace,
+		double bin_freq_step_hz,
+		double fundamental_hz,
+		std::size_t harmonics) {
+	if (!(bin_freq_step_hz > 0.0))
+		throw std::invalid_argument(
+			"harmonic_markers: bin_freq_step_hz must be positive (got "
+			+ std::to_string(bin_freq_step_hz) + ")");
+	if (!(fundamental_hz > 0.0))
+		throw std::invalid_argument(
+			"harmonic_markers: fundamental_hz must be positive (got "
+			+ std::to_string(fundamental_hz) + ")");
+	if (trace.empty() || harmonics == 0) return {};
+
+	std::vector<Marker> out;
+	out.reserve(harmonics);
+	for (std::size_t k = 2; k < 2 + harmonics; ++k) {
+		const double target_freq = static_cast<double>(k) * fundamental_hz;
+		const double target_bin_d = target_freq / bin_freq_step_hz;
+		// Round to nearest. std::lround would also work; using
+		// floor(x + 0.5) avoids platform-specific banker's rounding.
+		const std::size_t target_bin =
+			static_cast<std::size_t>(std::floor(target_bin_d + 0.5));
+		if (target_bin >= trace.size()) break;   // remaining harmonics out of range
+
+		Marker m;
+		m.bin_index    = target_bin;
+		m.frequency_hz = static_cast<double>(target_bin) * bin_freq_step_hz;
+		m.amplitude    = static_cast<double>(trace[target_bin]);
+		out.push_back(m);
+	}
+	return out;
+}
+
+// Two-marker delta. b minus a, in both frequency and amplitude.
+[[nodiscard]] inline DeltaMarker make_delta_marker(const Marker& a,
+                                                    const Marker& b) {
+	DeltaMarker d;
+	d.a = a;
+	d.b = b;
+	d.delta_freq_hz   = b.frequency_hz - a.frequency_hz;
+	d.delta_amplitude = b.amplitude    - a.amplitude;
+	return d;
+}
+
+} // namespace sw::dsp::spectrum

--- a/include/sw/dsp/spectrum/markers.hpp
+++ b/include/sw/dsp/spectrum/markers.hpp
@@ -147,19 +147,25 @@ template <DspOrderedField T>
 	if (trace.empty() || top_n == 0) return {};
 
 	// Step 1: collect (bin_index, amplitude) pairs for every local max.
-	struct Candidate { std::size_t bin; double amp; };
+	// Amplitude stored in T (not double) so the sort below preserves
+	// the mixed-precision ordering that DspOrderedField promises — same
+	// rationale as detect_peak / detect_negative_peak in detectors.hpp
+	// and min_max_double in instrument/measurements.hpp.
+	struct Candidate { std::size_t bin; T amp; };
 	std::vector<Candidate> candidates;
 	candidates.reserve(trace.size() / 4 + 4);   // rough upper bound
 	for (std::size_t i = 0; i < trace.size(); ++i) {
 		if (detail::is_local_max(trace, i))
-			candidates.push_back({i, static_cast<double>(trace[i])});
+			candidates.push_back({i, trace[i]});
 	}
 
-	// Step 2: sort by amplitude descending. Use a stable order on ties
-	// (lower bin first) so the result is deterministic.
+	// Step 2: sort by amplitude descending. Comparison is in T (per
+	// DspOrderedField); ties broken by lower bin first for determinism.
+	// Use only `>` so we don't require T to support `!=`.
 	std::sort(candidates.begin(), candidates.end(),
 	          [](const Candidate& a, const Candidate& b) {
-	              if (a.amp != b.amp) return a.amp > b.amp;
+	              if (a.amp > b.amp) return true;
+	              if (b.amp > a.amp) return false;
 	              return a.bin < b.bin;
 	          });
 
@@ -177,15 +183,18 @@ template <DspOrderedField T>
 		}
 		if (too_close) continue;
 
-		// Sub-bin parabolic interpolation. Skip for edge bins.
+		// Sub-bin parabolic interpolation. Skip for edge bins. The
+		// parabolic fit is a numerical operation that benefits from
+		// double accumulation regardless of T, so we cast at the
+		// boundary (same pattern as the Marker.amplitude output).
 		Marker m;
 		m.bin_index = c.bin;
-		m.amplitude = c.amp;
+		m.amplitude = static_cast<double>(c.amp);
 		double offset = 0.0;
 		if (c.bin > 0 && c.bin + 1 < trace.size()) {
 			offset = detail::parabolic_offset(
 				static_cast<double>(trace[c.bin - 1]),
-				c.amp,
+				static_cast<double>(c.amp),
 				static_cast<double>(trace[c.bin + 1]));
 		}
 		m.frequency_hz = (static_cast<double>(c.bin) + offset) * bin_freq_step_hz;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ dsp_add_test(test_bluestein       "Tests/Spectral")
 # =============================================================================
 dsp_add_test(test_spectrum_detectors        "Tests/Spectrum")
 dsp_add_test(test_spectrum_trace_averaging  "Tests/Spectrum")
+dsp_add_test(test_spectrum_markers          "Tests/Spectrum")
 
 # =============================================================================
 # Conditioning — AGC, compressor, envelope, sample-rate conversion, noise shaping

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,9 +41,10 @@ Tests/
 │   ├── test_fft
 │   ├── test_spectral            Z-transform, Laplace, PSD, spectrogram
 │   └── test_bluestein           Chirp-z arbitrary-length DFT
-├── Spectrum/                       Spectrum-analyzer-specific primitives
-│   ├── test_spectrum_detectors        Peak / sample / average / RMS / neg-peak
-│   └── test_spectrum_trace_averaging  Linear / exp / max-hold / min-hold / max-N
+├── Spectrum/                          Spectrum-analyzer-specific primitives
+│   ├── test_spectrum_detectors           Peak / sample / average / RMS / neg-peak
+│   ├── test_spectrum_trace_averaging     Linear / exp / max-hold / min-hold / max-N
+│   └── test_spectrum_markers             find_peaks / harmonic_markers / delta marker
 ├── Conditioning/
 │   ├── test_conditioning        AGC, compressor, envelope detector
 │   ├── test_src                 Rational sample-rate conversion

--- a/tests/test_spectrum_markers.cpp
+++ b/tests/test_spectrum_markers.cpp
@@ -252,6 +252,31 @@ void test_harmonic_markers_rounding() {
 	std::cout << "  harmonic_markers_rounding: passed\n";
 }
 
+void test_harmonic_markers_overflow_safe() {
+	// Pathological inputs that would, without the pre-cast range guard,
+	// invoke implementation-defined behavior when casting an enormous
+	// double to std::size_t. fundamental_hz near double's upper edge
+	// drives target_bin_d to +inf at k=2; the loop must break cleanly
+	// without a wrapped or trap-representation cast.
+	std::array<double, 8> trace;
+	trace.fill(0.0);
+	auto h_inf = harmonic_markers(std::span<const double>{trace},
+	                               /*step=*/1.0,
+	                               /*fundamental=*/1e308,
+	                               /*harmonics=*/5);
+	REQUIRE(h_inf.empty());
+
+	// Huge but finite k. With harmonics = 1000 and a fundamental that
+	// puts the 2nd harmonic well past trace.size(), the loop should
+	// break on the very first iteration. No crash, no garbage markers.
+	auto h_big = harmonic_markers(std::span<const double>{trace},
+	                               /*step=*/1.0,
+	                               /*fundamental=*/100.0,    // 2nd at bin 200
+	                               /*harmonics=*/1000);
+	REQUIRE(h_big.empty());
+	std::cout << "  harmonic_markers_overflow_safe: passed\n";
+}
+
 // ============================================================================
 // make_delta_marker
 // ============================================================================
@@ -328,6 +353,7 @@ int main() {
 		test_harmonic_markers_basic();
 		test_harmonic_markers_out_of_range_truncates();
 		test_harmonic_markers_rounding();
+		test_harmonic_markers_overflow_safe();
 
 		test_make_delta_marker();
 		test_validation();

--- a/tests/test_spectrum_markers.cpp
+++ b/tests/test_spectrum_markers.cpp
@@ -93,23 +93,33 @@ void test_find_peaks_top_n_smaller_than_available() {
 // ============================================================================
 
 void test_find_peaks_min_separation() {
-	// A "broad peak": three adjacent bins all above the noise floor,
-	// each higher than its further neighbor. Each bin is technically a
-	// local max relative to its immediate neighbors. With
-	// min_separation_bins = 3, only the strongest survives the
-	// greedy-selection step.
+	// Two distinct local maxima within min_separation_bins of each
+	// other. is_local_max requires strict > on both neighbors, so the
+	// previous version of this test (which had only one local max in
+	// the 10..12 region) didn't actually exercise the suppression
+	// logic. New layout:
+	//
+	//   bin 9  = 4 (local max: > -50 floor on left, > 0 on right)
+	//   bin 10 = 0 (valley, not a peak)
+	//   bin 11 = 5 (local max AND stronger than bin 9)
+	//   bin 12 = 0 (valley)
+	//
+	// Both 9 and 11 are local maxes. Greedy selects bin 11 first
+	// (stronger amplitude); bin 9 is then 2 bins away — within the
+	// min_separation_bins=3 window — and gets suppressed.
 	std::array<double, 32> trace;
 	trace.fill(-50.0);
-	trace[10] = 0.0;     // peak
-	trace[11] = 5.0;     // higher peak (this should win)
+	trace[9]  = 4.0;
+	trace[10] = 0.0;
+	trace[11] = 5.0;
 	trace[12] = 0.0;
-	// Place a second well-separated peak at bin 25.
+	// Well-separated second peak.
 	trace[25] = 3.0;
 
 	auto peaks = find_peaks(std::span<const double>{trace}, 100.0,
 	                         /*top_n=*/4, /*min_separation_bins=*/3);
-	// Within bins 10-12 only one peak survives (bin 11, the strongest);
-	// the well-separated peak at 25 also returns. So 2 markers total.
+	// Result: bin 11 (strongest, picked first) suppresses bin 9; bin 25
+	// is well clear and also returned. Total = 2 markers.
 	REQUIRE(peaks.size() == 2);
 	REQUIRE(peaks[0].bin_index == 11);
 	REQUIRE(peaks[1].bin_index == 25);

--- a/tests/test_spectrum_markers.cpp
+++ b/tests/test_spectrum_markers.cpp
@@ -1,0 +1,332 @@
+// test_spectrum_markers.cpp: tests for the spectrum-analyzer marker /
+// peak-find utilities (find_peaks, harmonic_markers, make_delta_marker).
+//
+// Coverage:
+//   - find_peaks: synthetic 3-tone trace returns the 3 expected peaks
+//     in descending amplitude order
+//   - find_peaks: min_separation_bins suppresses adjacent local-max
+//     chatter (broad peak across multiple bins counts once)
+//   - find_peaks: sub-bin parabolic interpolation accurate to within
+//     bin_step / 4 on a synthetic peak with known sub-bin offset
+//   - find_peaks edge cases: empty trace, top_n=0, single-sample trace,
+//     peak at first bin, peak at last bin, all-equal trace
+//   - harmonic_markers: returns markers at k * fundamental for k=2..N,
+//     bin_index = round(k*f / step), amplitude = trace[that bin]
+//   - harmonic_markers: out-of-range harmonics silently truncated
+//   - make_delta_marker: b minus a in frequency and amplitude
+//   - Validation: invalid bin_freq_step_hz / fundamental_hz throw
+//   - Mixed-precision sanity: float trace gives reasonable peaks
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <sw/dsp/spectrum/markers.hpp>
+
+using namespace sw::dsp::spectrum;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+static bool approx(double a, double b, double tol) {
+	return std::abs(a - b) <= tol;
+}
+
+// ============================================================================
+// find_peaks: synthetic 3-tone trace
+// ============================================================================
+
+void test_find_peaks_three_tones() {
+	// 64-bin trace with three peaks at bins 10, 25, 50 with amplitudes
+	// 30, 20, 25 dB. Background noise floor at -100 dB.
+	std::array<double, 64> trace;
+	trace.fill(-100.0);
+	trace[10] = 30.0;
+	trace[25] = 20.0;
+	trace[50] = 25.0;
+	const double bin_step = 1000.0;   // 1 kHz/bin
+
+	auto peaks = find_peaks(std::span<const double>{trace}, bin_step, /*top_n=*/3);
+	REQUIRE(peaks.size() == 3);
+	// Returned in descending amplitude order: 30, 25, 20.
+	REQUIRE(peaks[0].bin_index == 10);
+	REQUIRE(peaks[1].bin_index == 50);
+	REQUIRE(peaks[2].bin_index == 25);
+	REQUIRE(approx(peaks[0].amplitude, 30.0, 1e-12));
+	REQUIRE(approx(peaks[1].amplitude, 25.0, 1e-12));
+	REQUIRE(approx(peaks[2].amplitude, 20.0, 1e-12));
+	// Frequency = bin_index * step (no sub-bin interp because the
+	// neighbors are at the noise floor — parabolic vertex collapses to
+	// the integer bin).
+	REQUIRE(approx(peaks[0].frequency_hz, 10.0 * bin_step, 1e-9));
+	std::cout << "  find_peaks_three_tones: passed\n";
+}
+
+void test_find_peaks_top_n_smaller_than_available() {
+	// Same trace, ask for only 2 peaks — should get the strongest two.
+	std::array<double, 64> trace;
+	trace.fill(-100.0);
+	trace[10] = 30.0;
+	trace[25] = 20.0;
+	trace[50] = 25.0;
+	auto peaks = find_peaks(std::span<const double>{trace}, 1000.0, /*top_n=*/2);
+	REQUIRE(peaks.size() == 2);
+	REQUIRE(peaks[0].bin_index == 10);
+	REQUIRE(peaks[1].bin_index == 50);
+	std::cout << "  find_peaks_top_n_smaller_than_available: passed\n";
+}
+
+// ============================================================================
+// find_peaks: min_separation suppresses adjacent local-max chatter
+// ============================================================================
+
+void test_find_peaks_min_separation() {
+	// A "broad peak": three adjacent bins all above the noise floor,
+	// each higher than its further neighbor. Each bin is technically a
+	// local max relative to its immediate neighbors. With
+	// min_separation_bins = 3, only the strongest survives the
+	// greedy-selection step.
+	std::array<double, 32> trace;
+	trace.fill(-50.0);
+	trace[10] = 0.0;     // peak
+	trace[11] = 5.0;     // higher peak (this should win)
+	trace[12] = 0.0;
+	// Place a second well-separated peak at bin 25.
+	trace[25] = 3.0;
+
+	auto peaks = find_peaks(std::span<const double>{trace}, 100.0,
+	                         /*top_n=*/4, /*min_separation_bins=*/3);
+	// Within bins 10-12 only one peak survives (bin 11, the strongest);
+	// the well-separated peak at 25 also returns. So 2 markers total.
+	REQUIRE(peaks.size() == 2);
+	REQUIRE(peaks[0].bin_index == 11);
+	REQUIRE(peaks[1].bin_index == 25);
+	std::cout << "  find_peaks_min_separation: passed\n";
+}
+
+// ============================================================================
+// find_peaks: sub-bin parabolic interpolation
+// ============================================================================
+
+void test_find_peaks_sub_bin_interpolation() {
+	// A symmetric parabolic peak with vertex between bins. y[i-1]=8,
+	// y[i]=10, y[i+1]=9. Vertex offset:
+	//     delta = 0.5 * (8 - 9) / (8 - 20 + 9) = 0.5 * -1 / -3 = +0.1667
+	// So the recovered freq should be (i + 0.1667) * bin_step.
+	std::array<double, 32> trace;
+	trace.fill(-50.0);
+	const std::size_t i = 15;
+	trace[i - 1] = 8.0;
+	trace[i]     = 10.0;
+	trace[i + 1] = 9.0;
+	const double bin_step = 1000.0;
+
+	auto peaks = find_peaks(std::span<const double>{trace}, bin_step, /*top_n=*/1);
+	REQUIRE(peaks.size() == 1);
+	REQUIRE(peaks[0].bin_index == i);
+	const double expected_freq = (static_cast<double>(i) + 1.0/6.0) * bin_step;
+	REQUIRE(approx(peaks[0].frequency_hz, expected_freq, bin_step / 4.0));
+	std::cout << "  find_peaks_sub_bin_interpolation: passed (freq="
+	          << peaks[0].frequency_hz << " expected " << expected_freq << ")\n";
+}
+
+// ============================================================================
+// find_peaks: edge cases
+// ============================================================================
+
+void test_find_peaks_edge_cases() {
+	// Empty trace -> empty result.
+	std::span<const double> empty{};
+	REQUIRE(find_peaks(empty, 1000.0, 5).empty());
+
+	// top_n = 0 -> empty result.
+	std::array<double, 5> trace = {1.0, 2.0, 3.0, 2.0, 1.0};
+	REQUIRE(find_peaks(std::span<const double>{trace}, 1000.0, 0).empty());
+
+	// Single-sample trace -> the one bin is a peak.
+	std::array<double, 1> single = {7.5};
+	auto p1 = find_peaks(std::span<const double>{single}, 1000.0, 5);
+	REQUIRE(p1.size() == 1);
+	REQUIRE(p1[0].bin_index == 0);
+	REQUIRE(approx(p1[0].amplitude, 7.5, 1e-12));
+
+	// All-equal trace -> bin 0 is technically a peak (>= neighbor)?
+	// Our is_local_max uses strict >. With equal neighbors, no bin is
+	// strictly greater than its neighbor, so no peaks.
+	std::array<double, 4> flat;
+	flat.fill(2.0);
+	REQUIRE(find_peaks(std::span<const double>{flat}, 1000.0, 5).empty());
+
+	// Peak at first bin (must be > neighbor).
+	std::array<double, 5> first_peak = {10.0, 5.0, 0.0, 0.0, 0.0};
+	auto pf = find_peaks(std::span<const double>{first_peak}, 1000.0, 1);
+	REQUIRE(pf.size() == 1);
+	REQUIRE(pf[0].bin_index == 0);
+	// Edge bin: no parabolic interp -> frequency_hz == 0 * step.
+	REQUIRE(approx(pf[0].frequency_hz, 0.0, 1e-12));
+
+	// Peak at last bin.
+	std::array<double, 5> last_peak = {0.0, 0.0, 0.0, 5.0, 10.0};
+	auto pl = find_peaks(std::span<const double>{last_peak}, 1000.0, 1);
+	REQUIRE(pl.size() == 1);
+	REQUIRE(pl[0].bin_index == 4);
+	REQUIRE(approx(pl[0].frequency_hz, 4.0 * 1000.0, 1e-12));
+
+	std::cout << "  find_peaks_edge_cases: passed\n";
+}
+
+// ============================================================================
+// harmonic_markers
+// ============================================================================
+
+void test_harmonic_markers_basic() {
+	// 100-bin trace, 1 kHz/bin, fundamental at 5 kHz (bin 5).
+	// Harmonics at 10/15/20 kHz -> bins 10/15/20.
+	std::array<double, 100> trace;
+	for (std::size_t i = 0; i < trace.size(); ++i)
+		trace[i] = static_cast<double>(i);   // synthetic ramp for distinct values
+	const double step = 1000.0;
+	const double f0 = 5000.0;
+
+	auto h = harmonic_markers(std::span<const double>{trace}, step, f0, /*harmonics=*/3);
+	REQUIRE(h.size() == 3);
+	REQUIRE(h[0].bin_index == 10);   // 2nd harmonic
+	REQUIRE(h[1].bin_index == 15);   // 3rd
+	REQUIRE(h[2].bin_index == 20);   // 4th
+	REQUIRE(approx(h[0].amplitude, 10.0, 1e-12));
+	REQUIRE(approx(h[1].amplitude, 15.0, 1e-12));
+	REQUIRE(approx(h[2].amplitude, 20.0, 1e-12));
+	REQUIRE(approx(h[0].frequency_hz, 10000.0, 1e-9));
+	std::cout << "  harmonic_markers_basic: passed\n";
+}
+
+void test_harmonic_markers_out_of_range_truncates() {
+	// Fundamental at 30 kHz, trace is 100 bins at 1 kHz/bin = 100 kHz max.
+	// 2nd harmonic at 60 kHz (bin 60) -> in range.
+	// 3rd at 90 kHz (bin 90) -> in range.
+	// 4th at 120 kHz -> out of range; truncated.
+	// 5th at 150 kHz -> out of range.
+	std::array<double, 100> trace;
+	trace.fill(-100.0);
+	trace[60] = 5.0;
+	trace[90] = 3.0;
+	auto h = harmonic_markers(std::span<const double>{trace}, 1000.0, 30000.0, 4);
+	REQUIRE(h.size() == 2);
+	REQUIRE(h[0].bin_index == 60);
+	REQUIRE(h[1].bin_index == 90);
+	std::cout << "  harmonic_markers_out_of_range_truncates: passed\n";
+}
+
+void test_harmonic_markers_rounding() {
+	// Fundamental that doesn't sit exactly on a bin: 5333 Hz, 1 kHz step.
+	// 2nd harmonic at 10666 Hz -> round to bin 11.
+	// 3rd at 15999 Hz -> round to bin 16.
+	std::array<double, 100> trace;
+	for (std::size_t i = 0; i < trace.size(); ++i) trace[i] = static_cast<double>(i);
+	auto h = harmonic_markers(std::span<const double>{trace}, 1000.0, 5333.0, 2);
+	REQUIRE(h.size() == 2);
+	REQUIRE(h[0].bin_index == 11);
+	REQUIRE(h[1].bin_index == 16);
+	std::cout << "  harmonic_markers_rounding: passed\n";
+}
+
+// ============================================================================
+// make_delta_marker
+// ============================================================================
+
+void test_make_delta_marker() {
+	Marker a; a.bin_index = 10; a.frequency_hz = 100.0; a.amplitude = -10.0;
+	Marker b; b.bin_index = 50; b.frequency_hz = 500.0; b.amplitude = -25.0;
+	auto d = make_delta_marker(a, b);
+	REQUIRE(approx(d.delta_freq_hz, 400.0, 1e-12));      // 500 - 100
+	REQUIRE(approx(d.delta_amplitude, -15.0, 1e-12));    // -25 - (-10)
+	REQUIRE(d.a.bin_index == 10);
+	REQUIRE(d.b.bin_index == 50);
+	std::cout << "  make_delta_marker: passed\n";
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+void test_validation() {
+	std::array<double, 4> trace = {1.0, 2.0, 3.0, 0.0};
+	bool t1 = false, t2 = false, t3 = false, t4 = false;
+
+	try { (void)find_peaks(std::span<const double>{trace}, 0.0, 1); }
+	catch (const std::invalid_argument&) { t1 = true; }
+	REQUIRE(t1);
+
+	try { (void)find_peaks(std::span<const double>{trace}, -100.0, 1); }
+	catch (const std::invalid_argument&) { t2 = true; }
+	REQUIRE(t2);
+
+	try { (void)harmonic_markers(std::span<const double>{trace}, 0.0, 1000.0, 3); }
+	catch (const std::invalid_argument&) { t3 = true; }
+	REQUIRE(t3);
+
+	try { (void)harmonic_markers(std::span<const double>{trace}, 1000.0, 0.0, 3); }
+	catch (const std::invalid_argument&) { t4 = true; }
+	REQUIRE(t4);
+
+	std::cout << "  validation: passed\n";
+}
+
+// ============================================================================
+// Mixed-precision sanity: float trace
+// ============================================================================
+
+void test_float_trace() {
+	std::array<float, 32> trace;
+	trace.fill(-100.0f);
+	trace[8] = 5.0f;
+	trace[20] = 8.0f;
+	auto peaks = find_peaks(std::span<const float>{trace}, 100.0, 2);
+	REQUIRE(peaks.size() == 2);
+	REQUIRE(peaks[0].bin_index == 20);   // higher amplitude wins
+	REQUIRE(peaks[1].bin_index == 8);
+	REQUIRE(approx(peaks[0].amplitude, 8.0, 1e-6));
+	std::cout << "  float_trace: passed\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_spectrum_markers\n";
+
+		test_find_peaks_three_tones();
+		test_find_peaks_top_n_smaller_than_available();
+		test_find_peaks_min_separation();
+		test_find_peaks_sub_bin_interpolation();
+		test_find_peaks_edge_cases();
+
+		test_harmonic_markers_basic();
+		test_harmonic_markers_out_of_range_truncates();
+		test_harmonic_markers_rounding();
+
+		test_make_delta_marker();
+		test_validation();
+		test_float_trace();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary
- Third sub-issue under #134 (Epic: Spectrum Analyzer Demonstrator). Adds the trace-interrogation primitives: `find_peaks`, `harmonic_markers`, `make_delta_marker`.
- Independent of the other in-flight #134 work — operates on any trace span of any `DspOrderedField + ConvertibleToDouble` type.

## API
```cpp
struct Marker      { std::size_t bin_index; double frequency_hz; double amplitude; };
struct DeltaMarker { Marker a, b; double delta_freq_hz; double delta_amplitude; };

template <DspOrderedField T>
std::vector<Marker> find_peaks(std::span<const T> trace,
                                double bin_freq_step_hz,
                                std::size_t top_n,
                                std::size_t min_separation_bins = 3);

template <DspOrderedField T>
std::vector<Marker> harmonic_markers(std::span<const T> trace,
                                      double bin_freq_step_hz,
                                      double fundamental_hz,
                                      std::size_t harmonics);

DeltaMarker make_delta_marker(const Marker& a, const Marker& b);
```

## Algorithm details
- **`find_peaks`** uses the standard greedy top-N-with-min-separation pattern: enumerate local maxima → sort by amplitude descending (ties broken by lower bin) → greedy-pick skipping peaks within `min_separation_bins` of any already-picked peak. The greedy step suppresses broad-peak chatter (a peak straddling 3 adjacent bins would otherwise consume all top_n slots).
- **Sub-bin parabolic interpolation** for the peak frequency: `delta = 0.5 * (y[-1] - y[+1]) / (y[-1] - 2*y[0] + y[+1])`, clamped to `[-0.5, +0.5]`. Skipped for edge bins (no parabola fits with two points). Exact-zero guard on the denominator (matches the convention in `instrument/measurements::interp_crossing`).
- **`harmonic_markers`** uses round-to-nearest-bin (`floor(x + 0.5)` to avoid platform-specific banker's rounding). No peak-search around the target bin — the caller composes with `find_peaks` for peak-snapped harmonics. Out-of-range harmonics truncated silently.

## Mixed-precision contract
- Amplitude comparisons in `T` (`DspOrderedField`).
- Sub-bin interpolation in `double`.
- Marker / DeltaMarker fields are `double` for uniform reporting-layer types.

## Changes
- `include/sw/dsp/spectrum/markers.hpp` — new module (~170 lines)
- `tests/test_spectrum_markers.cpp` — 11 sub-tests (~250 lines)
- `tests/CMakeLists.txt` — register test
- `tests/README.md` — Spectrum entry updated

## Test results
| Target                    | gcc build | gcc test | clang build | clang test |
|---------------------------|-----------|----------|-------------|------------|
| test_spectrum_markers     | OK        | 11/11 PASS | OK        | 11/11 PASS |
| Full ctest (42 tests)     | OK        | 42/42    | OK          | 42/42      |

Coverage: 3-tone known-answer, top-N truncation, min-separation suppression, sub-bin interp recovers a known offset within `bin_step/4`, six edge-case classes (empty / top_n=0 / single bin / all-equal / first-bin peak / last-bin peak), harmonic basic / out-of-range / round-to-nearest, delta marker arithmetic, validation, float-trace mixed-precision sanity.

## Test plan
- [x] Fast CI passes
- [x] CodeRabbit review (drafts skip auto-review; trigger with `@coderabbitai review`)
- [x] Promote to ready: `gh pr ready`

Resolves #179

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added spectrum peak markers, harmonic marker detection, and delta-marker comparisons with configurable sensitivity, separation, input validation, and sub-bin frequency estimation.

* **Tests**
  * Added a new test executable covering peak finding, harmonic detection, interpolation, edge cases, input validation, mixed-precision and safety scenarios; registered for automated test runs.

* **Documentation**
  * Updated test listings to include the new marker-detection tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->