### PR TITLE
feat(spectrum): VBW (video bandwidth) post-detector LPF

### DIFF
--- a/include/sw/dsp/spectrum/vbw_filter.hpp
+++ b/include/sw/dsp/spectrum/vbw_filter.hpp
@@ -61,9 +61,14 @@ public:
 	//                 Must be > 0.
 	VBWFilter(double cutoff_hz, double sample_rate_hz)
 		: sample_rate_hz_(sample_rate_hz) {
-		if (!(sample_rate_hz > 0.0))
+		// isfinite + positive. The two checks together exclude NaN
+		// (rejected by both), -inf (rejected by `> 0.0`), and +inf
+		// (rejected by isfinite). +inf is the sneaky one: it would
+		// pass the > 0.0 check and then make alpha = 1 - exp(-x/inf)
+		// = 0, giving a useless "y stuck at y_prev" filter.
+		if (!std::isfinite(sample_rate_hz) || !(sample_rate_hz > 0.0))
 			throw std::invalid_argument(
-				"VBWFilter: sample_rate_hz must be positive (got "
+				"VBWFilter: sample_rate_hz must be positive and finite (got "
 				+ std::to_string(sample_rate_hz) + ")");
 		set_cutoff(cutoff_hz);   // designs alpha; sets cutoff_hz_
 	}
@@ -107,9 +112,13 @@ public:
 	// call continues smoothly from the running state. The user sliding
 	// the VBW knob doesn't see a discontinuity.
 	void set_cutoff(double cutoff_hz) {
-		if (!(cutoff_hz > 0.0))
+		// Same isfinite-and-positive rule as the constructor.
+		// +inf would pass `> 0.0` and then short-circuit through
+		// the Nyquist check (`inf > 0.5*fs` is true), but explicit
+		// isfinite gives a clearer error message.
+		if (!std::isfinite(cutoff_hz) || !(cutoff_hz > 0.0))
 			throw std::invalid_argument(
-				"VBWFilter: cutoff_hz must be positive (got "
+				"VBWFilter: cutoff_hz must be positive and finite (got "
 				+ std::to_string(cutoff_hz) + ")");
 		if (cutoff_hz > 0.5 * sample_rate_hz_)
 			throw std::invalid_argument(

--- a/include/sw/dsp/spectrum/vbw_filter.hpp
+++ b/include/sw/dsp/spectrum/vbw_filter.hpp
@@ -21,12 +21,25 @@
 // Mixed-precision contract:
 //   - CoeffScalar holds alpha (and 1 - alpha). For very low cutoffs
 //     the pole sits very close to z = 1; coefficient precision matters
-//     for stability at fc ~ fs/1000.
-//   - StateScalar holds y_prev_. Narrow types may quantize the
-//     integrator's settling tail.
-//   - SampleScalar is the streaming I/O type.
-//   - DenormalPrevention<SampleScalar> AC injection on each update -
-//     same convention as the IIR stages in nco.hpp / halfband.hpp /
+//     for stability at fc ~ fs/1000. alpha itself is designed in
+//     double and cast to CoeffScalar — same convention as
+//     EqualizerFilter and the analyzer demos. Designing in
+//     CoeffScalar would be unsafe for narrow fixpnt types where the
+//     intermediate constant 2*pi (~6.28) overflows the integer
+//     headroom (e.g., fixpnt<32,30> Q2.30 saturates at ~2). Once the
+//     final alpha is in [0, 1] the cast-to-CoeffScalar fits any type.
+//   - StateScalar holds y_prev_ AND drives the IIR accumulator. The
+//     full update y = alpha*x + (1-alpha)*y_prev + denormal_.ac()
+//     happens in StateScalar; only the public output is cast to
+//     SampleScalar. This keeps the recursive feedback at full
+//     state precision instead of collapsing through a Sample cast on
+//     every iteration.
+//   - SampleScalar is the public streaming I/O type.
+//   - DenormalPrevention<StateScalar> AC injection inside the
+//     feedback loop — flushes state-side denormals which would
+//     otherwise accumulate via y_prev_. Injecting on the Sample
+//     output instead would be a no-op for the feedback path. Same
+//     convention as the IIR stages in nco.hpp / halfband.hpp /
 //     spectrum/trace_averaging.hpp.
 //
 // Retune (set_cutoff()) is bumpless: y_prev_ is preserved across the
@@ -75,18 +88,22 @@ public:
 
 	// Streaming - single sample.
 	SampleScalar process(SampleScalar x) {
-		// y[n] = alpha * x[n] + (1 - alpha) * y[n-1]   + denormal AC
-		// Computed in StateScalar precision then cast to SampleScalar
-		// on output. The cast at the boundary mirrors the convention
-		// used by nco.hpp / halfband.hpp.
+		// y[n] = alpha * x[n] + (1 - alpha) * y[n-1] + denormal AC
+		//
+		// The IIR is computed entirely in StateScalar precision. The
+		// denormal AC injection happens INSIDE the feedback loop (on
+		// y, not on y_out) because denormals accumulate via the
+		// y_prev_ feedback path — injecting only on the SampleScalar
+		// output wouldn't flush state-side denormals. y_prev_ then
+		// stores the full StateScalar y unchanged; casting to
+		// SampleScalar happens only at the public-output boundary.
 		const StateScalar y =
 			static_cast<StateScalar>(alpha_)
 			* static_cast<StateScalar>(x)
-			+ static_cast<StateScalar>(one_minus_alpha_) * y_prev_;
-		const SampleScalar y_out =
-			static_cast<SampleScalar>(y) + denormal_.ac();
-		y_prev_ = static_cast<StateScalar>(y_out);
-		return y_out;
+			+ static_cast<StateScalar>(one_minus_alpha_) * y_prev_
+			+ denormal_.ac();
+		y_prev_ = y;
+		return static_cast<SampleScalar>(y);
 	}
 
 	// In-place block process.
@@ -142,7 +159,7 @@ public:
 	// produce identical output (same fix as TraceAverager::reset).
 	void reset() {
 		y_prev_ = StateScalar{};
-		denormal_ = DenormalPrevention<SampleScalar>{};
+		denormal_ = DenormalPrevention<StateScalar>{};
 	}
 
 	[[nodiscard]] double cutoff_hz()      const { return cutoff_hz_; }
@@ -154,7 +171,7 @@ private:
 	CoeffScalar alpha_           = CoeffScalar{};
 	CoeffScalar one_minus_alpha_ = CoeffScalar{};
 	StateScalar y_prev_          = StateScalar{};
-	DenormalPrevention<SampleScalar> denormal_;
+	DenormalPrevention<StateScalar> denormal_;
 };
 
 } // namespace sw::dsp::spectrum

--- a/include/sw/dsp/spectrum/vbw_filter.hpp
+++ b/include/sw/dsp/spectrum/vbw_filter.hpp
@@ -1,0 +1,151 @@
+#pragma once
+// vbw_filter.hpp: spectrum-analyzer video-bandwidth (VBW) post-detector LPF.
+//
+// In a swept-tuned analyzer the VBW filter sits AFTER the detector and
+// BEFORE the trace memory. Its job is to smooth the detector output:
+// lower VBW = more averaging = lower noise floor at the cost of slower
+// response to amplitude changes; higher VBW = faster response but
+// noisier trace. It's the standard scope-analyzer noise-vs-speed knob.
+//
+// Implementation: a simple leaky-integrator single-pole IIR
+//
+//     y[n] = alpha * x[n] + (1 - alpha) * y[n-1]    + denormal AC
+//
+// where alpha = 1 - exp(-2*pi*fc / fs). This is the "matched-z" /
+// impulse-invariant form. -3 dB at fc to within 5% for fc << fs/2,
+// which is the typical VBW-vs-RBW use (VBW is usually >= 10x lower
+// than the analyzer's bin rate). For fc closer to Nyquist the
+// approximation drifts; the constructor rejects fc > fs/2 to keep the
+// filter inside its design range.
+//
+// Mixed-precision contract:
+//   - CoeffScalar holds alpha (and 1 - alpha). For very low cutoffs
+//     the pole sits very close to z = 1; coefficient precision matters
+//     for stability at fc ~ fs/1000.
+//   - StateScalar holds y_prev_. Narrow types may quantize the
+//     integrator's settling tail.
+//   - SampleScalar is the streaming I/O type.
+//   - DenormalPrevention<SampleScalar> AC injection on each update -
+//     same convention as the IIR stages in nco.hpp / halfband.hpp /
+//     spectrum/trace_averaging.hpp.
+//
+// Retune (set_cutoff()) is bumpless: y_prev_ is preserved across the
+// coefficient change. Real analyzers behave this way - the user
+// sliding the VBW knob doesn't get a discontinuity in the displayed
+// trace.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/math/denormal.hpp>
+
+namespace sw::dsp::spectrum {
+
+template <DspField CoeffScalar  = double,
+          DspField StateScalar  = CoeffScalar,
+          DspScalar SampleScalar = StateScalar>
+class VBWFilter {
+public:
+	using coeff_scalar  = CoeffScalar;
+	using state_scalar  = StateScalar;
+	using sample_scalar = SampleScalar;
+
+	// cutoff_hz:      -3 dB cutoff frequency. Must be > 0 and <= fs/2.
+	// sample_rate_hz: streaming rate at which process() will be called.
+	//                 Must be > 0.
+	VBWFilter(double cutoff_hz, double sample_rate_hz)
+		: sample_rate_hz_(sample_rate_hz) {
+		if (!(sample_rate_hz > 0.0))
+			throw std::invalid_argument(
+				"VBWFilter: sample_rate_hz must be positive (got "
+				+ std::to_string(sample_rate_hz) + ")");
+		set_cutoff(cutoff_hz);   // designs alpha; sets cutoff_hz_
+	}
+
+	// Streaming - single sample.
+	SampleScalar process(SampleScalar x) {
+		// y[n] = alpha * x[n] + (1 - alpha) * y[n-1]   + denormal AC
+		// Computed in StateScalar precision then cast to SampleScalar
+		// on output. The cast at the boundary mirrors the convention
+		// used by nco.hpp / halfband.hpp.
+		const StateScalar y =
+			static_cast<StateScalar>(alpha_)
+			* static_cast<StateScalar>(x)
+			+ static_cast<StateScalar>(one_minus_alpha_) * y_prev_;
+		const SampleScalar y_out =
+			static_cast<SampleScalar>(y) + denormal_.ac();
+		y_prev_ = static_cast<StateScalar>(y_out);
+		return y_out;
+	}
+
+	// In-place block process.
+	void process_block(std::span<SampleScalar> samples) {
+		for (auto& s : samples) s = process(s);
+	}
+
+	// Separate-span block process. Length mismatch throws.
+	void process_block(std::span<const SampleScalar> input,
+	                   std::span<SampleScalar> output) {
+		if (input.size() != output.size())
+			throw std::invalid_argument(
+				"VBWFilter::process_block: input length "
+				+ std::to_string(input.size())
+				+ " does not match output length "
+				+ std::to_string(output.size()));
+		for (std::size_t i = 0; i < input.size(); ++i)
+			output[i] = process(input[i]);
+	}
+
+	// Bumpless retune: alpha_ and one_minus_alpha_ are recomputed from
+	// the new cutoff, but y_prev_ is preserved so the next process()
+	// call continues smoothly from the running state. The user sliding
+	// the VBW knob doesn't see a discontinuity.
+	void set_cutoff(double cutoff_hz) {
+		if (!(cutoff_hz > 0.0))
+			throw std::invalid_argument(
+				"VBWFilter: cutoff_hz must be positive (got "
+				+ std::to_string(cutoff_hz) + ")");
+		if (cutoff_hz > 0.5 * sample_rate_hz_)
+			throw std::invalid_argument(
+				"VBWFilter: cutoff_hz (" + std::to_string(cutoff_hz)
+				+ ") exceeds Nyquist (sample_rate_hz / 2 = "
+				+ std::to_string(0.5 * sample_rate_hz_) + ")");
+		cutoff_hz_ = cutoff_hz;
+		// alpha = 1 - exp(-2*pi*fc/fs)
+		// matched-z / impulse-invariant single-pole LPF; -3 dB at fc
+		// within 5% for fc << fs/2.
+		constexpr double pi = 3.14159265358979323846;
+		const double alpha_d = 1.0 - std::exp(-2.0 * pi * cutoff_hz / sample_rate_hz_);
+		alpha_           = static_cast<CoeffScalar>(alpha_d);
+		one_minus_alpha_ = static_cast<CoeffScalar>(1.0 - alpha_d);
+	}
+
+	// Clear y_prev_ to zero. Useful between independent measurements
+	// or unrelated stream segments where the previous state should not
+	// leak into the new run. denormal_'s alternating-sign tracker is
+	// also reseeded so a fresh-construction and a reset-then-rerun
+	// produce identical output (same fix as TraceAverager::reset).
+	void reset() {
+		y_prev_ = StateScalar{};
+		denormal_ = DenormalPrevention<SampleScalar>{};
+	}
+
+	[[nodiscard]] double cutoff_hz()      const { return cutoff_hz_; }
+	[[nodiscard]] double sample_rate_hz() const { return sample_rate_hz_; }
+
+private:
+	double      sample_rate_hz_;
+	double      cutoff_hz_       = 0.0;
+	CoeffScalar alpha_           = CoeffScalar{};
+	CoeffScalar one_minus_alpha_ = CoeffScalar{};
+	StateScalar y_prev_          = StateScalar{};
+	DenormalPrevention<SampleScalar> denormal_;
+};
+
+} // namespace sw::dsp::spectrum

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ dsp_add_test(test_bluestein       "Tests/Spectral")
 dsp_add_test(test_spectrum_detectors        "Tests/Spectrum")
 dsp_add_test(test_spectrum_trace_averaging  "Tests/Spectrum")
 dsp_add_test(test_spectrum_markers          "Tests/Spectrum")
+dsp_add_test(test_spectrum_vbw_filter       "Tests/Spectrum")
 
 # =============================================================================
 # Conditioning — AGC, compressor, envelope, sample-rate conversion, noise shaping

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,8 @@ Tests/
 ├── Spectrum/                          Spectrum-analyzer-specific primitives
 │   ├── test_spectrum_detectors           Peak / sample / average / RMS / neg-peak
 │   ├── test_spectrum_trace_averaging     Linear / exp / max-hold / min-hold / max-N
-│   └── test_spectrum_markers             find_peaks / harmonic_markers / delta marker
+│   ├── test_spectrum_markers             find_peaks / harmonic_markers / delta marker
+│   └── test_spectrum_vbw_filter          Video-bandwidth (post-detector) LPF
 ├── Conditioning/
 │   ├── test_conditioning        AGC, compressor, envelope detector
 │   ├── test_src                 Rational sample-rate conversion

--- a/tests/test_spectrum_vbw_filter.cpp
+++ b/tests/test_spectrum_vbw_filter.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iostream>
+#include <limits>
 #include <numbers>
 #include <span>
 #include <stdexcept>
@@ -193,7 +194,8 @@ void test_reset_clears_state() {
 // ============================================================================
 
 void test_validation() {
-	bool t1=false, t2=false, t3=false, t4=false, t5=false, t6=false;
+	bool t1=false, t2=false, t3=false, t4=false, t5=false, t6=false,
+	     t7=false, t8=false, t9=false, t10=false;
 
 	try { F(0.0, 1e6); } catch (const std::invalid_argument&) { t1 = true; }
 	REQUIRE(t1);
@@ -210,6 +212,21 @@ void test_validation() {
 	F vbw(1000.0, 1e6);
 	try { vbw.set_cutoff(-100.0); } catch (const std::invalid_argument&) { t6 = true; }
 	REQUIRE(t6);
+
+	// Non-finite inputs: NaN and +inf must both throw. NaN is caught
+	// by `> 0.0` (NaN comparisons are false); +inf is the one that
+	// would otherwise sneak past `> 0.0` and produce a useless
+	// "y stuck at y_prev" filter (alpha = 1 - exp(-x/inf) = 0).
+	const double NaN = std::numeric_limits<double>::quiet_NaN();
+	const double INF = std::numeric_limits<double>::infinity();
+	try { F(NaN, 1e6); } catch (const std::invalid_argument&) { t7 = true; }
+	REQUIRE(t7);
+	try { F(INF, 1e6); } catch (const std::invalid_argument&) { t8 = true; }
+	REQUIRE(t8);
+	try { F(1000.0, NaN); } catch (const std::invalid_argument&) { t9 = true; }
+	REQUIRE(t9);
+	try { F(1000.0, INF); } catch (const std::invalid_argument&) { t10 = true; }
+	REQUIRE(t10);
 	std::cout << "  validation: passed\n";
 }
 
@@ -231,21 +248,35 @@ void test_length_mismatch_throws() {
 // ============================================================================
 
 void test_float_settles_close_to_double() {
-	using FF = VBWFilter<float, float, float>;
+	// Three instantiations:
+	//   - all-float        VBWFilter<float, float, float>
+	//   - all-double       VBWFilter<double, double, double>
+	//   - mixed-precision  VBWFilter<double, double, float>
+	//                      (high-precision coefficients + state, float
+	//                      streaming I/O — the FPGA-pragmatic mix that
+	//                      the scope_demo's eq_float_storage_fx16 plan
+	//                      uses for its calibration FIR)
+	// All three should settle to ~7.5 for a constant input. Float
+	// drift bounded by float epsilon times ~5000 iterations of leaky
+	// integration is well under 1e-3.
+	using FF = VBWFilter<float,  float,  float>;
 	using FD = VBWFilter<double, double, double>;
+	using FM = VBWFilter<double, double, float>;
 	FF vbw_f(1000.0, 100000.0);
 	FD vbw_d(1000.0, 100000.0);
+	FM vbw_m(1000.0, 100000.0);
 	float  y_f = 0.0f;
 	double y_d = 0.0;
+	float  y_m = 0.0f;
 	for (int i = 0; i < 5000; ++i) {
 		y_f = vbw_f.process(7.5f);
 		y_d = vbw_d.process(7.5);
+		y_m = vbw_m.process(7.5f);
 	}
-	// Both should settle to ~7.5. Float drift bounded by float epsilon
-	// times ~5000 iterations of leaky integration — well under 1e-3.
 	REQUIRE(approx(static_cast<double>(y_f), y_d, 1e-3));
+	REQUIRE(approx(static_cast<double>(y_m), y_d, 1e-3));
 	std::cout << "  float_settles_close_to_double: passed (float="
-	          << y_f << " double=" << y_d << ")\n";
+	          << y_f << " mixed=" << y_m << " double=" << y_d << ")\n";
 }
 
 // ============================================================================

--- a/tests/test_spectrum_vbw_filter.cpp
+++ b/tests/test_spectrum_vbw_filter.cpp
@@ -1,0 +1,276 @@
+// test_spectrum_vbw_filter.cpp: tests for the spectrum-analyzer VBW
+// (video bandwidth) post-detector LPF.
+//
+// Coverage:
+//   - DC gain = 1: long constant input settles to the constant
+//   - Cutoff accuracy: |H(fc)| ~= 1/sqrt(2) (-3 dB) within 5% at
+//     three representative cutoffs (fc = fs/100, fs/10, fs/1000)
+//   - Stability at low cutoffs (fc = fs/1000): output stays bounded
+//     and converges to DC for a constant input
+//   - Bumpless retune: state preserved across set_cutoff(); output
+//     continuous (no discontinuity at the retune sample)
+//   - reset() clears state
+//   - Validation: zero/negative cutoff, zero/negative fs, fc above
+//     Nyquist all throw
+//   - Length mismatch in process_block(input, output) throws
+//   - Mixed-precision sanity: float SampleScalar produces a settled
+//     output close to the double reference
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <numbers>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <sw/dsp/spectrum/vbw_filter.hpp>
+
+using namespace sw::dsp::spectrum;
+using F = VBWFilter<double>;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+static bool approx(double a, double b, double tol) {
+	return std::abs(a - b) <= tol;
+}
+
+// ============================================================================
+// DC gain == 1
+// ============================================================================
+
+void test_dc_gain_unity() {
+	// Long run of constant input. After enough sweeps to settle the
+	// IIR (many time constants), the output equals the input.
+	F vbw(/*fc=*/1000.0, /*fs=*/100000.0);   // fc = fs/100
+	const double constant = 7.5;
+	double y = 0.0;
+	for (int i = 0; i < 5000; ++i) y = vbw.process(constant);
+	REQUIRE(approx(y, constant, 1e-3));
+	std::cout << "  dc_gain_unity: passed (settled to " << y << ")\n";
+}
+
+// ============================================================================
+// Cutoff accuracy: |H(fc)| ~= 1/sqrt(2) (-3 dB) within 5%
+// ============================================================================
+
+// Drive the filter with a sine at frequency `f_in_hz`, run for enough
+// samples to reach steady state, then measure the peak amplitude over
+// the last few cycles. Compare to the input amplitude to get |H|.
+static double measure_magnitude(F& vbw, double f_in_hz, double fs) {
+	const double pi = std::numbers::pi_v<double>;
+	const double amp = 1.0;
+	const std::size_t cycles_warmup = 50;
+	const std::size_t cycles_measure = 20;
+	const double samples_per_cycle = fs / f_in_hz;
+	const std::size_t n_warmup =
+		static_cast<std::size_t>(cycles_warmup * samples_per_cycle);
+	const std::size_t n_measure =
+		static_cast<std::size_t>(cycles_measure * samples_per_cycle);
+
+	for (std::size_t n = 0; n < n_warmup; ++n) {
+		const double x = amp * std::sin(2.0 * pi * f_in_hz
+		                                 * static_cast<double>(n) / fs);
+		(void)vbw.process(x);
+	}
+	double peak = 0.0;
+	for (std::size_t n = 0; n < n_measure; ++n) {
+		const double t = static_cast<double>(n_warmup + n) / fs;
+		const double x = amp * std::sin(2.0 * pi * f_in_hz * t);
+		const double y = vbw.process(x);
+		if (std::abs(y) > peak) peak = std::abs(y);
+	}
+	return peak / amp;
+}
+
+void test_cutoff_minus3db() {
+	// Three representative cutoffs spanning the typical VBW range.
+	// At each, |H(fc)| should be 1/sqrt(2) ~= 0.7071 within 5%.
+	const double sqrt_half = 1.0 / std::sqrt(2.0);
+	struct Case { double fs; double fc; const char* name; };
+	const Case cases[] = {
+		{1.0e6, 1.0e3, "fs=1MHz fc=1kHz"},     // fc = fs/1000
+		{1.0e6, 1.0e4, "fs=1MHz fc=10kHz"},    // fc = fs/100
+		{1.0e6, 1.0e5, "fs=1MHz fc=100kHz"},   // fc = fs/10
+	};
+	for (const auto& c : cases) {
+		F vbw(c.fc, c.fs);
+		const double mag = measure_magnitude(vbw, c.fc, c.fs);
+		const double err_pct = std::abs(mag - sqrt_half) / sqrt_half * 100.0;
+		if (!(err_pct < 5.0))
+			throw std::runtime_error(
+				std::string("cutoff accuracy out of spec: ") + c.name
+				+ " |H(fc)|=" + std::to_string(mag)
+				+ " err=" + std::to_string(err_pct) + "%");
+		std::cout << "  cutoff_minus3db [" << c.name << "]: |H(fc)|="
+		          << mag << " err=" << err_pct << "%\n";
+	}
+}
+
+// ============================================================================
+// Stability at low cutoffs (fc = fs/1000)
+// ============================================================================
+
+void test_stable_at_low_cutoff() {
+	F vbw(/*fc=*/1.0, /*fs=*/1000.0);   // fc = fs/1000
+	// Push a long bounded input and verify the output stays bounded.
+	double max_abs = 0.0;
+	for (int i = 0; i < 100000; ++i) {
+		const double x = (i % 2 == 0) ? 1.0 : -1.0;   // square wave at fs/2
+		const double y = vbw.process(x);
+		max_abs = std::max(max_abs, std::abs(y));
+		REQUIRE(std::isfinite(y));
+	}
+	// At fc = fs/1000 the filter heavily attenuates fs/2 signal — the
+	// output should be much smaller than 1 in magnitude.
+	REQUIRE(max_abs < 0.1);
+	std::cout << "  stable_at_low_cutoff: passed (max|y|=" << max_abs << ")\n";
+}
+
+// ============================================================================
+// Bumpless retune
+// ============================================================================
+
+void test_bumpless_retune() {
+	// "Bumpless" means set_cutoff() preserves y_prev_ across the
+	// coefficient change — the IIR state isn't reset. Pushing x=0
+	// after a retune is a clean test: with alpha_new and x=0, the
+	// output is simply (1 - alpha_new) * y_prev. So if y_prev was
+	// preserved, y_after equals (1 - alpha_new) times the immediately-
+	// pre-retune output.
+	F vbw(/*fc=*/1000.0, /*fs=*/100000.0);
+	double pre_retune = 0.0;
+	for (int i = 0; i < 5; ++i) pre_retune = vbw.process(1.0);   // partial settle
+	REQUIRE(pre_retune > 0.0);   // sanity: filter is responding
+
+	const double new_fc = 500.0;
+	const double new_fs = 100000.0;
+	// Recompute alpha for the post-retune cutoff using the same formula
+	// the filter uses internally. This couples the test to the design
+	// formula, but that's the right coupling — bumpless is precisely
+	// the property that the state passes through the formula change
+	// untouched.
+	const double pi = std::numbers::pi_v<double>;
+	const double alpha_new = 1.0 - std::exp(-2.0 * pi * new_fc / new_fs);
+	vbw.set_cutoff(new_fc);
+	const double y_after = vbw.process(0.0);
+	const double expected = (1.0 - alpha_new) * pre_retune;
+	// Tolerance loose enough to absorb the 1e-8 denormal AC injection.
+	REQUIRE(approx(y_after, expected, 1e-7));
+	std::cout << "  bumpless_retune: passed (y_after=" << y_after
+	          << " vs expected " << expected
+	          << " from preserved y_prev=" << pre_retune << ")\n";
+}
+
+// ============================================================================
+// reset() clears state
+// ============================================================================
+
+void test_reset_clears_state() {
+	F vbw(1000.0, 100000.0);
+	for (int i = 0; i < 100; ++i) vbw.process(10.0);   // build up state
+	vbw.reset();
+	// Push a zero sample. Without state, output should be 0 plus the
+	// 1e-8 denormal AC injection (no-op for posit/fixpnt; ~1e-8 on
+	// IEEE float/double). Tolerance loose enough to absorb that.
+	const double y0 = vbw.process(0.0);
+	REQUIRE(approx(y0, 0.0, 1e-7));
+	std::cout << "  reset_clears_state: passed\n";
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+void test_validation() {
+	bool t1=false, t2=false, t3=false, t4=false, t5=false, t6=false;
+
+	try { F(0.0, 1e6); } catch (const std::invalid_argument&) { t1 = true; }
+	REQUIRE(t1);
+	try { F(-1.0, 1e6); } catch (const std::invalid_argument&) { t2 = true; }
+	REQUIRE(t2);
+	try { F(1000.0, 0.0); } catch (const std::invalid_argument&) { t3 = true; }
+	REQUIRE(t3);
+	try { F(1000.0, -1.0); } catch (const std::invalid_argument&) { t4 = true; }
+	REQUIRE(t4);
+	// fc above Nyquist (fs/2)
+	try { F(/*fc=*/600000.0, /*fs=*/1e6); } catch (const std::invalid_argument&) { t5 = true; }
+	REQUIRE(t5);
+	// set_cutoff with invalid value also throws
+	F vbw(1000.0, 1e6);
+	try { vbw.set_cutoff(-100.0); } catch (const std::invalid_argument&) { t6 = true; }
+	REQUIRE(t6);
+	std::cout << "  validation: passed\n";
+}
+
+void test_length_mismatch_throws() {
+	F vbw(1000.0, 100000.0);
+	std::array<double, 8> in{};
+	std::array<double, 7> out{};
+	bool threw = false;
+	try {
+		vbw.process_block(std::span<const double>{in},
+		                   std::span<double>{out});
+	} catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  length_mismatch_throws: passed\n";
+}
+
+// ============================================================================
+// Mixed-precision sanity
+// ============================================================================
+
+void test_float_settles_close_to_double() {
+	using FF = VBWFilter<float, float, float>;
+	using FD = VBWFilter<double, double, double>;
+	FF vbw_f(1000.0, 100000.0);
+	FD vbw_d(1000.0, 100000.0);
+	float  y_f = 0.0f;
+	double y_d = 0.0;
+	for (int i = 0; i < 5000; ++i) {
+		y_f = vbw_f.process(7.5f);
+		y_d = vbw_d.process(7.5);
+	}
+	// Both should settle to ~7.5. Float drift bounded by float epsilon
+	// times ~5000 iterations of leaky integration — well under 1e-3.
+	REQUIRE(approx(static_cast<double>(y_f), y_d, 1e-3));
+	std::cout << "  float_settles_close_to_double: passed (float="
+	          << y_f << " double=" << y_d << ")\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_spectrum_vbw_filter\n";
+
+		test_dc_gain_unity();
+		test_cutoff_minus3db();
+		test_stable_at_low_cutoff();
+		test_bumpless_retune();
+		test_reset_clears_state();
+
+		test_validation();
+		test_length_mismatch_throws();
+
+		test_float_settles_close_to_double();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}

--- a/tests/test_spectrum_vbw_filter.cpp
+++ b/tests/test_spectrum_vbw_filter.cpp
@@ -21,6 +21,7 @@
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstddef>
@@ -99,11 +100,11 @@ void test_cutoff_minus3db() {
 	// At each, |H(fc)| should be 1/sqrt(2) ~= 0.7071 within 5%.
 	const double sqrt_half = 1.0 / std::sqrt(2.0);
 	struct Case { double fs; double fc; const char* name; };
-	const Case cases[] = {
+	const std::array<Case, 3> cases = {{
 		{1.0e6, 1.0e3, "fs=1MHz fc=1kHz"},     // fc = fs/1000
 		{1.0e6, 1.0e4, "fs=1MHz fc=10kHz"},    // fc = fs/100
 		{1.0e6, 1.0e5, "fs=1MHz fc=100kHz"},   // fc = fs/10
-	};
+	}};
 	for (const auto& c : cases) {
 		F vbw(c.fc, c.fs);
 		const double mag = measure_magnitude(vbw, c.fc, c.fs);
@@ -227,6 +228,16 @@ void test_validation() {
 	REQUIRE(t9);
 	try { F(1000.0, INF); } catch (const std::invalid_argument&) { t10 = true; }
 	REQUIRE(t10);
+
+	// set_cutoff() must apply the same validation as the constructor.
+	bool s_nan=false, s_inf=false, s_nyq=false;
+	try { vbw.set_cutoff(NaN); } catch (const std::invalid_argument&) { s_nan = true; }
+	REQUIRE(s_nan);
+	try { vbw.set_cutoff(INF); } catch (const std::invalid_argument&) { s_inf = true; }
+	REQUIRE(s_inf);
+	// Above Nyquist: vbw was constructed with fs = 1e6, so > 5e5 throws.
+	try { vbw.set_cutoff(/*fc=*/600000.0); } catch (const std::invalid_argument&) { s_nyq = true; }
+	REQUIRE(s_nyq);
 	std::cout << "  validation: passed\n";
 }
 


### PR DESCRIPTION
## Summary
- Fourth sub-issue under #134 done. The "noise vs speed" knob between the detector and the trace memory in a spectrum-analyzer pipeline.
- Single-pole leaky-integrator IIR with runtime-tunable cutoff. Bumpless retune (`set_cutoff` preserves state).

## API
```cpp
template <DspField CoeffScalar  = double,
          DspField StateScalar  = CoeffScalar,
          DspScalar SampleScalar = StateScalar>
class VBWFilter {
public:
    VBWFilter(double cutoff_hz, double sample_rate_hz);
    SampleScalar process(SampleScalar x);
    void process_block(std::span<SampleScalar> samples);                       // in-place
    void process_block(std::span<const SampleScalar> in, std::span<SampleScalar> out);
    void set_cutoff(double cutoff_hz);   // bumpless
    void reset();
    double cutoff_hz() const;
    double sample_rate_hz() const;
};
```

## Design
- `alpha = 1 - exp(-2*pi*fc/fs)` (matched-z / impulse-invariant). -3 dB at fc to within 5% for fc << fs/2 — the typical VBW use. Constructor rejects fc > fs/2 to keep the design inside its valid range.
- `DenormalPrevention<SampleScalar>` AC injection on each update, matching the pattern in `nco.hpp` / `halfband.hpp` / `trace_averaging.hpp`. No-op for posit/fixpnt; flushes IEEE denormals.
- `set_cutoff()` recomputes the coefficients but leaves `y_prev_` untouched — the trace doesn't jump when the user slides the VBW knob.
- `reset()` clears y_prev_ AND reseeds the denormal AC tracker, same pattern as `TraceAverager::reset` (a fresh-construction averager and a reset one produce bit-identical streams from then on).

## Cutoff accuracy (measured)
| fc / fs | err vs 1/sqrt(2) |
|---|---|
| 1/1000 | 0.0003% |
| 1/100  | 0.016% |
| 1/10   | 0.197% |

All comfortably under the 5% spec from the issue.

## Changes
- `include/sw/dsp/spectrum/vbw_filter.hpp` — new module (~140 lines)
- `tests/test_spectrum_vbw_filter.cpp` — 8 sub-tests (~270 lines)
- `tests/CMakeLists.txt` — register test under `Tests/Spectrum`
- `tests/README.md` — Spectrum entry updated

## Test results
| Target                  | gcc build | gcc test | clang build | clang test |
|-------------------------|-----------|----------|-------------|------------|
| test_spectrum_vbw_filter | OK        | 8/8 PASS | OK          | 8/8 PASS   |
| Full ctest (44 tests)    | OK        | 44/44    | OK          | 44/44      |

Coverage: DC gain unity, cutoff accuracy at three representative cutoffs (errors well under the 5% spec), stability at fc=fs/1000 with worst-case fs/2 drive, bumpless retune (verified by computing the expected post-retune output from the preserved y_prev), reset clears state, validation (zero/negative cutoff and fs, fc above Nyquist, set_cutoff with bad input), length-mismatch throw on the explicit-output block API, float-input mixed-precision sanity.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] CodeRabbit review (drafts skip auto-review; trigger with `@coderabbitai review`)
- [ ] Promote to ready when satisfied: `gh pr ready`

Resolves #176

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a video-bandwidth (VBW) smoothing filter with adjustable cutoff, bumpless retuning, reset, and block processing.

* **Tests**
  * Added comprehensive tests validating frequency response, steady-state behavior, stability, error handling (invalid inputs, mismatched spans), and mixed-precision results; new test target registered.

* **Documentation**
  * Updated test README to include the new VBWFilter test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->