### PR TITLE
feat(spectrum): front-end corrector alias for EqualizerFilter

### DIFF
--- a/include/sw/dsp/spectrum/front_end_corrector.hpp
+++ b/include/sw/dsp/spectrum/front_end_corrector.hpp
@@ -1,0 +1,58 @@
+#pragma once
+// front_end_corrector.hpp: spectrum-analyzer front-end calibration
+// (alias for instrument::EqualizerFilter).
+//
+// In a spectrum analyzer the analog front end (probe + amplifier +
+// ADC) imposes a non-flat magnitude response on the input. The
+// front-end corrector applies the inverse of that response so the
+// digital pipeline measures the source spectrum, not the
+// front-end-distorted spectrum.
+//
+// The math is identical to what the scope demo's calibration stage
+// does (the same FIR equalizer designed by frequency-sampling from a
+// CalibrationProfile). What differs is the *use* of the equalizer's
+// output:
+//   - Scope:    cares about edge fidelity and group delay; uses the
+//               equalized signal as a faithful time-domain
+//               reconstruction.
+//   - Analyzer: cares about magnitude flatness across frequency;
+//               uses the equalized signal so the FFT bin amplitudes
+//               match the source spectrum within the analyzer's
+//               specifications.
+//
+// Since the streaming math is identical, this header is a thin
+// using-alias rather than a wrapper class. Spectrum-namespace users
+// get a self-documenting name (`FrontEndCorrector`) without a
+// duplicated implementation. Both names refer to the same template
+// instantiation; behavior is bit-identical.
+//
+// If the analyzer pipeline ever needs calibration semantics that
+// genuinely differ from the scope's (e.g., a different design
+// algorithm, magnitude-only correction skipping phase, or built-in
+// group-delay compensation), promote this alias to a proper class
+// at that point. Today the EqualizerFilter design covers both use
+// cases.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <sw/dsp/concepts/scalar.hpp>
+#include <sw/dsp/instrument/calibration.hpp>
+
+namespace sw::dsp::spectrum {
+
+// Bring CalibrationProfile into the spectrum namespace for ergonomics.
+// CalibrationProfile is a non-templated value type — there's nothing
+// analyzer-specific about it; the same profile representation works
+// for both instrument paths (scope, analyzer).
+using CalibrationProfile = sw::dsp::instrument::CalibrationProfile;
+
+// Front-end equalizer for the spectrum-analyzer input path. Identical
+// template signature to instrument::EqualizerFilter; defaults match.
+template <DspField CoeffScalar  = double,
+          DspField StateScalar  = CoeffScalar,
+          DspScalar SampleScalar = StateScalar>
+using FrontEndCorrector =
+	sw::dsp::instrument::EqualizerFilter<CoeffScalar, StateScalar, SampleScalar>;
+
+} // namespace sw::dsp::spectrum

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ dsp_add_test(test_spectrum_rbw_filter       "Tests/Spectrum")
 dsp_add_test(test_spectrum_realtime         "Tests/Spectrum")
 dsp_add_test(test_spectrum_waterfall        "Tests/Spectrum")
 dsp_add_test(test_spectrum_swept_lo         "Tests/Spectrum")
+dsp_add_test(test_spectrum_front_end_corrector "Tests/Spectrum")
 
 # =============================================================================
 # Conditioning — AGC, compressor, envelope, sample-rate conversion, noise shaping

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,7 +49,8 @@ Tests/
 │   ├── test_spectrum_rbw_filter          Resolution-bandwidth (sync-tuned) BPF
 │   ├── test_spectrum_realtime            Streaming overlapping FFT engine
 │   ├── test_spectrum_waterfall           Circular 2D buffer for spectrogram displays
-│   └── test_spectrum_swept_lo            Phase-coherent linear/log chirp generator
+│   ├── test_spectrum_swept_lo            Phase-coherent linear/log chirp generator
+│   └── test_spectrum_front_end_corrector Calibration alias for EqualizerFilter
 ├── Conditioning/
 │   ├── test_conditioning        AGC, compressor, envelope detector
 │   ├── test_src                 Rational sample-rate conversion

--- a/tests/test_spectrum_front_end_corrector.cpp
+++ b/tests/test_spectrum_front_end_corrector.cpp
@@ -1,0 +1,112 @@
+// test_spectrum_front_end_corrector.cpp: tests that the spectrum/
+// FrontEndCorrector alias correctly forwards to instrument::
+// EqualizerFilter.
+//
+// The alias is a single line of code; the comprehensive testing of
+// the underlying equalizer is in test_instrument_calibration. This
+// file is a deliberate-minimum sanity check:
+//   - Type identity: spectrum::FrontEndCorrector<...> resolves to
+//     the same type as instrument::EqualizerFilter<...>.
+//   - CalibrationProfile alias resolves to the underlying type.
+//   - A FrontEndCorrector instance produces the same streaming
+//     output as a directly-constructed EqualizerFilter on the same
+//     profile + input.
+//
+// Per CLAUDE.md, tests use `if (!cond) throw std::runtime_error(...)`.
+//
+// Copyright (C) 2024-2026 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include <sw/dsp/spectrum/front_end_corrector.hpp>
+
+#define REQUIRE(cond) \
+	do { if (!(cond)) throw std::runtime_error( \
+		std::string("test failed: ") + #cond + \
+		" at " __FILE__ ":" + std::to_string(__LINE__)); } while (0)
+
+// ============================================================================
+// Type identity
+// ============================================================================
+
+void test_type_identity() {
+	using FE = sw::dsp::spectrum::FrontEndCorrector<>;
+	using EQ = sw::dsp::instrument::EqualizerFilter<>;
+	static_assert(std::is_same_v<FE, EQ>,
+		"FrontEndCorrector must alias EqualizerFilter exactly");
+
+	using FEf = sw::dsp::spectrum::FrontEndCorrector<float>;
+	using EQf = sw::dsp::instrument::EqualizerFilter<float>;
+	static_assert(std::is_same_v<FEf, EQf>,
+		"FrontEndCorrector<float> must alias EqualizerFilter<float>");
+
+	using PF = sw::dsp::spectrum::CalibrationProfile;
+	using IP = sw::dsp::instrument::CalibrationProfile;
+	static_assert(std::is_same_v<PF, IP>,
+		"spectrum::CalibrationProfile must alias instrument::CalibrationProfile");
+
+	std::cout << "  type_identity: passed\n";
+}
+
+// ============================================================================
+// Behavioral equivalence: alias produces identical output
+// ============================================================================
+
+void test_behavioral_equivalence() {
+	using namespace sw::dsp;
+
+	// Synthetic mild-rolloff profile, same shape used by the scope demo.
+	std::vector<double> freqs    = {0.0,   50e6, 100e6, 250e6, 500e6};
+	std::vector<double> gains_dB = {0.0,  -0.5,  -2.0,  -3.0,  -3.0};
+	std::vector<double> phases   = {0.0,  -0.10, -0.20, -0.30, -0.30};
+	instrument::CalibrationProfile profile(freqs, gains_dB, phases);
+
+	const double      fs       = 1.0e9;
+	const std::size_t num_taps = 31;
+
+	// Two instantiations on the same profile, same fs, same num_taps:
+	// one via the alias, one directly. They should produce
+	// bit-identical streaming output for the same input.
+	spectrum::FrontEndCorrector<double> via_alias(profile, num_taps, fs);
+	instrument::EqualizerFilter<double>  direct(profile, num_taps, fs);
+
+	std::vector<double> input(256);
+	for (std::size_t n = 0; n < input.size(); ++n)
+		input[n] = static_cast<double>(n % 13) - 6.0;   // arbitrary repeating pattern
+
+	for (std::size_t n = 0; n < input.size(); ++n) {
+		const double y_alias  = via_alias.process(input[n]);
+		const double y_direct = direct.process(input[n]);
+		if (y_alias != y_direct)
+			throw std::runtime_error(
+				"alias output diverged from direct at sample "
+				+ std::to_string(n) + ": alias=" + std::to_string(y_alias)
+				+ " direct=" + std::to_string(y_direct));
+	}
+	std::cout << "  behavioral_equivalence: passed (256 samples bit-identical)\n";
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+int main() {
+	try {
+		std::cout << "test_spectrum_front_end_corrector\n";
+
+		test_type_identity();
+		test_behavioral_equivalence();
+
+		std::cout << "all tests passed\n";
+		return 0;
+	} catch (const std::exception& ex) {
+		std::cerr << "FAILED: " << ex.what() << "\n";
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary
- Ninth sub-issue under #134. Wires the existing `instrument::CalibrationProfile` + `EqualizerFilter` (shipped in v0.6) into the spectrum-analyzer namespace.
- **Implementation choice**: a using-alias rather than a wrapper class. Issue body explicitly offered both options ("decide during implementation"); alias is the right call because the streaming math is identical for the scope and analyzer paths.

## Why an alias, not a wrapper
The same FIR equalizer designed by frequency-sampling from a `CalibrationProfile` does the right thing for both pipelines. What differs is how each pipeline *uses* the equalized output:

| Pipeline | Cares about | Example |
|----------|-------------|---------|
| Scope    | Edge fidelity, group delay | Faithful time-domain reconstruction of a glitch |
| Analyzer | Magnitude flatness across frequency | FFT bin amplitudes match source spectrum |

Since the math doesn't differ, a wrapper class would only duplicate `EqualizerFilter`'s constructor + `process()` forwarders. The using-alias gives spectrum-namespace users a self-documenting name (`FrontEndCorrector`) without runtime cost or duplication.

If analyzer-specific calibration semantics ever diverge from the scope's (different design algorithm, magnitude-only correction skipping phase, built-in group-delay compensation, etc.), promote the alias to a class at that point. Today `EqualizerFilter` covers both use cases.

## API
```cpp
namespace sw::dsp::spectrum {
    using CalibrationProfile = sw::dsp::instrument::CalibrationProfile;

    template <DspField CoeffScalar  = double,
              DspField StateScalar  = CoeffScalar,
              DspScalar SampleScalar = StateScalar>
    using FrontEndCorrector =
        sw::dsp::instrument::EqualizerFilter<CoeffScalar, StateScalar, SampleScalar>;
}
```

## Changes
- `include/sw/dsp/spectrum/front_end_corrector.hpp` — new module (~50 lines, mostly docstring)
- `tests/test_spectrum_front_end_corrector.cpp` — 2 sub-tests
- `tests/CMakeLists.txt` + `tests/README.md` — registration

## Tests
- **Type identity**: `static_assert` that `spectrum::FrontEndCorrector<...>` is the same type as `instrument::EqualizerFilter<...>`; same for `CalibrationProfile`. Verified for both default and explicit-`float` instantiations.
- **Behavioral equivalence**: 256 samples through a synthetic-profile alias instance and a same-profile direct `EqualizerFilter` instance produce bit-identical output sample-by-sample.

The comprehensive testing of `EqualizerFilter` is in `test_instrument_calibration`; this file is a deliberate-minimum sanity check that the alias forwards correctly.

## Test results
| Target                                | gcc build | gcc test | clang build | clang test |
|---------------------------------------|-----------|----------|-------------|------------|
| test_spectrum_front_end_corrector     | OK        | 2/2 PASS | OK          | 2/2 PASS   |
| Full ctest (49 tests)                 | OK        | 49/49    | OK          | 49/49      |

## Test plan
- [x] Fast CI passes
- [x] CodeRabbit review (drafts skip auto-review; trigger with `@coderabbitai review`)
- [x] Promote to ready: `gh pr ready`

Resolves #182

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spectrum front-end calibration module with type aliases for front-end correction and calibration profiles.

* **Tests**
  * Added comprehensive test coverage verifying type identity and behavioral equivalence of spectrum calibration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->