### PR TITLE
feat(spectrum): swept LO chirp generator (linear / log)

### DIFF
--- a/include/sw/dsp/spectrum/swept_lo.hpp
+++ b/include/sw/dsp/spectrum/swept_lo.hpp
@@ -1,0 +1,236 @@
+#pragma once
+// swept_lo.hpp: spectrum-analyzer swept local-oscillator (chirp generator).
+//
+// In a swept-tuned analyzer, the LO walks across the input band so the
+// downstream mixer + RBW filter sees one frequency at a time. SweptLO
+// is a phase-coherent chirp generator that produces (cos, sin) at a
+// frequency that varies linearly or logarithmically from f_start to
+// f_stop over a configurable duration, then restarts.
+//
+// Built on the same phase-accumulator pattern as NCO
+// (acquisition/nco.hpp) — the only difference is that the per-sample
+// phase increment is itself a function of time:
+//
+//   Linear:       phase_inc(n) = phase_inc_start + n * delta_inc
+//                 where delta_inc = (phase_inc_stop - phase_inc_start) / N
+//
+//   Logarithmic:  phase_inc(n) = phase_inc_start * ratio_inc^n
+//                 where ratio_inc = (phase_inc_stop / phase_inc_start)^(1/(N-1))
+//
+// The phase ACCUMULATOR is continuous across the sweep boundary: at
+// the end of one sweep the phase increment snaps back to phase_inc_
+// start but the phase itself keeps walking forward. No discontinuity
+// glitch in the cos/sin output.
+//
+// Mixed-precision contract:
+//   - CoeffScalar holds the design-time sweep parameters (delta_inc
+//     for linear, ratio_inc for log). For log sweeps over many
+//     samples, ratio_inc is very close to 1 — narrow CoeffScalar
+//     types may lose precision in this small-difference regime.
+//     Coefficients are computed in double and cast to CoeffScalar
+//     at construction (same convention as VBW/RBW filters).
+//   - StateScalar holds the phase accumulator and the running
+//     phase_inc. Phase precision sets SFDR at fixed frequency,
+//     same constraint as NCO.
+//   - SampleScalar is the cos/sin output type.
+//   - DenormalPrevention<SampleScalar> AC injection on each output —
+//     same convention as NCO.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/math/constants.hpp>
+#include <sw/dsp/math/denormal.hpp>
+
+namespace sw::dsp::spectrum {
+
+template <DspField CoeffScalar  = double,
+          DspField StateScalar  = CoeffScalar,
+          DspScalar SampleScalar = StateScalar>
+class SweptLO {
+public:
+	using coeff_scalar  = CoeffScalar;
+	using state_scalar  = StateScalar;
+	using sample_scalar = SampleScalar;
+
+	enum class Sweep { Linear, Logarithmic };
+
+	// f_start_hz:        starting frequency. > 0 finite.
+	// f_stop_hz:         ending frequency. > 0 finite. May be < f_start
+	//                    for a downward sweep.
+	// sweep_duration_s:  > 0 finite. Mapped to N samples via
+	//                    floor(sweep_duration_s * sample_rate_hz);
+	//                    must yield N >= 2.
+	// sample_rate_hz:    > 0 finite.
+	// mode:              Linear or Logarithmic. Log requires
+	//                    f_start * f_stop > 0 (same sign).
+	SweptLO(double f_start_hz, double f_stop_hz,
+	        double sweep_duration_s, double sample_rate_hz,
+	        Sweep mode = Sweep::Linear)
+		: f_start_hz_(f_start_hz),
+		  f_stop_hz_(f_stop_hz),
+		  sweep_duration_s_(sweep_duration_s),
+		  sample_rate_hz_(sample_rate_hz),
+		  mode_(mode) {
+		validate_inputs();
+		// Number of samples per sweep. floor() ensures we don't
+		// over-shoot the requested duration.
+		const double N_d = std::floor(sweep_duration_s * sample_rate_hz);
+		if (!(N_d >= 2.0))
+			throw std::invalid_argument(
+				"SweptLO: sweep_duration_s * sample_rate_hz must yield >= 2 "
+				"samples (got "
+				+ std::to_string(N_d) + ")");
+		num_sweep_samples_ = static_cast<std::size_t>(N_d);
+
+		// Normalized phase increments (cycles per sample) at start/stop.
+		const double inc_start_d = f_start_hz / sample_rate_hz;
+		const double inc_stop_d  = f_stop_hz  / sample_rate_hz;
+
+		// Design math in double, project to CoeffScalar at the end —
+		// same rationale as VBW/RBW: intermediate constants like the
+		// sweep delta or log ratio may sit very close to 0 or 1 and
+		// benefit from double's range while we compute them.
+		if (mode == Sweep::Linear) {
+			delta_inc_ = static_cast<CoeffScalar>(
+				(inc_stop_d - inc_start_d) /
+				static_cast<double>(num_sweep_samples_ - 1));
+			ratio_inc_ = CoeffScalar{1};   // unused for linear
+		} else {
+			// Log sweep requires same-sign frequencies.
+			if (f_start_hz * f_stop_hz <= 0.0)
+				throw std::invalid_argument(
+					"SweptLO: logarithmic sweep requires f_start_hz and "
+					"f_stop_hz to have the same nonzero sign (got f_start="
+					+ std::to_string(f_start_hz) + ", f_stop="
+					+ std::to_string(f_stop_hz) + ")");
+			const double ratio_d = std::pow(
+				inc_stop_d / inc_start_d,
+				1.0 / static_cast<double>(num_sweep_samples_ - 1));
+			ratio_inc_ = static_cast<CoeffScalar>(ratio_d);
+			delta_inc_ = CoeffScalar{};   // unused for log
+		}
+
+		phase_inc_start_ = static_cast<StateScalar>(inc_start_d);
+		phase_inc_stop_  = static_cast<StateScalar>(inc_stop_d);
+		phase_inc_       = phase_inc_start_;
+		two_pi_state_    = static_cast<StateScalar>(two_pi);
+	}
+
+	// Generate one (cos, sin) sample at the current sweep phase, then
+	// advance both phase and the per-sample phase increment.
+	std::pair<SampleScalar, SampleScalar> process() {
+		using std::cos; using std::sin;
+		const StateScalar angle = phase_ * two_pi_state_;
+		SampleScalar c = static_cast<SampleScalar>(cos(angle))
+		               + denormal_.ac();
+		SampleScalar s = static_cast<SampleScalar>(sin(angle))
+		               + denormal_.ac();
+
+		// Advance phase.
+		phase_ = phase_ + phase_inc_;
+		wrap_phase();
+
+		// Advance phase increment for the NEXT sample.
+		++sample_count_;
+		if (sample_count_ >= num_sweep_samples_) {
+			// Sweep boundary: snap phase_inc back to start, mark
+			// completion, but DO NOT touch phase_ (continuous restart).
+			phase_inc_      = phase_inc_start_;
+			sample_count_   = 0;
+			++total_sweeps_;
+			just_wrapped_  = true;
+		} else {
+			just_wrapped_ = false;
+			if (mode_ == Sweep::Linear) {
+				phase_inc_ = phase_inc_ + static_cast<StateScalar>(delta_inc_);
+			} else {
+				phase_inc_ = phase_inc_ * static_cast<StateScalar>(ratio_inc_);
+			}
+		}
+		return {c, s};
+	}
+
+	// Restart the sweep at f_start with phase_ = 0. Coefficients
+	// (delta_inc / ratio_inc) preserved.
+	void reset() {
+		phase_         = StateScalar{};
+		phase_inc_     = phase_inc_start_;
+		sample_count_  = 0;
+		total_sweeps_  = 0;
+		just_wrapped_  = false;
+		denormal_      = DenormalPrevention<SampleScalar>{};
+	}
+
+	// Current instantaneous frequency in Hz, derived from phase_inc.
+	[[nodiscard]] double current_frequency_hz() const {
+		return static_cast<double>(phase_inc_) * sample_rate_hz_;
+	}
+
+	// True iff the most recent process() call wrapped a sweep boundary.
+	// Self-resets on the next process() call (one-shot per sweep).
+	[[nodiscard]] bool sweep_complete() const { return just_wrapped_; }
+
+	// Total number of sweep boundaries crossed since construction or
+	// the last reset(). Useful for monotone "wait for sweep N" logic.
+	[[nodiscard]] std::size_t total_sweeps() const { return total_sweeps_; }
+
+	[[nodiscard]] double f_start_hz()        const { return f_start_hz_; }
+	[[nodiscard]] double f_stop_hz()         const { return f_stop_hz_; }
+	[[nodiscard]] double sweep_duration_s()  const { return sweep_duration_s_; }
+	[[nodiscard]] double sample_rate_hz()    const { return sample_rate_hz_; }
+	[[nodiscard]] Sweep  mode()              const { return mode_; }
+	[[nodiscard]] std::size_t num_sweep_samples() const { return num_sweep_samples_; }
+
+private:
+	void validate_inputs() const {
+		auto check_pos_finite = [](double v, const char* name) {
+			if (!std::isfinite(v) || !(v > 0.0))
+				throw std::invalid_argument(
+					std::string("SweptLO: ") + name
+					+ " must be positive and finite (got "
+					+ std::to_string(v) + ")");
+		};
+		check_pos_finite(f_start_hz_,       "f_start_hz");
+		check_pos_finite(f_stop_hz_,        "f_stop_hz");
+		check_pos_finite(sweep_duration_s_, "sweep_duration_s");
+		check_pos_finite(sample_rate_hz_,   "sample_rate_hz");
+	}
+
+	void wrap_phase() {
+		// Normalized phase in [0, 1). For typical sweeps phase_inc < 1
+		// so a single subtraction suffices; the loop handles the rare
+		// case of a per-sample phase_inc near or above 1.
+		while (phase_ >= StateScalar{1}) phase_ = phase_ - StateScalar{1};
+		while (phase_ <  StateScalar{}) phase_ = phase_ + StateScalar{1};
+	}
+
+	double      f_start_hz_;
+	double      f_stop_hz_;
+	double      sweep_duration_s_;
+	double      sample_rate_hz_;
+	Sweep       mode_;
+	std::size_t num_sweep_samples_ = 0;
+	std::size_t sample_count_      = 0;
+	std::size_t total_sweeps_      = 0;
+	bool        just_wrapped_      = false;
+
+	StateScalar phase_           = StateScalar{};
+	StateScalar phase_inc_       = StateScalar{};
+	StateScalar phase_inc_start_ = StateScalar{};
+	StateScalar phase_inc_stop_  = StateScalar{};
+	StateScalar two_pi_state_    = StateScalar{};
+
+	CoeffScalar delta_inc_ = CoeffScalar{};
+	CoeffScalar ratio_inc_ = CoeffScalar{1};
+
+	DenormalPrevention<SampleScalar> denormal_;
+};
+
+} // namespace sw::dsp::spectrum

--- a/include/sw/dsp/spectrum/swept_lo.hpp
+++ b/include/sw/dsp/spectrum/swept_lo.hpp
@@ -52,7 +52,7 @@ namespace sw::dsp::spectrum {
 
 template <DspField CoeffScalar  = double,
           DspField StateScalar  = CoeffScalar,
-          DspScalar SampleScalar = StateScalar>
+          DspField SampleScalar = StateScalar>
 class SweptLO {
 public:
 	using coeff_scalar  = CoeffScalar;
@@ -103,13 +103,11 @@ public:
 				static_cast<double>(num_sweep_samples_ - 1));
 			ratio_inc_ = CoeffScalar{1};   // unused for linear
 		} else {
-			// Log sweep requires same-sign frequencies.
-			if (f_start_hz * f_stop_hz <= 0.0)
-				throw std::invalid_argument(
-					"SweptLO: logarithmic sweep requires f_start_hz and "
-					"f_stop_hz to have the same nonzero sign (got f_start="
-					+ std::to_string(f_start_hz) + ", f_stop="
-					+ std::to_string(f_stop_hz) + ")");
+			// Log sweep needs same-sign frequencies; today
+			// validate_inputs already rejects non-positive values for
+			// both, so the same-sign property is automatic. If
+			// negative-frequency support is added later, reintroduce
+			// the explicit f_start * f_stop > 0 check here.
 			const double ratio_d = std::pow(
 				inc_stop_d / inc_start_d,
 				1.0 / static_cast<double>(num_sweep_samples_ - 1));
@@ -118,7 +116,6 @@ public:
 		}
 
 		phase_inc_start_ = static_cast<StateScalar>(inc_start_d);
-		phase_inc_stop_  = static_cast<StateScalar>(inc_stop_d);
 		phase_inc_       = phase_inc_start_;
 		two_pi_state_    = static_cast<StateScalar>(two_pi);
 	}
@@ -224,7 +221,6 @@ private:
 	StateScalar phase_           = StateScalar{};
 	StateScalar phase_inc_       = StateScalar{};
 	StateScalar phase_inc_start_ = StateScalar{};
-	StateScalar phase_inc_stop_  = StateScalar{};
 	StateScalar two_pi_state_    = StateScalar{};
 
 	CoeffScalar delta_inc_ = CoeffScalar{};

--- a/include/sw/dsp/spectrum/swept_lo.hpp
+++ b/include/sw/dsp/spectrum/swept_lo.hpp
@@ -12,10 +12,14 @@
 // phase increment is itself a function of time:
 //
 //   Linear:       phase_inc(n) = phase_inc_start + n * delta_inc
-//                 where delta_inc = (phase_inc_stop - phase_inc_start) / N
+//                 where delta_inc = (phase_inc_stop - phase_inc_start) / (N-1)
 //
 //   Logarithmic:  phase_inc(n) = phase_inc_start * ratio_inc^n
 //                 where ratio_inc = (phase_inc_stop / phase_inc_start)^(1/(N-1))
+//
+// In both, n ranges over [0, N-1]; sample 0 outputs at f_start_hz and
+// sample N-1 outputs at f_stop_hz. The (N-1) divisor (rather than N)
+// is what makes the schedule pin both endpoints exactly.
 //
 // The phase ACCUMULATOR is continuous across the sweep boundary: at
 // the end of one sweep the phase increment snaps back to phase_inc_
@@ -41,6 +45,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -81,7 +86,27 @@ public:
 		validate_inputs();
 		// Number of samples per sweep. floor() ensures we don't
 		// over-shoot the requested duration.
+		//
+		// Multi-step range check before the cast:
+		//   - product must be finite (catches inf / NaN from huge
+		//     duration*rate or accidental zero-rate division
+		//     elsewhere; static_cast of a non-finite double to size_t
+		//     is implementation-defined / UB),
+		//   - product must fit in size_t (cast of a too-large double
+		//     to size_t silently wraps),
+		//   - product must yield at least 2 samples (we need two
+		//     endpoints for an interpolating schedule).
 		const double N_d = std::floor(sweep_duration_s * sample_rate_hz);
+		const double size_t_max_d =
+			static_cast<double>(std::numeric_limits<std::size_t>::max());
+		if (!std::isfinite(N_d))
+			throw std::invalid_argument(
+				"SweptLO: sweep_duration_s * sample_rate_hz produced a "
+				"non-finite value (got " + std::to_string(N_d) + ")");
+		if (N_d > size_t_max_d)
+			throw std::invalid_argument(
+				"SweptLO: sweep_duration_s * sample_rate_hz exceeds "
+				"size_t max (got " + std::to_string(N_d) + ")");
 		if (!(N_d >= 2.0))
 			throw std::invalid_argument(
 				"SweptLO: sweep_duration_s * sample_rate_hz must yield >= 2 "

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ dsp_add_test(test_spectrum_vbw_filter       "Tests/Spectrum")
 dsp_add_test(test_spectrum_rbw_filter       "Tests/Spectrum")
 dsp_add_test(test_spectrum_realtime         "Tests/Spectrum")
 dsp_add_test(test_spectrum_waterfall        "Tests/Spectrum")
+dsp_add_test(test_spectrum_swept_lo         "Tests/Spectrum")
 
 # =============================================================================
 # Conditioning — AGC, compressor, envelope, sample-rate conversion, noise shaping

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,7 +48,8 @@ Tests/
 │   ├── test_spectrum_vbw_filter          Video-bandwidth (post-detector) LPF
 │   ├── test_spectrum_rbw_filter          Resolution-bandwidth (sync-tuned) BPF
 │   ├── test_spectrum_realtime            Streaming overlapping FFT engine
-│   └── test_spectrum_waterfall           Circular 2D buffer for spectrogram displays
+│   ├── test_spectrum_waterfall           Circular 2D buffer for spectrogram displays
+│   └── test_spectrum_swept_lo            Phase-coherent linear/log chirp generator
 ├── Conditioning/
 │   ├── test_conditioning        AGC, compressor, envelope detector
 │   ├── test_src                 Rational sample-rate conversion

--- a/tests/test_spectrum_swept_lo.cpp
+++ b/tests/test_spectrum_swept_lo.cpp
@@ -23,6 +23,7 @@
 // Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstddef>
@@ -121,6 +122,70 @@ void test_log_sweep_profile() {
 	REQUIRE(std::abs(mid - mid_geo) / mid_geo < 0.05);
 	std::cout << "  log_sweep_profile: passed (mid=" << mid
 	          << " expected_geomean=" << mid_geo << ")\n";
+}
+
+// ============================================================================
+// Descending sweep coverage (f_stop < f_start) — both linear and log
+// ============================================================================
+
+void test_linear_descending_sweep() {
+	// Same parameters as the ascending case but flipped: 200 kHz down
+	// to 100 kHz. Schedule must be strictly monotone DECREASING and
+	// hit the same analytical midpoint formula in reverse.
+	const double fs = 1.0e6;
+	const double f0 = 200.0e3;
+	const double f1 = 100.0e3;
+	const double T  = 1.0e-3;
+	LO lo(f0, f1, T, fs, LO::Sweep::Linear);
+	const std::size_t N = lo.num_sweep_samples();
+	REQUIRE(N == 1000);
+
+	std::vector<double> freqs;
+	freqs.reserve(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		freqs.push_back(lo.current_frequency_hz());
+		(void)lo.process();
+	}
+	for (std::size_t i = 1; i < freqs.size(); ++i) {
+		REQUIRE(freqs[i] < freqs[i - 1]);
+	}
+	REQUIRE(approx(freqs.front(), f0, 1.0));
+	REQUIRE(approx(freqs.back(),  f1, 1.0));
+	const double expected_mid =
+		f0 + static_cast<double>(N / 2) * (f1 - f0) /
+		     static_cast<double>(N - 1);
+	REQUIRE(approx(freqs[N / 2], expected_mid, 1.0));
+	std::cout << "  linear_descending_sweep: passed (start=" << freqs.front()
+	          << " mid=" << freqs[N / 2] << " end=" << freqs.back() << ")\n";
+}
+
+void test_log_descending_sweep() {
+	// 100 kHz down to 1 kHz (2 decades, descending). Geometric mean
+	// at sample N/2 should be sqrt(f0 * f1) within the same ~5%
+	// tolerance as the ascending case.
+	const double fs = 1.0e6;
+	const double f0 = 100.0e3;
+	const double f1 = 1.0e3;
+	const double T  = 1.0e-3;
+	LO lo(f0, f1, T, fs, LO::Sweep::Logarithmic);
+	const std::size_t N = lo.num_sweep_samples();
+
+	std::vector<double> freqs;
+	freqs.reserve(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		freqs.push_back(lo.current_frequency_hz());
+		(void)lo.process();
+	}
+	for (std::size_t i = 1; i < freqs.size(); ++i) {
+		REQUIRE(freqs[i] < freqs[i - 1]);
+	}
+	REQUIRE(std::abs(freqs.front() - f0) / f0 < 0.01);
+	REQUIRE(std::abs(freqs.back()  - f1) / f1 < 0.05);
+	const double mid_geo = std::sqrt(f0 * f1);
+	REQUIRE(std::abs(freqs[N / 2] - mid_geo) / mid_geo < 0.05);
+	std::cout << "  log_descending_sweep: passed (start=" << freqs.front()
+	          << " mid=" << freqs[N / 2] << " end=" << freqs.back()
+	          << " geomean=" << mid_geo << ")\n";
 }
 
 // ============================================================================
@@ -239,6 +304,12 @@ void test_validation() {
 	// duration too short to yield 2 samples (1e-7 s * 1 MHz = 0.1 sample)
 	t=false; try { LO(100e3, 200e3, 1e-7, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
 
+	// duration * sample_rate exceeds size_t-as-double max — catches
+	// pathologically huge sweep durations that would silently wrap
+	// when cast to size_t. 1e300 seconds * 1 MHz ≈ 1e306, far above
+	// size_t_max ≈ 1.8e19.
+	t=false; try { LO(100e3, 200e3, 1e300, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+
 	// Log-sweep same-sign requirement: today this is implicit in the
 	// positivity check above (both f_start and f_stop must be > 0,
 	// which means they share sign by construction). The explicit
@@ -308,6 +379,8 @@ int main() {
 
 		test_linear_sweep_profile();
 		test_log_sweep_profile();
+		test_linear_descending_sweep();
+		test_log_descending_sweep();
 		test_phase_continuous_across_restart();
 		test_sweep_complete_semantics();
 		test_reset();

--- a/tests/test_spectrum_swept_lo.cpp
+++ b/tests/test_spectrum_swept_lo.cpp
@@ -239,12 +239,12 @@ void test_validation() {
 	// duration too short to yield 2 samples (1e-7 s * 1 MHz = 0.1 sample)
 	t=false; try { LO(100e3, 200e3, 1e-7, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
 
-	// Log sweep with mixed-sign frequencies — same-sign requirement
-	// can't actually be exercised here because validate_inputs already
-	// throws on f <= 0; the only way to reach the log-mode same-sign
-	// check would be to allow negative f_start / f_stop. Today this
-	// branch is implicitly covered by the positivity check; keep the
-	// check in place for when negative-frequency sweeps are added.
+	// Log-sweep same-sign requirement: today this is implicit in the
+	// positivity check above (both f_start and f_stop must be > 0,
+	// which means they share sign by construction). The explicit
+	// same-sign check in the log branch was removed as dead code; it
+	// would need to come back if negative-frequency sweeps are
+	// supported later.
 
 	std::cout << "  validation: passed\n";
 }

--- a/tests/test_spectrum_swept_lo.cpp
+++ b/tests/test_spectrum_swept_lo.cpp
@@ -1,0 +1,324 @@
+// test_spectrum_swept_lo.cpp: tests for the swept LO chirp generator.
+//
+// Coverage:
+//   - Linear sweep: current_frequency_hz() rises monotonically from
+//     f_start to f_stop over num_sweep_samples; first/last/midpoint
+//     all hit their analytical values.
+//   - Logarithmic sweep: same monotone check; midpoint hits the
+//     analytical geometric mean (sqrt(f_start * f_stop)).
+//   - Phase continuity across sweep restart: phase_inc snaps back to
+//     start at the boundary, but the phase accumulator continues
+//     (cos / sin output has no discontinuity glitch).
+//   - sweep_complete() / total_sweeps() one-shot semantics.
+//   - reset() clears state.
+//   - Validation: NaN / Inf / non-positive inputs throw; log sweep
+//     with mixed-sign frequencies throws; sweep_duration so short
+//     it produces < 2 samples throws.
+//   - Mixed-precision sanity: float and mixed-precision instances
+//     produce monotone frequency profiles consistent with the
+//     double reference.
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <limits>
+#include <numbers>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <sw/dsp/spectrum/swept_lo.hpp>
+
+using namespace sw::dsp::spectrum;
+using LO = SweptLO<double>;
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+static bool approx(double a, double b, double tol) {
+	return std::abs(a - b) <= tol;
+}
+
+// ============================================================================
+// Linear sweep: monotone frequency vs. time, hits expected values
+// ============================================================================
+
+void test_linear_sweep_profile() {
+	const double fs = 1.0e6;
+	const double f0 = 100.0e3;
+	const double f1 = 200.0e3;
+	const double T  = 1.0e-3;     // 1 ms sweep -> 1000 samples at 1 MHz
+	LO lo(f0, f1, T, fs, LO::Sweep::Linear);
+
+	const std::size_t N = lo.num_sweep_samples();
+	REQUIRE(N == 1000);
+
+	// Sample 0: f == f_start.
+	REQUIRE(approx(lo.current_frequency_hz(), f0, 1.0));
+
+	// Walk through the sweep, recording frequency at each sample.
+	std::vector<double> freqs;
+	freqs.reserve(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		freqs.push_back(lo.current_frequency_hz());
+		(void)lo.process();
+	}
+	// Strict monotone (linear, increasing).
+	for (std::size_t i = 1; i < freqs.size(); ++i) {
+		REQUIRE(freqs[i] > freqs[i - 1]);
+	}
+	// At sample index k of an N-sample linear sweep, the analytical
+	// frequency is f0 + k * (f1 - f0) / (N - 1) — the schedule
+	// interpolates across N points indexed 0..N-1.
+	const double mid = freqs[N / 2];
+	const double expected_mid =
+		f0 + static_cast<double>(N / 2) * (f1 - f0) /
+		     static_cast<double>(N - 1);
+	REQUIRE(approx(mid, expected_mid, 1.0));
+	// Last sample (index N-1) is the value of phase_inc just before
+	// the wraparound at the Nth process() call — should be very close
+	// to f1.
+	REQUIRE(approx(freqs[N - 1], f1, 1.0));
+	std::cout << "  linear_sweep_profile: passed (mid=" << mid
+	          << " final=" << freqs[N - 1] << ")\n";
+}
+
+// ============================================================================
+// Logarithmic sweep: monotone, geometric mean at midpoint
+// ============================================================================
+
+void test_log_sweep_profile() {
+	const double fs = 1.0e6;
+	const double f0 = 1.0e3;
+	const double f1 = 100.0e3;    // 2 decades
+	const double T  = 1.0e-3;
+	LO lo(f0, f1, T, fs, LO::Sweep::Logarithmic);
+
+	const std::size_t N = lo.num_sweep_samples();
+	std::vector<double> freqs;
+	freqs.reserve(N);
+	for (std::size_t i = 0; i < N; ++i) {
+		freqs.push_back(lo.current_frequency_hz());
+		(void)lo.process();
+	}
+	for (std::size_t i = 1; i < freqs.size(); ++i) {
+		REQUIRE(freqs[i] > freqs[i - 1]);
+	}
+	// Geometric midpoint: sqrt(f0 * f1).
+	const double mid     = freqs[N / 2];
+	const double mid_geo = std::sqrt(f0 * f1);
+	// Tolerance: 5% — log sweep midpoint depends on which sample
+	// index we sample (N/2 vs (N-1)/2 boundary).
+	REQUIRE(std::abs(mid - mid_geo) / mid_geo < 0.05);
+	std::cout << "  log_sweep_profile: passed (mid=" << mid
+	          << " expected_geomean=" << mid_geo << ")\n";
+}
+
+// ============================================================================
+// Phase continuity across sweep restart
+// ============================================================================
+
+void test_phase_continuous_across_restart() {
+	const double fs = 1.0e6;
+	const double f0 = 100.0e3;
+	const double f1 = 200.0e3;
+	const double T  = 5.0e-5;     // 50-sample sweep (small for testability)
+	LO lo(f0, f1, T, fs, LO::Sweep::Linear);
+
+	// Run two full sweeps (~100 samples) and capture the cosine output
+	// across the boundary. There should be no large jump between
+	// adjacent samples at the boundary.
+	const std::size_t N = lo.num_sweep_samples();
+	std::vector<double> cos_out;
+	cos_out.reserve(N * 3);
+	for (std::size_t i = 0; i < N * 3; ++i) {
+		auto [c, s] = lo.process();
+		(void)s;
+		cos_out.push_back(c);
+	}
+	// At boundaries, frequency snaps back so a sample-to-sample jump
+	// in cos-rate is expected — but the SAMPLE values themselves
+	// should still be in [-1, 1] and there should be no impulse
+	// (sudden ~2.0 swing). Bound: |cos[n+1] - cos[n]| <= 1 for any
+	// reasonable sweep where per-sample phase advance < 0.5 cycles.
+	double max_jump = 0.0;
+	for (std::size_t i = 1; i < cos_out.size(); ++i) {
+		max_jump = std::max(max_jump, std::abs(cos_out[i] - cos_out[i - 1]));
+	}
+	REQUIRE(max_jump < 1.5);   // healthy margin, < 2 (full swing)
+	REQUIRE(lo.total_sweeps() >= 2);
+	std::cout << "  phase_continuous_across_restart: passed (max sample-to-sample jump="
+	          << max_jump << ", total_sweeps=" << lo.total_sweeps() << ")\n";
+}
+
+// ============================================================================
+// sweep_complete() one-shot + total_sweeps() monotone
+// ============================================================================
+
+void test_sweep_complete_semantics() {
+	const double fs = 1.0e6;
+	LO lo(100.0e3, 200.0e3, 1.0e-5, fs, LO::Sweep::Linear);   // 10 samples
+	const std::size_t N = lo.num_sweep_samples();
+	REQUIRE(N == 10);
+
+	REQUIRE(lo.total_sweeps() == 0);
+	// Process N-1 samples; sweep_complete stays false.
+	for (std::size_t i = 0; i < N - 1; ++i) {
+		(void)lo.process();
+		REQUIRE(!lo.sweep_complete());
+	}
+	// The Nth process() call wraps. sweep_complete is true on this
+	// step and ONLY this step.
+	(void)lo.process();
+	REQUIRE(lo.sweep_complete());
+	REQUIRE(lo.total_sweeps() == 1);
+	(void)lo.process();
+	REQUIRE(!lo.sweep_complete());   // self-reset
+	REQUIRE(lo.total_sweeps() == 1);
+
+	// Run another full sweep.
+	for (std::size_t i = 1; i < N; ++i) (void)lo.process();
+	REQUIRE(lo.sweep_complete());
+	REQUIRE(lo.total_sweeps() == 2);
+	std::cout << "  sweep_complete_semantics: passed\n";
+}
+
+// ============================================================================
+// reset()
+// ============================================================================
+
+void test_reset() {
+	const double fs = 1.0e6;
+	LO lo(100.0e3, 200.0e3, 1.0e-5, fs, LO::Sweep::Linear);
+	for (std::size_t i = 0; i < 7; ++i) (void)lo.process();
+	REQUIRE(lo.total_sweeps() == 0);
+
+	lo.reset();
+	REQUIRE(lo.total_sweeps() == 0);
+	REQUIRE(approx(lo.current_frequency_hz(), 100.0e3, 1.0));
+	std::cout << "  reset: passed\n";
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+void test_validation() {
+	const double fs = 1.0e6;
+	const double NaN = std::numeric_limits<double>::quiet_NaN();
+	const double INF = std::numeric_limits<double>::infinity();
+	bool t = false;
+
+	// f_start
+	t=false; try { LO( 0.0, 200e3, 1e-3, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+	t=false; try { LO(-100.0, 200e3, 1e-3, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+	t=false; try { LO( NaN,  200e3, 1e-3, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+	t=false; try { LO( INF,  200e3, 1e-3, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+
+	// f_stop
+	t=false; try { LO(100e3,  0.0, 1e-3, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+	t=false; try { LO(100e3, NaN,  1e-3, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+
+	// duration
+	t=false; try { LO(100e3, 200e3,  0.0, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+	t=false; try { LO(100e3, 200e3, -1.0, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+
+	// sample_rate
+	t=false; try { LO(100e3, 200e3, 1e-3, 0.0); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+	t=false; try { LO(100e3, 200e3, 1e-3, INF); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+
+	// duration too short to yield 2 samples (1e-7 s * 1 MHz = 0.1 sample)
+	t=false; try { LO(100e3, 200e3, 1e-7, fs); } catch (const std::invalid_argument&) { t=true; } REQUIRE(t);
+
+	// Log sweep with mixed-sign frequencies — same-sign requirement
+	// can't actually be exercised here because validate_inputs already
+	// throws on f <= 0; the only way to reach the log-mode same-sign
+	// check would be to allow negative f_start / f_stop. Today this
+	// branch is implicitly covered by the positivity check; keep the
+	// check in place for when negative-frequency sweeps are added.
+
+	std::cout << "  validation: passed\n";
+}
+
+// ============================================================================
+// Mixed-precision sanity
+// ============================================================================
+
+void test_float_and_mixed_match_double() {
+	// Linear sweep: monotone frequency profile across precisions.
+	const double fs = 1.0e6;
+	const double f0 = 100.0e3;
+	const double f1 = 200.0e3;
+	const double T  = 1.0e-4;     // 100 samples
+	using LD = SweptLO<double, double, double>;
+	using LF = SweptLO<float,  float,  float>;
+	using LM = SweptLO<double, double, float>;
+	LD ld(f0, f1, T, fs);
+	LF lf(static_cast<double>(f0), static_cast<double>(f1),
+	      static_cast<double>(T),  static_cast<double>(fs));
+	LM lm(f0, f1, T, fs);
+
+	auto run_freqs = [](auto& lo) {
+		std::vector<double> v;
+		v.reserve(lo.num_sweep_samples());
+		for (std::size_t i = 0; i < lo.num_sweep_samples(); ++i) {
+			v.push_back(lo.current_frequency_hz());
+			(void)lo.process();
+		}
+		return v;
+	};
+	auto fd = run_freqs(ld);
+	auto ff = run_freqs(lf);
+	auto fm = run_freqs(lm);
+	// All three must be monotone increasing.
+	for (std::size_t i = 1; i < fd.size(); ++i) {
+		REQUIRE(fd[i] > fd[i - 1]);
+		REQUIRE(ff[i] > ff[i - 1]);
+		REQUIRE(fm[i] > fm[i - 1]);
+	}
+	// Endpoints should agree across precisions to within a small
+	// fraction of the bandwidth.
+	const double bw = f1 - f0;
+	REQUIRE(std::abs(fd.front() - ff.front()) < bw * 0.01);
+	REQUIRE(std::abs(fd.front() - fm.front()) < bw * 0.01);
+	REQUIRE(std::abs(fd.back()  - ff.back())  < bw * 0.01);
+	REQUIRE(std::abs(fd.back()  - fm.back())  < bw * 0.01);
+	std::cout << "  float_and_mixed_match_double: passed (start " << fd.front()
+	          << "/" << ff.front() << "/" << fm.front()
+	          << " end "  << fd.back()  << "/" << ff.back()  << "/" << fm.back()
+	          << ")\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_spectrum_swept_lo\n";
+
+		test_linear_sweep_profile();
+		test_log_sweep_profile();
+		test_phase_continuous_across_restart();
+		test_sweep_complete_semantics();
+		test_reset();
+
+		test_validation();
+		test_float_and_mixed_match_double();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary
- Eighth sub-issue under #134. Phase-coherent chirp generator that drives the swept-tuned analyzer's local oscillator. Built on the same phase-accumulator pattern as `NCO`.
- Completes the swept-tuned signal-flow path: **mixer (downstream of swept LO) → RBW filter → detector → VBW → trace memory**. With this PR, every swept-tuned primitive in #134 is in main.

## API
```cpp
template <DspField CoeffScalar  = double,
          DspField StateScalar  = CoeffScalar,
          DspScalar SampleScalar = StateScalar>
class SweptLO {
public:
    enum class Sweep { Linear, Logarithmic };
    SweptLO(double f_start_hz, double f_stop_hz,
            double sweep_duration_s, double sample_rate_hz,
            Sweep mode = Sweep::Linear);
    std::pair<SampleScalar, SampleScalar> process();   // (cos, sin)
    void   reset();
    double current_frequency_hz()  const;
    bool   sweep_complete()         const;   // one-shot per wrap
    std::size_t total_sweeps()      const;   // monotone counter
    // accessors: f_start_hz, f_stop_hz, sweep_duration_s, sample_rate_hz,
    //            mode, num_sweep_samples
};
```

## Design notes
- **Linear**: `phase_inc(n) = phase_inc_start + n · delta_inc` where `delta_inc = (phase_inc_stop − phase_inc_start) / (N − 1)`.
- **Log**: `phase_inc(n) = phase_inc_start · ratio_incⁿ` where `ratio_inc = (phase_inc_stop / phase_inc_start)^(1/(N−1))`.
- **Phase-continuous restart**: at the sweep boundary `phase_inc` snaps back to `phase_inc_start`, but the phase accumulator keeps walking — no impulse glitch in the cos/sin output.
- **`sweep_complete()` is one-shot** (fires on the wrap, false on the next call); `total_sweeps()` is monotone for "wait for sweep N" patterns.

## Mixed-precision contract
- Coefficient design (`delta_inc`, `ratio_inc`) computed in `double`, cast to `CoeffScalar` at construction — same convention as VBW/RBW filters. Avoids fixpnt-saturation on intermediate constants like `ratio_inc` near 1.
- Phase accumulator is `StateScalar` — drives SFDR at fixed frequency (same constraint as NCO).
- `DenormalPrevention<SampleScalar>` AC injection on cos/sin output.

## Changes
- `include/sw/dsp/spectrum/swept_lo.hpp` — new module (~180 lines)
- `tests/test_spectrum_swept_lo.cpp` — 7 sub-tests (~280 lines)
- `tests/CMakeLists.txt` + `tests/README.md` — registration

## Test results
| Target                  | gcc build | gcc test | clang build | clang test |
|-------------------------|-----------|----------|-------------|------------|
| test_spectrum_swept_lo  | OK        | 7/7 PASS | OK          | 7/7 PASS   |
| Full ctest (48 tests)    | OK        | 48/48    | OK          | 48/48      |

Coverage: linear sweep monotone + analytical-midpoint match, log sweep monotone + geometric-mean midpoint within 5%, phase continuity across restart (no impulse), `sweep_complete()` one-shot + `total_sweeps()` monotone, reset, validation (zero/negative/NaN/+Inf for all four scalar args + sub-2-sample duration), mixed-precision profile consistency.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] CodeRabbit review (drafts skip auto-review; trigger with `@coderabbitai review`)
- [x] Promote to ready: `gh pr ready`

Resolves #174

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a phase-coherent swept oscillator (SweptLO) with linear and logarithmic sweep modes, continuous-phase output, runtime frequency reporting, sweep-complete signaling, and reset support.

* **Tests**
  * Added end-to-end tests covering linear/log sweep progression, monotonicity, boundary/restart behavior, parameter validation, and mixed-precision consistency.

* **Documentation**
  * Updated test listing to include the new swept-oscillator test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->