### PR TITLE
feat(spectrum): waterfall buffer (circular 2D trace memory)

### DIFF
--- a/include/sw/dsp/spectrum/waterfall_buffer.hpp
+++ b/include/sw/dsp/spectrum/waterfall_buffer.hpp
@@ -42,6 +42,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <limits>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -59,17 +60,10 @@ public:
 	//              full spectrum, or fft_size/2 + 1 for one-sided).
 	// num_frames:  ring capacity (how many frames to retain).
 	WaterfallBuffer(std::size_t num_bins, std::size_t num_frames)
-		: num_bins_(num_bins),
+		: num_bins_(check_dims(num_bins, num_frames)),   // throws on bad input
 		  num_frames_capacity_(num_frames),
 		  ring_(num_bins * num_frames),
-		  compact_(num_bins * num_frames) {
-		if (num_bins == 0)
-			throw std::invalid_argument(
-				"WaterfallBuffer: num_bins must be > 0");
-		if (num_frames == 0)
-			throw std::invalid_argument(
-				"WaterfallBuffer: num_frames must be > 0");
-	}
+		  compact_(num_bins * num_frames) {}
 
 	// Append a frame to the buffer. The frame must have exactly
 	// num_bins samples; otherwise std::invalid_argument. When the
@@ -154,6 +148,32 @@ public:
 	[[nodiscard]] std::size_t num_frames_filled()    const { return num_frames_filled_; }
 
 private:
+	// Validates the constructor's dimension arguments. Returns
+	// num_bins (so it can drive num_bins_'s init in the member-init
+	// list) on success; throws on any of:
+	//   - num_bins == 0
+	//   - num_frames == 0
+	//   - num_bins * num_frames overflows std::size_t. The ring and
+	//     compact buffers are sized by this product, so a silent
+	//     overflow would allocate a tiny buffer and let later index
+	//     arithmetic walk off the end.
+	static std::size_t check_dims(std::size_t num_bins,
+	                              std::size_t num_frames) {
+		if (num_bins == 0)
+			throw std::invalid_argument(
+				"WaterfallBuffer: num_bins must be > 0");
+		if (num_frames == 0)
+			throw std::invalid_argument(
+				"WaterfallBuffer: num_frames must be > 0");
+		// Compare against max/x rather than multiplying first.
+		if (num_bins > std::numeric_limits<std::size_t>::max() / num_frames)
+			throw std::length_error(
+				"WaterfallBuffer: num_bins * num_frames overflows size_t (got "
+				+ std::to_string(num_bins) + " * "
+				+ std::to_string(num_frames) + ")");
+		return num_bins;
+	}
+
 	std::size_t num_bins_;
 	std::size_t num_frames_capacity_;
 	std::size_t write_pos_         = 0;

--- a/include/sw/dsp/spectrum/waterfall_buffer.hpp
+++ b/include/sw/dsp/spectrum/waterfall_buffer.hpp
@@ -1,0 +1,165 @@
+#pragma once
+// waterfall_buffer.hpp: circular 2D trace memory for waterfall displays.
+//
+// Stores the last `num_frames` FFT magnitude frames produced by a
+// streaming spectrum processor (RealtimeSpectrum, see
+// realtime_spectrum.hpp). Each frame is `num_bins` samples wide; the
+// storage is a circular buffer that overwrites the oldest frame when
+// full, so the buffer always holds the most recent frames available.
+//
+// This is the data structure behind a waterfall / spectrogram display:
+// time on one axis (frame number), frequency on the other (bin
+// number), amplitude as color/intensity. The display refresh fetches
+// the last K frames in chronological order; the buffer fills as new
+// FFT outputs land.
+//
+// Naming note: the class is called WaterfallBuffer (not Spectrogram)
+// to avoid colliding with sw::dsp::spectral::Spectrogram, which is the
+// batch STFT in the general-spectral module. Spectral = general DSP
+// transforms; Spectrum = analyzer-specific stages (this file).
+//
+// Mixed-precision contract:
+//   Pure storage. The SampleScalar template parameter only affects
+//   how amplitude values are stored; no arithmetic is performed on
+//   them. push_frame copies the input span into the ring; reads
+//   either return a zero-copy view of one frame (frame_at) or
+//   compact a contiguous chronological slice into the internal
+//   compaction buffer (last_frames). Same precision-blind story
+//   as TriggerRingBuffer.
+//
+// API split between zero-copy and compacted views:
+//   frame_at(i)        - single-frame, zero-copy span into the ring.
+//                        Always works because each frame is num_bins
+//                        consecutive entries in the ring.
+//   last_frames(count) - multi-frame, non-const, returns a span into
+//                        an internal compaction buffer because frames
+//                        crossing the wrap point aren't contiguous in
+//                        the ring. Compacts on call. Suitable for
+//                        once-per-display-refresh use.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/concepts/scalar.hpp>
+
+namespace sw::dsp::spectrum {
+
+template <DspScalar SampleScalar>
+class WaterfallBuffer {
+public:
+	using sample_scalar = SampleScalar;
+
+	// num_bins:    number of frequency bins per frame (= FFT size for
+	//              full spectrum, or fft_size/2 + 1 for one-sided).
+	// num_frames:  ring capacity (how many frames to retain).
+	WaterfallBuffer(std::size_t num_bins, std::size_t num_frames)
+		: num_bins_(num_bins),
+		  num_frames_capacity_(num_frames),
+		  ring_(num_bins * num_frames),
+		  compact_(num_bins * num_frames) {
+		if (num_bins == 0)
+			throw std::invalid_argument(
+				"WaterfallBuffer: num_bins must be > 0");
+		if (num_frames == 0)
+			throw std::invalid_argument(
+				"WaterfallBuffer: num_frames must be > 0");
+	}
+
+	// Append a frame to the buffer. The frame must have exactly
+	// num_bins samples; otherwise std::invalid_argument. When the
+	// ring is full, the oldest frame is overwritten — total
+	// num_frames_filled() saturates at capacity.
+	void push_frame(std::span<const SampleScalar> magnitude) {
+		if (magnitude.size() != num_bins_)
+			throw std::invalid_argument(
+				"WaterfallBuffer::push_frame: magnitude length "
+				+ std::to_string(magnitude.size())
+				+ " must equal num_bins " + std::to_string(num_bins_));
+		const std::size_t offset = write_pos_ * num_bins_;
+		for (std::size_t i = 0; i < num_bins_; ++i)
+			ring_[offset + i] = magnitude[i];
+		write_pos_ = (write_pos_ + 1) % num_frames_capacity_;
+		if (num_frames_filled_ < num_frames_capacity_) ++num_frames_filled_;
+	}
+
+	// Read a single frame by chronological index. idx_from_oldest = 0
+	// is the oldest available frame; idx_from_oldest = num_frames_
+	// filled() - 1 is the newest (most recently pushed). The returned
+	// span is a zero-copy view into the ring.
+	[[nodiscard]] std::span<const SampleScalar>
+	frame_at(std::size_t idx_from_oldest) const {
+		if (idx_from_oldest >= num_frames_filled_)
+			throw std::out_of_range(
+				"WaterfallBuffer::frame_at: index "
+				+ std::to_string(idx_from_oldest)
+				+ " >= num_frames_filled() "
+				+ std::to_string(num_frames_filled_));
+		// Slot of the oldest frame: write_pos_ - num_frames_filled_,
+		// modulo capacity. Then add idx_from_oldest.
+		const std::size_t base =
+			(write_pos_ + num_frames_capacity_ - num_frames_filled_)
+			% num_frames_capacity_;
+		const std::size_t slot = (base + idx_from_oldest) % num_frames_capacity_;
+		const std::size_t offset = slot * num_bins_;
+		return std::span<const SampleScalar>(
+			ring_.data() + offset, num_bins_);
+	}
+
+	// Read the last `count` frames in chronological order (oldest
+	// first), returned as a flat span of length count * num_bins_ in
+	// row-major (frame-major) layout. count is clamped to
+	// num_frames_filled() — fewer-than-requested frames are returned
+	// when the buffer hasn't filled yet.
+	//
+	// Non-const because the implementation compacts into an internal
+	// buffer (the ring's frames cross the wrap point and aren't
+	// contiguous in storage). Suitable for once-per-display-refresh
+	// use; not a hot-loop API.
+	[[nodiscard]] std::span<const SampleScalar>
+	last_frames(std::size_t count) {
+		const std::size_t available = std::min(count, num_frames_filled_);
+		if (available == 0) return {};
+
+		// Walk frames from (num_frames_filled - available) to end,
+		// copying each into the compaction buffer.
+		const std::size_t start = num_frames_filled_ - available;
+		for (std::size_t k = 0; k < available; ++k) {
+			auto src = frame_at(start + k);
+			const std::size_t dst_offset = k * num_bins_;
+			for (std::size_t i = 0; i < num_bins_; ++i)
+				compact_[dst_offset + i] = src[i];
+		}
+		return std::span<const SampleScalar>(
+			compact_.data(), available * num_bins_);
+	}
+
+	// Discard all stored frames; capacity preserved. Subsequent reads
+	// return empty until push_frame is called again.
+	void clear() {
+		write_pos_         = 0;
+		num_frames_filled_ = 0;
+		// Ring contents not zeroed — frame_at / last_frames bound their
+		// reads by num_frames_filled_, so stale ring data is
+		// unreachable.
+	}
+
+	[[nodiscard]] std::size_t num_bins()             const { return num_bins_; }
+	[[nodiscard]] std::size_t num_frames_capacity()  const { return num_frames_capacity_; }
+	[[nodiscard]] std::size_t num_frames_filled()    const { return num_frames_filled_; }
+
+private:
+	std::size_t num_bins_;
+	std::size_t num_frames_capacity_;
+	std::size_t write_pos_         = 0;
+	std::size_t num_frames_filled_ = 0;
+	mtl::vec::dense_vector<SampleScalar> ring_;
+	mtl::vec::dense_vector<SampleScalar> compact_;
+};
+
+} // namespace sw::dsp::spectrum

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ dsp_add_test(test_spectrum_markers          "Tests/Spectrum")
 dsp_add_test(test_spectrum_vbw_filter       "Tests/Spectrum")
 dsp_add_test(test_spectrum_rbw_filter       "Tests/Spectrum")
 dsp_add_test(test_spectrum_realtime         "Tests/Spectrum")
+dsp_add_test(test_spectrum_waterfall        "Tests/Spectrum")
 
 # =============================================================================
 # Conditioning — AGC, compressor, envelope, sample-rate conversion, noise shaping

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,7 +47,8 @@ Tests/
 │   ├── test_spectrum_markers             find_peaks / harmonic_markers / delta marker
 │   ├── test_spectrum_vbw_filter          Video-bandwidth (post-detector) LPF
 │   ├── test_spectrum_rbw_filter          Resolution-bandwidth (sync-tuned) BPF
-│   └── test_spectrum_realtime            Streaming overlapping FFT engine
+│   ├── test_spectrum_realtime            Streaming overlapping FFT engine
+│   └── test_spectrum_waterfall           Circular 2D buffer for spectrogram displays
 ├── Conditioning/
 │   ├── test_conditioning        AGC, compressor, envelope detector
 │   ├── test_src                 Rational sample-rate conversion

--- a/tests/test_spectrum_waterfall.cpp
+++ b/tests/test_spectrum_waterfall.cpp
@@ -1,0 +1,266 @@
+// test_spectrum_waterfall.cpp: tests for the waterfall buffer (circular
+// 2D trace memory for spectrogram displays).
+//
+// Coverage:
+//   - Construction validates non-zero num_bins / num_frames
+//   - push_frame: length mismatch throws
+//   - Partial fill: num_frames_filled() grows up to capacity, then
+//     saturates
+//   - Wrap point: after capacity + k pushes, the oldest stored frame
+//     is the (k+1)-th push (the first k were evicted)
+//   - frame_at: zero-copy single-frame access; out-of-range throws
+//   - last_frames: chronological order, count clamping at fill,
+//     count==0 returns empty span
+//   - clear() resets state and lets fresh pushes start over
+//   - Mixed-precision storage: float frames stored and retrieved
+//     bit-exactly (this is pure storage; no arithmetic)
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <sw/dsp/spectrum/waterfall_buffer.hpp>
+
+using namespace sw::dsp::spectrum;
+using W = WaterfallBuffer<double>;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+// Helper: build a frame of length B where each sample equals
+// frame_id * 100 + bin (gives unique values for verification).
+static std::vector<double> make_frame(std::size_t B, double frame_id) {
+	std::vector<double> f(B);
+	for (std::size_t i = 0; i < B; ++i)
+		f[i] = frame_id * 100.0 + static_cast<double>(i);
+	return f;
+}
+
+// ============================================================================
+// Construction
+// ============================================================================
+
+void test_construction_validation() {
+	bool t1 = false, t2 = false;
+	try { W(0, 4); } catch (const std::invalid_argument&) { t1 = true; }
+	REQUIRE(t1);
+	try { W(8, 0); } catch (const std::invalid_argument&) { t2 = true; }
+	REQUIRE(t2);
+
+	// Valid construction: empty initial state.
+	W w(8, 4);
+	REQUIRE(w.num_bins() == 8);
+	REQUIRE(w.num_frames_capacity() == 4);
+	REQUIRE(w.num_frames_filled() == 0);
+	std::cout << "  construction_validation: passed\n";
+}
+
+// ============================================================================
+// push_frame: length mismatch
+// ============================================================================
+
+void test_push_frame_length_mismatch_throws() {
+	W w(8, 4);
+	std::array<double, 7> wrong{};
+	bool threw = false;
+	try { w.push_frame(std::span<const double>{wrong}); }
+	catch (const std::invalid_argument&) { threw = true; }
+	REQUIRE(threw);
+	std::cout << "  push_frame_length_mismatch_throws: passed\n";
+}
+
+// ============================================================================
+// Partial fill: num_frames_filled grows then saturates
+// ============================================================================
+
+void test_partial_fill_saturates_at_capacity() {
+	const std::size_t B = 4;
+	const std::size_t C = 3;
+	W w(B, C);
+
+	for (std::size_t k = 0; k < C; ++k) {
+		auto f = make_frame(B, static_cast<double>(k));
+		w.push_frame(std::span<const double>{f});
+		REQUIRE(w.num_frames_filled() == k + 1);
+	}
+	// Capacity reached. Push 5 more — num_frames_filled stays at C.
+	for (std::size_t k = 0; k < 5; ++k) {
+		auto f = make_frame(B, static_cast<double>(C + k));
+		w.push_frame(std::span<const double>{f});
+		REQUIRE(w.num_frames_filled() == C);
+	}
+	std::cout << "  partial_fill_saturates_at_capacity: passed\n";
+}
+
+// ============================================================================
+// Wrap point: oldest survives correctly
+// ============================================================================
+
+void test_wrap_oldest_survivor() {
+	// Capacity 3. Push frames with ids 0..6. After 7 pushes, the
+	// stored frames are the last 3: ids 4, 5, 6. frame_at(0) = id 4,
+	// frame_at(1) = id 5, frame_at(2) = id 6.
+	const std::size_t B = 4;
+	const std::size_t C = 3;
+	W w(B, C);
+	for (std::size_t id = 0; id < 7; ++id) {
+		auto f = make_frame(B, static_cast<double>(id));
+		w.push_frame(std::span<const double>{f});
+	}
+	REQUIRE(w.num_frames_filled() == C);
+	for (std::size_t i = 0; i < C; ++i) {
+		auto f = w.frame_at(i);
+		const double expected_id = static_cast<double>(4 + i);
+		REQUIRE(f[0] == expected_id * 100.0 + 0.0);
+		REQUIRE(f[B - 1] == expected_id * 100.0 + static_cast<double>(B - 1));
+	}
+	std::cout << "  wrap_oldest_survivor: passed\n";
+}
+
+// ============================================================================
+// frame_at: out-of-range throws
+// ============================================================================
+
+void test_frame_at_out_of_range_throws() {
+	W w(4, 3);
+	bool threw_empty = false, threw_full = false;
+
+	// Empty: any index throws.
+	try { (void)w.frame_at(0); } catch (const std::out_of_range&) { threw_empty = true; }
+	REQUIRE(threw_empty);
+
+	// Push 2 frames. frame_at(0) and frame_at(1) work; frame_at(2) and
+	// frame_at(7) throw.
+	auto f = make_frame(4, 1.0);
+	w.push_frame(std::span<const double>{f});
+	w.push_frame(std::span<const double>{f});
+	(void)w.frame_at(0);
+	(void)w.frame_at(1);
+	try { (void)w.frame_at(2); } catch (const std::out_of_range&) { threw_full = true; }
+	REQUIRE(threw_full);
+	std::cout << "  frame_at_out_of_range_throws: passed\n";
+}
+
+// ============================================================================
+// last_frames: chronological order + clamping
+// ============================================================================
+
+void test_last_frames_chronological() {
+	const std::size_t B = 4;
+	const std::size_t C = 5;
+	W w(B, C);
+	// Push 7 frames (ids 0..6). Stored: ids 2..6.
+	for (std::size_t id = 0; id < 7; ++id) {
+		auto f = make_frame(B, static_cast<double>(id));
+		w.push_frame(std::span<const double>{f});
+	}
+	// last_frames(3) should return ids 4, 5, 6 in that order.
+	auto view = w.last_frames(3);
+	REQUIRE(view.size() == 3 * B);
+	for (std::size_t k = 0; k < 3; ++k) {
+		const double expected_id = static_cast<double>(4 + k);
+		for (std::size_t i = 0; i < B; ++i) {
+			const std::size_t flat = k * B + i;
+			REQUIRE(view[flat] == expected_id * 100.0 + static_cast<double>(i));
+		}
+	}
+	std::cout << "  last_frames_chronological: passed\n";
+}
+
+void test_last_frames_clamping() {
+	const std::size_t B = 4;
+	const std::size_t C = 5;
+	W w(B, C);
+	// Push only 2 frames; ask for 10. Should return 2.
+	for (std::size_t id = 0; id < 2; ++id) {
+		auto f = make_frame(B, static_cast<double>(id));
+		w.push_frame(std::span<const double>{f});
+	}
+	auto view = w.last_frames(10);
+	REQUIRE(view.size() == 2 * B);
+	// Frame 0 first, frame 1 next.
+	REQUIRE(view[0]                == 0.0 * 100.0 + 0.0);
+	REQUIRE(view[B + 0]            == 1.0 * 100.0 + 0.0);
+
+	// last_frames(0) returns empty.
+	auto empty = w.last_frames(0);
+	REQUIRE(empty.empty());
+	std::cout << "  last_frames_clamping: passed\n";
+}
+
+// ============================================================================
+// clear() resets state
+// ============================================================================
+
+void test_clear_resets_state() {
+	W w(4, 3);
+	for (std::size_t id = 0; id < 5; ++id) {
+		auto f = make_frame(4, static_cast<double>(id));
+		w.push_frame(std::span<const double>{f});
+	}
+	REQUIRE(w.num_frames_filled() == 3);
+
+	w.clear();
+	REQUIRE(w.num_frames_filled() == 0);
+	REQUIRE(w.last_frames(5).empty());
+
+	// Push fresh frame: shows up at index 0.
+	auto f = make_frame(4, 99.0);
+	w.push_frame(std::span<const double>{f});
+	REQUIRE(w.num_frames_filled() == 1);
+	auto frame = w.frame_at(0);
+	REQUIRE(frame[0] == 99.0 * 100.0 + 0.0);
+	std::cout << "  clear_resets_state: passed\n";
+}
+
+// ============================================================================
+// Mixed-precision storage: round-trip exactness
+// ============================================================================
+
+void test_float_storage_round_trip() {
+	using WF = WaterfallBuffer<float>;
+	WF wf(4, 3);
+	std::array<float, 4> a = {1.5f, 2.25f, -3.125f, 4.75f};
+	wf.push_frame(std::span<const float>{a});
+	auto f = wf.frame_at(0);
+	for (std::size_t i = 0; i < 4; ++i) REQUIRE(f[i] == a[i]);
+	std::cout << "  float_storage_round_trip: passed\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_spectrum_waterfall\n";
+
+		test_construction_validation();
+		test_push_frame_length_mismatch_throws();
+		test_partial_fill_saturates_at_capacity();
+		test_wrap_oldest_survivor();
+		test_frame_at_out_of_range_throws();
+		test_last_frames_chronological();
+		test_last_frames_clamping();
+		test_clear_resets_state();
+		test_float_storage_round_trip();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}

--- a/tests/test_spectrum_waterfall.cpp
+++ b/tests/test_spectrum_waterfall.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iostream>
+#include <limits>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -53,11 +54,17 @@ static std::vector<double> make_frame(std::size_t B, double frame_id) {
 // ============================================================================
 
 void test_construction_validation() {
-	bool t1 = false, t2 = false;
+	bool t1 = false, t2 = false, t3 = false;
 	try { W(0, 4); } catch (const std::invalid_argument&) { t1 = true; }
 	REQUIRE(t1);
 	try { W(8, 0); } catch (const std::invalid_argument&) { t2 = true; }
 	REQUIRE(t2);
+
+	// Multiplication overflow guard: num_bins * num_frames must fit in
+	// size_t. Use values whose product overflows on any 64-bit system.
+	const std::size_t huge = std::numeric_limits<std::size_t>::max() / 2 + 1;
+	try { W(huge, 4); } catch (const std::length_error&) { t3 = true; }
+	REQUIRE(t3);
 
 	// Valid construction: empty initial state.
 	W w(8, 4);
@@ -135,14 +142,15 @@ void test_wrap_oldest_survivor() {
 
 void test_frame_at_out_of_range_throws() {
 	W w(4, 3);
-	bool threw_empty = false, threw_full = false;
+	bool threw_empty = false, threw_full = false, threw_far = false;
 
 	// Empty: any index throws.
 	try { (void)w.frame_at(0); } catch (const std::out_of_range&) { threw_empty = true; }
 	REQUIRE(threw_empty);
 
-	// Push 2 frames. frame_at(0) and frame_at(1) work; frame_at(2) and
-	// frame_at(7) throw.
+	// Push 2 frames. frame_at(0) and frame_at(1) work; frame_at(2)
+	// (just past the filled count) and frame_at(7) (well past it,
+	// even past capacity) both throw.
 	auto f = make_frame(4, 1.0);
 	w.push_frame(std::span<const double>{f});
 	w.push_frame(std::span<const double>{f});
@@ -150,6 +158,8 @@ void test_frame_at_out_of_range_throws() {
 	(void)w.frame_at(1);
 	try { (void)w.frame_at(2); } catch (const std::out_of_range&) { threw_full = true; }
 	REQUIRE(threw_full);
+	try { (void)w.frame_at(7); } catch (const std::out_of_range&) { threw_far = true; }
+	REQUIRE(threw_far);
 	std::cout << "  frame_at_out_of_range_throws: passed\n";
 }
 


### PR DESCRIPTION
## Summary
- Seventh sub-issue under #134. Circular 2D buffer storing the last `N` FFT magnitude frames from `RealtimeSpectrum` (#180). Data structure behind a waterfall / spectrogram display.

## API
```cpp
template <DspScalar SampleScalar>
class WaterfallBuffer {
public:
    WaterfallBuffer(std::size_t num_bins, std::size_t num_frames);

    void push_frame(std::span<const SampleScalar> magnitude);

    // Zero-copy single-frame access; idx 0 = oldest, filled-1 = newest.
    std::span<const SampleScalar> frame_at(std::size_t idx_from_oldest) const;

    // Compacted multi-frame view, chronological order, flat layout.
    // Non-const (internal compaction buffer); count clamps to filled.
    std::span<const SampleScalar> last_frames(std::size_t count);

    void clear();
    std::size_t num_bins() const;
    std::size_t num_frames_capacity() const;
    std::size_t num_frames_filled() const;
};
```

## Naming note
Class is `WaterfallBuffer` (not `Spectrogram`) to avoid colliding with `sw::dsp::spectral::Spectrogram`, which is the existing batch STFT in the general-spectral module. **Spectral** = general DSP transforms; **Spectrum** = analyzer-specific stages (this file). The issue's "spectrogram / waterfall buffer" title cleanly maps to the latter name.

## Design notes
- **Single-frame access is zero-copy**: each frame occupies `num_bins` consecutive entries in the ring, so a single frame view is always contiguous regardless of wrap position.
- **Multi-frame access requires compaction** because frames straddling the wrap point aren't contiguous in storage. `last_frames()` is therefore non-const (writes the compaction buffer). Suitable for once-per-display-refresh use; not a hot loop.
- **`count` clamps to `num_frames_filled()`** — fewer-than-requested returned during the partial-fill window; `count == 0` returns empty span.

## Mixed-precision contract
Pure storage; no arithmetic. SampleScalar values are byte-copied through push/read; round-trip is bit-exact for any DspScalar.

## Changes
- `include/sw/dsp/spectrum/waterfall_buffer.hpp` — new module (~140 lines)
- `tests/test_spectrum_waterfall.cpp` — 9 sub-tests (~250 lines)
- `tests/CMakeLists.txt` + `tests/README.md` — registration

## Test results
| Target                   | gcc build | gcc test | clang build | clang test |
|--------------------------|-----------|----------|-------------|------------|
| test_spectrum_waterfall  | OK        | 9/9 PASS | OK          | 9/9 PASS   |
| Full ctest (47 tests)    | OK        | 47/47    | OK          | 47/47      |

Coverage: construction validation, push length-mismatch throws, partial-fill saturation, wrap-point eviction order, `frame_at` out-of-range throws, `last_frames` chronological order + clamping + zero-count, `clear` resets, float-storage round-trip.

## Test plan
- [x] Fast CI passes
- [x] CodeRabbit review (drafts skip auto-review; trigger with `@coderabbitai review`)
- [x] Promote to ready: `gh pr ready`

Resolves #181

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a spectrogram "waterfall" circular 2D buffer for efficient storage and real-time display of spectral data, with frame-level push, indexed access, bulk retrieval, and clear/reset behavior.

* **Tests**
  * Added comprehensive unit tests validating construction, bounds/overflow checks, push/read semantics, wrap-around behavior, bulk retrieval ordering, mixed-precision case, and clear/reset.

* **Documentation**
  * Updated test hierarchy docs to include the new spectrogram buffer test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->