### PR TITLE
chore: bump MTL5 dependency to v5.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ else()
 	# which landed post-v5.2.0.
 	dsp_fetch_headers_only(mtl5
 		https://github.com/stillwater-sc/mtl5.git
-		v5.4.0)
+		v5.5.0)
 	# SYSTEM: see Universal block above for rationale.
 	target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE
 		$<BUILD_INTERFACE:${mtl5_SOURCE_DIR}/include>)


### PR DESCRIPTION
Bumps the MTL5 FetchContent pin v5.4.0 → **v5.5.0**.

## Verification (local, fetching the real tag)
- FetchContent resolves MTL5 at `v5.5.0`.
- All 49 tests pass.

Universal unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an external build dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->